### PR TITLE
#153 CcStrict validation works incorrectly

### DIFF
--- a/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
@@ -67,7 +67,8 @@ public final class CcStrict implements Codec {
         if (identity.urn().isEmpty()) {
             throw new DecodingException("urn is empty");
         }
-        if (!identity.urn().matches("urn:[a-z]+:.+")) {
+        // @checkstyle LineLength (1 line)
+        if (!identity.urn().matches("^(?i)^urn(?-i):[a-z]{1,31}(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$")) {
             throw new DecodingException("urn isn't valid");
         }
         return identity;

--- a/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
@@ -68,7 +68,7 @@ public final class CcStrict implements Codec {
             throw new DecodingException("urn is empty");
         }
         // @checkstyle LineLength (1 line)
-        if (!identity.urn().matches("^(?i)^urn(?-i):[a-z]{1,31}(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$")) {
+        if (!identity.urn().matches("^(?i)^urn(?-i):[a-zA-Z0-9]([\\-a-zA-Z0-9]{1,31})(:([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)+(\\?\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?(&\\w+(=([\\-a-zA-Z0-9/]|%[0-9a-fA-F]{2})*)?)*)?\\*?$")) {
             throw new DecodingException("urn isn't valid");
         }
         return identity;

--- a/src/test/java/org/takes/facets/auth/codecs/CcStrictTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcStrictTest.java
@@ -70,9 +70,9 @@ public final class CcStrictTest {
         MatcherAssert.assertThat(
             new String(
                 new CcStrict(new CcPlain()).encode(
-                    new Identity.Simple("urn:test:1:1")
+                    new Identity.Simple("urn:test-domain-org:valid:1")
                 )
-            ), Matchers.equalTo("urn%3Atest%3A1%3A1")
+            ), Matchers.equalTo("urn%3Atest-domain-org%3Avalid%3A1")
         );
     }
 }

--- a/src/test/java/org/takes/facets/auth/codecs/CcStrictTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcStrictTest.java
@@ -67,5 +67,12 @@ public final class CcStrictTest {
                 )
             ), Matchers.equalTo("urn%3Atest%3A1")
         );
+        MatcherAssert.assertThat(
+            new String(
+                new CcStrict(new CcPlain()).encode(
+                    new Identity.Simple("urn:test:1:1")
+                )
+            ), Matchers.equalTo("urn%3Atest%3A1%3A1")
+        );
     }
 }


### PR DESCRIPTION
task #153
Changed urn validation according with RFC 2141 in CcStrict, RFC 2141 compilant regexp took [here](https://github.com/jcabi/jcabi-urn/blob/master/src/main/java/com/jcabi/urn/URN.java#L98).
Also changed unit test
