### PR TITLE
#206 RqLengthAware doesn't intercept the other two read() methods

### DIFF
--- a/src/main/java/org/takes/rq/RqLengthAware.java
+++ b/src/main/java/org/takes/rq/RqLengthAware.java
@@ -128,6 +128,21 @@ public final class RqLengthAware extends RqWrap {
             --this.more;
             return this.origin.read();
         }
+
+        @Override
+        public int read(final byte[] buf) throws IOException {
+            final int readed = this.origin.read(buf);
+            this.more -= readed;
+            return readed;
+        }
+
+        @Override
+        public int read(final byte[] buf, final int off,
+            final int len) throws IOException {
+            final int readed  = this.origin.read(buf, off, len);
+            this.more -= readed;
+            return readed;
+        }
     }
 
 }

--- a/src/test/java/org/takes/rq/RqLengthAwareTest.java
+++ b/src/test/java/org/takes/rq/RqLengthAwareTest.java
@@ -89,13 +89,12 @@ public final class RqLengthAwareTest {
      */
     @Test
     public void readsByte() throws IOException {
-        final String data = "{test}";
+        final String data = "test";
         final InputStream stream = new RqLengthAware(
             new RqFake(
                 Arrays.asList(
                     "GET /test1",
-                    "Host: b.example.com",
-                    "Content-type: text/json"
+                    "Host: b.example.com"
                 ),
                 data
             )
@@ -148,8 +147,7 @@ public final class RqLengthAwareTest {
             new RqFake(
                 Arrays.asList(
                     "GET /test3",
-                    "Host: d.example.com",
-                    "Content-type: text/plain; charset=us-ascii"
+                    "Host: d.example.com"
                 ),
                 data
             )


### PR DESCRIPTION
for #206 
* implemented  the other two InputStream.read() methods