### PR TITLE
#46 RsWithCookie must reject if invalid characters

### DIFF
--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -129,7 +129,7 @@ public final class RsWithCookie extends RsWrap {
      * @param value Cookie value
      * @return Cookie value
      */
-    private static String checkValue(final String value) {
+    private static CharSequence checkValue(final CharSequence value) {
         if (!RsWithCookie.CVALUE_PTRN.matcher(value).matches()) {
             throw new IllegalArgumentException(
                 String.format(
@@ -146,7 +146,7 @@ public final class RsWithCookie extends RsWrap {
      * @param name Cookie name;
      * @return Cookie name
      */
-    private static String checkName(final String name) {
+    private static CharSequence checkName(final CharSequence name) {
         if (!RsWithCookie.CNAME_PTRN.matcher(name).matches()) {
             throw new IllegalArgumentException(
                 String.format(

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -58,6 +58,18 @@ import org.takes.Response;
 public final class RsWithCookie extends RsWrap {
 
     /**
+     * Cookie value validation regexp.
+     * @checkstyle LineLengthCheck (2 lines)
+     */
+    private static final Pattern CVALUE_PTRN = Pattern.compile("[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*|\"[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*\"");
+
+    /**
+     * Cookie name validation regexp.
+     * @checkstyle LineLengthCheck (2 lines)
+     */
+    private static final Pattern CNAME_PTRN = Pattern.compile("[\\x20-\\x7E&&[^()<>@,;:\\\"/\\[\\]?={} ]]+");
+
+    /**
      * Ctor.
      * @param name Cookie name
      * @param value Value of it
@@ -115,8 +127,7 @@ public final class RsWithCookie extends RsWrap {
      * @return Cookie value
      */
     private static String checkValue(final String value) {
-        // @checkstyle LineLengthCheck (1 line)
-        if (!Pattern.matches("[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*|\"[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*\"", value)) {
+        if (!CVALUE_PTRN.matcher(value).matches()) {
             throw new IllegalArgumentException(
                 String.format(
                     "Cookie value %s contains invalid characters",
@@ -133,8 +144,7 @@ public final class RsWithCookie extends RsWrap {
      * @return Cookie name
      */
     private static String checkName(final String name) {
-        // @checkstyle LineLengthCheck (1 line)
-        if (!Pattern.matches("[\\x20-\\x7E&&[^()<>@,;:\\\"/\\[\\]?={} ]]+", name)) {
+        if (!CNAME_PTRN.matcher(name).matches()) {
             throw new IllegalArgumentException(
                 String.format(
                     "Cookie name %s contains invalid characters",

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -127,7 +127,7 @@ public final class RsWithCookie extends RsWrap {
      * @return Cookie value
      */
     private static String checkValue(final String value) {
-        if (!CVALUE_PTRN.matcher(value).matches()) {
+        if (!RsWithCookie.CVALUE_PTRN.matcher(value).matches()) {
             throw new IllegalArgumentException(
                 String.format(
                     "Cookie value %s contains invalid characters",
@@ -144,7 +144,7 @@ public final class RsWithCookie extends RsWrap {
      * @return Cookie name
      */
     private static String checkName(final String name) {
-        if (!CNAME_PTRN.matcher(name).matches()) {
+        if (!RsWithCookie.CNAME_PTRN.matcher(name).matches()) {
             throw new IllegalArgumentException(
                 String.format(
                     "Cookie name %s contains invalid characters",

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -23,11 +23,17 @@
  */
 package org.takes.rs;
 
+import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
 
 /**
  * Response decorator, with an additional cookie.
+ *
+ * The decorator validates cookie name according
+ * @see <a href="http://tools.ietf.org/html/rfc2616#section-2.2">RFC 2616</a>
+ * and cookie value according
+ * @see <a href="http://tools.ietf.org/html/rfc6265#section-4.1.1">RFC 6265</a>
  *
  * <p>Use this decorator in order to return a response with a "Set-Cookie"
  * header inside, for example:
@@ -43,7 +49,6 @@ import org.takes.Response;
  * <pre> Set-Cookie: u=Jeff;Path=/;Expires=Wed, 13 Jan 2021 22:23:01 GMT</pre>
  *
  * <p>The class is immutable and thread-safe.
- *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.1
@@ -74,7 +79,13 @@ public final class RsWithCookie extends RsWrap {
         final String value, final String... attrs) {
         super(
             new RsWithHeader(
-                res, "Set-Cookie", RsWithCookie.make(name, value, attrs)
+                res,
+                "Set-Cookie",
+                RsWithCookie.make(
+                    RsWithCookie.checkName(name),
+                    RsWithCookie.checkValue(value),
+                    attrs
+            )
         )
         );
     }
@@ -97,4 +108,39 @@ public final class RsWithCookie extends RsWrap {
         return text.toString();
     }
 
+    /**
+     * Checks value according RFC 6265 section 4.1.1.
+     * @param value Cookie value
+     * @return Cookie value
+     */
+    private static String checkValue(final String value) {
+        // @checkstyle LineLengthCheck (1 line)
+        if (!Pattern.matches("[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*|\"[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*\"", value)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Cookie value %s contains invalid characters",
+                    value
+                )
+            );
+        }
+        return value;
+    }
+
+    /**
+     * Checks name according RFC 2616, section 2.2.
+     * @param name Cookie name;
+     * @return Cookie name
+     */
+    private static String checkName(final String name) {
+        // @checkstyle LineLengthCheck (1 line)
+        if (!Pattern.matches("[\\x20-\\x7E&&[^()<>@,;:\\\"/\\[\\]?={} ]]+", name)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Cookie name %s contains invalid characters",
+                    name
+                )
+            );
+        }
+        return name;
+    }
 }

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -49,6 +49,7 @@ import org.takes.Response;
  * <pre> Set-Cookie: u=Jeff;Path=/;Expires=Wed, 13 Jan 2021 22:23:01 GMT</pre>
  *
  * <p>The class is immutable and thread-safe.
+ *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.1

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -59,15 +59,18 @@ public final class RsWithCookie extends RsWrap {
 
     /**
      * Cookie value validation regexp.
-     * @checkstyle LineLengthCheck (2 lines)
+     * @checkstyle LineLengthCheck (3 lines)
      */
-    private static final Pattern CVALUE_PTRN = Pattern.compile("[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*|\"[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*\"");
+    private static final Pattern CVALUE_PTRN = Pattern.compile(
+        "[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*|\"[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*\""
+    );
 
     /**
      * Cookie name validation regexp.
-     * @checkstyle LineLengthCheck (2 lines)
      */
-    private static final Pattern CNAME_PTRN = Pattern.compile("[\\x20-\\x7E&&[^()<>@,;:\\\"/\\[\\]?={} ]]+");
+    private static final Pattern CNAME_PTRN = Pattern.compile(
+        "[\\x20-\\x7E&&[^()<>@,;:\\\"/\\[\\]?={} ]]+"
+    );
 
     /**
      * Ctor.

--- a/src/test/java/org/takes/rs/RsWithCookieTest.java
+++ b/src/test/java/org/takes/rs/RsWithCookieTest.java
@@ -62,7 +62,7 @@ public final class RsWithCookieTest {
     }
 
     /**
-     * RsWithCookie can rejects invalid cookie name.
+     * RsWithCookie can reject invalid cookie name.
      * @throws IOException If some problem inside
      */
     @Test(expected = IllegalArgumentException.class)
@@ -71,7 +71,7 @@ public final class RsWithCookieTest {
     }
 
     /**
-     * RsWithCookie can rejects invalid cookie value.
+     * RsWithCookie can reject invalid cookie value.
      * @throws IOException If some problem inside
      */
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/takes/rs/RsWithCookieTest.java
+++ b/src/test/java/org/takes/rs/RsWithCookieTest.java
@@ -61,4 +61,21 @@ public final class RsWithCookieTest {
         );
     }
 
+    /**
+     * RsWithCookie can rejects invalid cookie name.
+     * @throws IOException If some problem inside
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsInvalidName() throws IOException {
+        new RsWithCookie(new RsEmpty(), "f oo", "works");
+    }
+
+    /**
+     * RsWithCookie can rejects invalid cookie value.
+     * @throws IOException If some problem inside
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsInvalidValue() throws IOException {
+        new RsWithCookie(new RsEmpty(), "bar", "wo\"rks");
+    }
 }


### PR DESCRIPTION
For task #46 

*  Ctor parameter name validates according [RFC 2616, section 2.2](http://tools.ietf.org/html/rfc6265#section-4.1.)
*  Ctor parameter value validates according [RFC 6265 section 4.1.1](http://tools.ietf.org/html/rfc2616#section-2.2)
*  added unit tests for new functionality