### PR TITLE
TkConsumes decorator implementation

### DIFF
--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -83,8 +83,8 @@ public final class FkContentType implements Fork {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private static MediaTypes getType(final Request req) throws IOException {
         MediaTypes list = new MediaTypes();
-        final Iterable<String> headers =
-            new RqHeaders(req).header("Content-Type");
+        final Iterable<String> headers = new RqHeaders.Base(req)
+            .header("Content-Type");
         for (final String hdr : headers) {
             list = list.merge(new MediaTypes(hdr));
         }

--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -1,0 +1,97 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.fork;
+
+import java.io.IOException;
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.misc.Opt;
+import org.takes.rq.RqHeaders;
+
+/**
+ * Fork by Content-type accepted by "Content-Type" HTTP header.
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ * @see RsFork
+ */
+@EqualsAndHashCode(of = { "type", "origin" })
+public final class FkContentType implements Fork {
+
+    /**
+     * Type we can deliver.
+     */
+    private final transient MediaTypes type;
+
+    /**
+     * Response to return.
+     */
+    private final transient Response origin;
+
+    /**
+     * Ctor.
+     * @param atype Accepted type
+     * @param response Response to return
+     */
+    public FkContentType(final String atype, final Response response) {
+        this.type = new MediaTypes(atype);
+        this.origin = response;
+    }
+
+    @Override
+    public Opt<Response> route(final Request req) throws IOException {
+        final Opt<Response> resp;
+        if (FkContentType.getType(req).contains(this.type)) {
+            resp = new Opt.Single<Response>(this.origin);
+        } else {
+            resp = new Opt.Empty<Response>();
+        }
+        return resp;
+    }
+
+    /**
+     * Get Content-Type type provided by the client.
+     * @param req Request
+     * @return Media type
+     * @throws IOException If fails
+     */
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    private static MediaTypes getType(final Request req) throws IOException {
+        MediaTypes list = new MediaTypes();
+        final Iterable<String> headers =
+            new RqHeaders(req).header("Content-Type");
+        for (final String hdr : headers) {
+            list = list.merge(new MediaTypes(hdr));
+        }
+        if (list.isEmpty()) {
+            list = new MediaTypes("*/*");
+        }
+        return list;
+    }
+
+}

--- a/src/main/java/org/takes/facets/fork/TkConsumes.java
+++ b/src/main/java/org/takes/facets/fork/TkConsumes.java
@@ -1,0 +1,63 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.fork;
+
+import java.io.IOException;
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.tk.TkWrap;
+
+/**
+ * Take that acts on request with specified "Content-Type" HTTP headers only.
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+@EqualsAndHashCode(callSuper = true)
+public final class TkConsumes extends TkWrap {
+    /**
+     * Ctor.
+     * @param take Original take
+     * @param type Content-Type
+     */
+    public TkConsumes(final Take take, final String type) {
+        super(
+            new Take() {
+                @Override
+                public Response act(final Request req) throws IOException {
+                    return new RsFork(
+                        req,
+                        new FkContentType(type, take.act(req))
+                    );
+                }
+            }
+        );
+    }
+
+}

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -43,42 +43,88 @@ import org.takes.rs.RsEmpty;
 public final class FkContentTypeTest {
 
     /**
-     * FkContentType can match by Content-Type header.
+     * Content-Type header.
+     */
+    private static final String CONTENT_TYPE = "Content-Type";
+
+    /**
+     * FkContentType can match by Content-Type header with any of types.
      * @throws IOException If some problem inside
      */
     @Test
-    public void matchesByContentTypeHeader() throws IOException {
-        final String contenttype = "Content-Type";
+    public void matchesWithAnyTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType("text/xml", new RsEmpty()).route(
-                new RqWithHeader(new RqFake(), contenttype, "*/* ")
+                new RqWithHeader(new RqFake(), CONTENT_TYPE, "*/* ")
             ).has(),
             Matchers.is(true)
         );
+    }
+
+    /**
+     * FkContentType can match by Content-Type header with different types.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void matchesDifferentTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
                 "application/json charset=utf-8", new RsEmpty()
             ).route(
-                new RqWithHeader(new RqFake(), contenttype, "image/*")
+                new RqWithHeader(new RqFake(), CONTENT_TYPE, "images/*")
             ).has(),
             Matchers.is(false)
         );
+    }
+
+    /**
+     * FkContentType can match by Content-Type header with identical types.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void matchesIdenticalTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
                 "text/html charset=iso-8859-1", new RsEmpty()
             ).route(
                 new RqWithHeader(
                     // @checkstyle MultipleStringLiteralsCheck (1 line)
-                    new RqFake(), contenttype, "text/html charset=iso-8859-1"
+                    new RqFake(), CONTENT_TYPE, "text/html charset=iso-8859-1"
                 )
             ).has(),
             Matchers.is(true)
         );
+    }
+
+    /**
+     * FkContentType can match by Content-Type header with empty type.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void matchesEmptyType() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType("*/*", new RsEmpty()).route(
-                new RqWithHeader(new RqFake(), contenttype, "")
+                new RqWithHeader(new RqFake(), CONTENT_TYPE, "")
             ).has(),
             Matchers.is(true)
+        );
+    }
+
+    /**
+     * FkContentType can match by Content-Type header with different encodings.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void matchesDifferentEncodingsTypes() throws IOException {
+        MatcherAssert.assertThat(
+            new FkContentType(
+                "text/html charset=iso-8859-1", new RsEmpty()
+            ).route(
+                new RqWithHeader(
+                    new RqFake(), CONTENT_TYPE, "text/html charset=utf8"
+                )
+            ).has(),
+            Matchers.is(false)
         );
     }
 

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -1,0 +1,95 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.fork;
+
+import java.io.IOException;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.rq.RqFake;
+import org.takes.rq.RqWithHeader;
+import org.takes.rs.RsEmpty;
+
+/**
+ * Test case for {@link FkContentType}.
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
+ */
+public final class FkContentTypeTest {
+
+    /**
+     * FkContentType can match by Content-Type header.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void matchesByContentTypeHeader() throws IOException {
+        final String contenttype = "Content-Type";
+        MatcherAssert.assertThat(
+            new FkContentType("text/xml", new RsEmpty()).route(
+                new RqWithHeader(new RqFake(), contenttype, "*/* ")
+            ).has(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new FkContentType(
+                "application/json charset=utf-8", new RsEmpty()
+            ).route(
+                new RqWithHeader(new RqFake(), contenttype, "image/*")
+            ).has(),
+            Matchers.is(false)
+        );
+        MatcherAssert.assertThat(
+            new FkContentType(
+                "text/html charset=iso-8859-1", new RsEmpty()
+            ).route(
+                new RqWithHeader(
+                    // @checkstyle MultipleStringLiteralsCheck (1 line)
+                    new RqFake(), contenttype, "text/html charset=iso-8859-1"
+                )
+            ).has(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new FkContentType("*/*", new RsEmpty()).route(
+                new RqWithHeader(new RqFake(), contenttype, "")
+            ).has(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * Checks FkContentType equals method.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void equalsAndHashCodeEqualTest() throws Exception {
+        EqualsVerifier.forClass(FkContentType.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .verify();
+    }
+}

--- a/src/test/java/org/takes/facets/fork/TkConsumesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkConsumesTest.java
@@ -70,13 +70,10 @@ public final class TkConsumesTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(response).print(),
-            Matchers.equalTo(
+            Matchers.startsWith(
                 Joiner.on("\r\n").join(
                     "HTTP/1.1 200 OK",
-                    // @checkstyle MultipleStringLiteralsCheck (1 line)
-                    "Content-Type: application/json",
-                    "",
-                    ""
+                    "Content-Type: application/json"
                 )
             )
         );

--- a/src/test/java/org/takes/facets/fork/TkConsumesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkConsumesTest.java
@@ -1,0 +1,117 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.fork;
+
+import com.google.common.base.Joiner;
+import java.io.IOException;
+import java.util.Arrays;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.HttpException;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.rq.RqFake;
+import org.takes.rs.RsEmpty;
+import org.takes.rs.RsJSON;
+import org.takes.rs.RsPrint;
+import org.takes.tk.TkFixed;
+
+/**
+ * Test case for {@link TkConsumes}.
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
+ */
+public final class TkConsumesTest {
+
+    /**
+     * TkConsumes can accept request with certain Content-Type.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void acceptsCorrectContentTypeRequest() throws IOException {
+        final Take consumes = new TkConsumes(
+            new TkFixed(new RsJSON(new RsEmpty())),
+            "application/json"
+        );
+        final Response response = consumes.act(
+            new RqFake(
+                Arrays.asList(
+                    "GET /?TkConsumes",
+                    "Content-Type: application/json"
+                ),
+                ""
+            )
+        );
+        MatcherAssert.assertThat(
+            new RsPrint(response).print(),
+            Matchers.equalTo(
+                Joiner.on("\r\n").join(
+                    "HTTP/1.1 200 OK",
+                    // @checkstyle MultipleStringLiteralsCheck (1 line)
+                    "Content-Type: application/json",
+                    "",
+                    ""
+                )
+            )
+        );
+    }
+
+    /**
+     * TkConsumes can fail on unsupported Content-Type header.
+     * @throws IOException If some problem inside
+     */
+    @Test(expected = HttpException.class)
+    public void failsOnUnsupportedAcceptHeader() throws IOException {
+        final Take consumes = new TkConsumes(
+            new TkFixed(new RsJSON(new RsEmpty())),
+            "application/json"
+        );
+        consumes.act(
+            new RqFake(
+                Arrays.asList(
+                    "GET /?TkConsumes error",
+                    "Content-Type: application/xml"
+                ),
+                ""
+            )
+        ).head();
+    }
+
+    /**
+     * Checks TkConsumes equals method.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void equalsAndHashCodeEqualTest() throws Exception {
+        EqualsVerifier.forClass(TkConsumes.class)
+            .withRedefinedSuperclass()
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .verify();
+    }
+}


### PR DESCRIPTION
This is fix for https://github.com/yegor256/takes/issues/107
Added new fork ```FkContentType```, new decorator ```TkConsumes``` and required tests for it.