### PR TITLE
Fix for issue #148 - Build failed on windows with lots of EOL violations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Check out all text files in UNIX format.
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted 
+# to native line endings on checkout.
+*.txt text
+*.java text
+*.groovy text
+*.xml text
+*.md text
+*.pom text
+*.properties text
+*.tex text
+*.vm text
+*.xsl text
+*.yml text
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Issue description:
If you use operation system with default "end of line char" different from Unix/Linux (\n), and you have no default config for your git:
 after checkout repository, all files will contains "standard" for you system end of line char. So build will fail with error from qulice about end of line violations if all files. 

Fix:
added git config for repository to force using Unix\Linux end of line char. 