### PR TITLE
 Socket information in request

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -129,14 +129,19 @@ public final class BkBasic implements Back {
     private static Request addSocketHeaders(final Request req,
         final Socket socket) {
         return new RqWithHeaders(
-            req, new StringBuilder().append("X-Takes-LocalAddress: ")
-            .append(socket.getLocalAddress().toString())
-            .append("X-Takes-LocalPort")
-            .append(Integer.toString(socket.getLocalPort()))
-            .append("X-Takes-RemoteAddress")
-            .append(socket.getInetAddress().toString())
-            .append("X-Takes-RemotePort")
-            .append(Integer.toString(socket.getPort()))
+            req,
+            String.format(
+                "X-Takes-LocalAddress: %s", socket.getLocalAddress().toString()
+            ),
+            String.format(
+                "X-Takes-LocalPort: %d", socket.getLocalPort()
+            ),
+            String.format(
+                "X-Takes-RemoteAddress: %s", socket.getInetAddress().toString()
+            ),
+            String.format(
+                "X-Takes-RemotePort: %d", socket.getPort()
+            )
         );
     }
 }

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -38,6 +38,7 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqLive;
+import org.takes.rq.RqWithHeader;
 import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 import org.takes.rs.RsWithStatus;
@@ -73,7 +74,10 @@ public final class BkBasic implements Back {
         final InputStream input = socket.getInputStream();
         try {
             this.print(
-                new RqLive(new BufferedInputStream(input)),
+                BkBasic.addSocketHeaders(
+                    new RqLive(new BufferedInputStream(input)),
+                    socket
+                ),
                 new BufferedOutputStream(socket.getOutputStream())
             );
         } finally {
@@ -114,6 +118,34 @@ public final class BkBasic implements Back {
             new RsText(new ByteArrayInputStream(baos.toByteArray())),
             HttpURLConnection.HTTP_INTERNAL_ERROR
         );
+    }
+
+    /**
+     * Adds custom headers with information about socket.
+     * @param req Request
+     * @param socket Socket
+     * @return Request with custom headers
+     */
+    private static Request addSocketHeaders(final Request req,
+        final Socket socket) {
+        Request mreq = req;
+        mreq = new RqWithHeader(
+            mreq, "X-Takes-LocalAddress",
+            socket.getLocalAddress().toString()
+        );
+        mreq = new RqWithHeader(
+            mreq, "X-Takes-LocalPort",
+            Integer.toString(socket.getLocalPort())
+        );
+        mreq = new RqWithHeader(
+            mreq, "X-Takes-RemoteAddress",
+            socket.getInetAddress().toString()
+        );
+        mreq = new RqWithHeader(
+            mreq, "X-Takes-RemotePort",
+            Integer.toString(socket.getPort())
+        );
+        return mreq;
     }
 
 }

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -37,7 +37,7 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqLive;
-import org.takes.rq.RqWithHeader;
+import org.takes.rq.RqWithHeaders;
 import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 import org.takes.rs.RsWithStatus;
@@ -128,15 +128,15 @@ public final class BkBasic implements Back {
      */
     private static Request addSocketHeaders(final Request req,
         final Socket socket) {
-        return new RqWithHeader(
-            req, "X-Takes-LocalAddress", socket.getLocalAddress().toString()
-        ).withAdditionalHeader(
-            "X-Takes-LocalPort", Integer.toString(socket.getLocalPort())
-        ).withAdditionalHeader(
-            "X-Takes-RemoteAddress", socket.getInetAddress().toString()
-        ).withAdditionalHeader(
-            "X-Takes-RemotePort", Integer.toString(socket.getPort())
+        return new RqWithHeaders(
+            req, new StringBuilder().append("X-Takes-LocalAddress: ")
+            .append(socket.getLocalAddress().toString())
+            .append("X-Takes-LocalPort")
+            .append(Integer.toString(socket.getLocalPort()))
+            .append("X-Takes-RemoteAddress")
+            .append(socket.getInetAddress().toString())
+            .append("X-Takes-RemotePort")
+            .append(Integer.toString(socket.getPort()))
         );
     }
-
 }

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -37,6 +37,7 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqLive;
+import org.takes.rq.RqWithHeader;
 import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 import org.takes.rs.RsWithStatus;
@@ -50,6 +51,7 @@ import org.takes.rs.RsWithStatus;
  * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @checkstyle IndentationCheck (500 lines)
  */
 @EqualsAndHashCode(of = "take")
 public final class BkBasic implements Back {
@@ -72,7 +74,10 @@ public final class BkBasic implements Back {
         final InputStream input = socket.getInputStream();
         try {
             this.print(
-                new RqLive(input),
+                BkBasic.addSocketHeaders(
+                    new RqLive(input),
+                    socket
+                ),
                 new BufferedOutputStream(socket.getOutputStream())
             );
         } finally {
@@ -112,6 +117,25 @@ public final class BkBasic implements Back {
         return new RsWithStatus(
             new RsText(new ByteArrayInputStream(baos.toByteArray())),
             HttpURLConnection.HTTP_INTERNAL_ERROR
+        );
+    }
+
+    /**
+     * Adds custom headers with information about socket.
+     * @param req Request
+     * @param socket Socket
+     * @return Request with custom headers
+     */
+    private static Request addSocketHeaders(final Request req,
+        final Socket socket) {
+        return new RqWithHeader(
+            req, "X-Takes-LocalAddress", socket.getLocalAddress().toString()
+        ).withAdditionalHeader(
+            "X-Takes-LocalPort", Integer.toString(socket.getLocalPort())
+        ).withAdditionalHeader(
+            "X-Takes-RemoteAddress", socket.getInetAddress().toString()
+        ).withAdditionalHeader(
+            "X-Takes-RemotePort", Integer.toString(socket.getPort())
         );
     }
 

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -130,18 +130,10 @@ public final class BkBasic implements Back {
         final Socket socket) {
         return new RqWithHeaders(
             req,
-            String.format(
-                "X-Takes-LocalAddress: %s", socket.getLocalAddress().toString()
-            ),
-            String.format(
-                "X-Takes-LocalPort: %d", socket.getLocalPort()
-            ),
-            String.format(
-                "X-Takes-RemoteAddress: %s", socket.getInetAddress().toString()
-            ),
-            String.format(
-                "X-Takes-RemotePort: %d", socket.getPort()
-            )
+            String.format("X-Takes-LocalAddress: %s", socket.getLocalAddress()),
+            String.format("X-Takes-LocalPort: %d", socket.getLocalPort()),
+            String.format("X-Takes-RemoteAddress: %s", socket.getInetAddress()),
+            String.format("X-Takes-RemotePort: %d", socket.getPort())
         );
     }
 }

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -72,7 +72,7 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public int getLocalPort() throws IOException {
-        return this.getPort("X-Takes-LocalPort");
+        return Integer.parseInt(this.headerValue("X-Takes-LocalPort"));
     }
 
     /**
@@ -81,7 +81,7 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public int getRemotePort() throws IOException {
-        return this.getPort("X-Takes-RemotePort");
+        return Integer.parseInt(this.headerValue("X-Takes-RemotePort"));
     }
 
     /**
@@ -99,15 +99,5 @@ public final class RqSocket extends RqWrap {
             }
         }
         return result;
-    }
-
-    /**
-     * Parses port value from the provided header.
-     * @param header Header to parse
-     * @return Integer value of the port
-     * @throws IOException If fails
-     */
-    private int getPort(final CharSequence header) throws IOException {
-        return Integer.parseInt(this.headerValue(header));
     }
 }

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -54,7 +54,10 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public InetAddress getLocalAddress() throws IOException {
-        return InetAddress.getByName(this.headerValue("X-Takes-LocalAddress"));
+        return InetAddress.getByName(
+            new RqHeaders.Base(this).header("X-Takes-LocalAddress")
+                .iterator().next()
+        );
     }
 
     /**
@@ -63,7 +66,10 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public InetAddress getRemoteAddress() throws IOException {
-        return InetAddress.getByName(this.headerValue("X-Takes-RemoteAddress"));
+        return InetAddress.getByName(
+            new RqHeaders.Base(this).header("X-Takes-RemoteAddress")
+                .iterator().next()
+        );
     }
 
     /**
@@ -72,7 +78,10 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public int getLocalPort() throws IOException {
-        return Integer.parseInt(this.headerValue("X-Takes-LocalPort"));
+        return Integer.parseInt(
+            new RqHeaders.Base(this).header("X-Takes-LocalPort")
+                .iterator().next()
+        );
     }
 
     /**
@@ -81,23 +90,9 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public int getRemotePort() throws IOException {
-        return Integer.parseInt(this.headerValue("X-Takes-RemotePort"));
-    }
-
-    /**
-     * Parses value of the provided header from head.
-     * @param header Header to parse
-     * @return String value of the provided header
-     * @throws IOException If fails
-     */
-    private String headerValue(final CharSequence header) throws IOException {
-        String result = "";
-        for (final String line : this.head()) {
-            final String[] parts = line.split(": ", 2);
-            if (parts[0].contains(header)) {
-                result = parts[1];
-            }
-        }
-        return result;
+        return Integer.parseInt(
+            new RqHeaders.Base(this).header("X-Takes-RemotePort")
+                .iterator().next()
+        );
     }
 }

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -55,8 +55,8 @@ public final class RqSocket extends RqWrap {
      */
     public InetAddress getLocalAddress() throws IOException {
         return InetAddress.getByName(
-            new RqHeaders.Base(this).header("X-Takes-LocalAddress")
-                .iterator().next()
+            new RqHeaders.Smart(new RqHeaders.Base(this))
+                .single("X-Takes-LocalAddress")
         );
     }
 
@@ -67,8 +67,8 @@ public final class RqSocket extends RqWrap {
      */
     public InetAddress getRemoteAddress() throws IOException {
         return InetAddress.getByName(
-            new RqHeaders.Base(this).header("X-Takes-RemoteAddress")
-                .iterator().next()
+            new RqHeaders.Smart(new RqHeaders.Base(this))
+                .single("X-Takes-RemoteAddress")
         );
     }
 
@@ -79,8 +79,8 @@ public final class RqSocket extends RqWrap {
      */
     public int getLocalPort() throws IOException {
         return Integer.parseInt(
-            new RqHeaders.Base(this).header("X-Takes-LocalPort")
-                .iterator().next()
+            new RqHeaders.Smart(new RqHeaders.Base(this))
+                .single("X-Takes-LocalPort")
         );
     }
 
@@ -91,8 +91,8 @@ public final class RqSocket extends RqWrap {
      */
     public int getRemotePort() throws IOException {
         return Integer.parseInt(
-            new RqHeaders.Base(this).header("X-Takes-RemotePort")
-                .iterator().next()
+            new RqHeaders.Smart(new RqHeaders.Base(this))
+                .single("X-Takes-RemotePort")
         );
     }
 }

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -1,0 +1,119 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rq;
+
+import com.restfb.util.StringUtils;
+import java.io.IOException;
+import java.net.InetAddress;
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+
+/**
+ * Request decorator to get custom socket headers.
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+@EqualsAndHashCode(callSuper = true)
+public final class RqSocket extends RqWrap {
+
+    /**
+     * Ctor.
+     * @param req Original request
+     */
+    public RqSocket(final Request req) {
+        super(req);
+    }
+
+    /**
+     * Returns IP address from the X-Takes-LocalAddress header.
+     * @return Local InetAddress
+     * @throws IOException If fails
+     */
+    public InetAddress getLocalAddress() throws IOException {
+        return InetAddress.getByName(this.parseHeader("X-Takes-LocalAddress"));
+    }
+
+    /**
+     * Returns IP address from the X-Takes-RemoteAddress header.
+     * @return Remote InetAddress
+     * @throws IOException If fails
+     */
+    public InetAddress getRemoteAddress() throws IOException {
+        return InetAddress.getByName(this.parseHeader("X-Takes-RemoteAddress"));
+    }
+
+    /**
+     * Returns port from the X-Takes-LocalPort header.
+     * @return Local Port
+     * @throws IOException If fails
+     */
+    public int getLocalPort() throws IOException {
+        return this.getPort("X-Takes-LocalPort");
+    }
+
+    /**
+     * Returns port from the X-Takes-RemotePort header.
+     * @return Remote Port
+     * @throws IOException If fails
+     */
+    public int getRemotePort() throws IOException {
+        return this.getPort("X-Takes-RemotePort");
+    }
+
+    /**
+     * Parses value of the provided header from head.
+     * @param header Header to parse
+     * @return String value of the provided header
+     * @throws IOException If fails
+     */
+    private String parseHeader(final CharSequence header) throws IOException {
+        String result = "";
+        for (final String line : this.head()) {
+            final String[] parts = line.split(": ", 2);
+            if (parts[0].contains(header)) {
+                result = parts[1];
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Parses port value from the provided header.
+     * @param header Header to parse
+     * @return Integer value of the port
+     * @throws IOException If fails
+     */
+    private int getPort(final CharSequence header) throws IOException {
+        final String value = this.parseHeader(header);
+        int port = 0;
+        if (!StringUtils.isBlank(value)) {
+            port = Integer.parseInt(value);
+        }
+        return port;
+    }
+}

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -23,7 +23,6 @@
  */
 package org.takes.rq;
 
-import com.restfb.util.StringUtils;
 import java.io.IOException;
 import java.net.InetAddress;
 import lombok.EqualsAndHashCode;
@@ -55,7 +54,7 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public InetAddress getLocalAddress() throws IOException {
-        return InetAddress.getByName(this.parseHeader("X-Takes-LocalAddress"));
+        return InetAddress.getByName(this.headerValue("X-Takes-LocalAddress"));
     }
 
     /**
@@ -64,7 +63,7 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     public InetAddress getRemoteAddress() throws IOException {
-        return InetAddress.getByName(this.parseHeader("X-Takes-RemoteAddress"));
+        return InetAddress.getByName(this.headerValue("X-Takes-RemoteAddress"));
     }
 
     /**
@@ -91,7 +90,7 @@ public final class RqSocket extends RqWrap {
      * @return String value of the provided header
      * @throws IOException If fails
      */
-    private String parseHeader(final CharSequence header) throws IOException {
+    private String headerValue(final CharSequence header) throws IOException {
         String result = "";
         for (final String line : this.head()) {
             final String[] parts = line.split(": ", 2);
@@ -109,11 +108,6 @@ public final class RqSocket extends RqWrap {
      * @throws IOException If fails
      */
     private int getPort(final CharSequence header) throws IOException {
-        final String value = this.parseHeader(header);
-        int port = 0;
-        if (!StringUtils.isBlank(value)) {
-            port = Integer.parseInt(value);
-        }
-        return port;
+        return Integer.parseInt(this.headerValue(header));
     }
 }

--- a/src/main/java/org/takes/rq/RqWithHeader.java
+++ b/src/main/java/org/takes/rq/RqWithHeader.java
@@ -79,7 +79,7 @@ public final class RqWithHeader extends RqWrap {
     }
 
     /**
-     * Add additional multiply headers.
+     * Add additional header.
      * @param name Header name
      * @param value Header value
      * @return Request with extra header

--- a/src/main/java/org/takes/rq/RqWithHeader.java
+++ b/src/main/java/org/takes/rq/RqWithHeader.java
@@ -78,4 +78,15 @@ public final class RqWithHeader extends RqWrap {
         );
     }
 
+    /**
+     * Add additional multiply headers.
+     * @param name Header name
+     * @param value Header value
+     * @return Request with extra header
+     */
+    public RqWithHeader withAdditionalHeader(final CharSequence name,
+        final CharSequence value) {
+        return new RqWithHeader(this, name, value);
+    }
+
 }

--- a/src/main/java/org/takes/rq/RqWithHeaders.java
+++ b/src/main/java/org/takes/rq/RqWithHeaders.java
@@ -25,6 +25,7 @@ package org.takes.rq;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.EqualsAndHashCode;
@@ -35,30 +36,29 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
  * @version $Id$
- * @since 0.1
+ * @since 1.0
  */
 @EqualsAndHashCode(callSuper = true)
-public final class RqWithHeader extends RqWrap {
+public final class RqWithHeaders extends RqWrap {
 
     /**
      * Ctor.
      * @param req Original request
-     * @param name Header name
-     * @param value Header value
+     * @param headers Headers to add
      */
-    public RqWithHeader(final Request req, final CharSequence name,
-        final CharSequence value) {
-        this(req, String.format("%s: %s", name, value));
+    public RqWithHeaders(final Request req, final CharSequence... headers) {
+        this(req, Arrays.asList(headers));
     }
 
     /**
      * Ctor.
      * @param req Original request
-     * @param header Header to add
+     * @param headers Headers to add
      */
-    public RqWithHeader(final Request req, final CharSequence header) {
+    public RqWithHeaders(final Request req,
+        final Iterable<? extends CharSequence> headers) {
         super(
             new Request() {
                 @Override
@@ -67,7 +67,9 @@ public final class RqWithHeader extends RqWrap {
                     for (final String hdr : req.head()) {
                         head.add(hdr);
                     }
-                    head.add(header.toString());
+                    for (final CharSequence header : headers) {
+                        head.add(header.toString().trim());
+                    }
                     return head;
                 }
                 @Override

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -27,6 +27,7 @@ import com.google.common.base.Joiner;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.Socket;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -60,6 +61,14 @@ public final class BkBasicTest {
                 ).getBytes()
             )
         );
+        Mockito.when(socket.getLocalAddress()).thenReturn(
+            InetAddress.getLocalHost()
+        );
+        Mockito.when(socket.getLocalPort()).thenReturn(0);
+        Mockito.when(socket.getInetAddress()).thenReturn(
+            InetAddress.getLocalHost()
+        );
+        Mockito.when(socket.getPort()).thenReturn(0);
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Mockito.when(socket.getOutputStream()).thenReturn(baos);
         new BkBasic(new TkText("Hello world!")).accept(socket);

--- a/src/test/java/org/takes/rq/RqSocketTest.java
+++ b/src/test/java/org/takes/rq/RqSocketTest.java
@@ -1,0 +1,167 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rq;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RqSocket}.
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
+ * @checkstyle MagicNumberCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+public final class RqSocketTest {
+
+    /**
+     * RqSocket can return local address.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnLocalAddress() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("GET", "X-Takes-LocalAddress: 192.168.134.1")
+            ).getLocalAddress(),
+            Matchers.is(InetAddress.getByName("192.168.134.1"))
+        );
+    }
+
+    /**
+     * RqSocket can return local port.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnLocalPort() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(new RqFake("PATCH", "X-Takes-LocalPort: 55555"))
+                .getLocalPort(),
+            Matchers.is(55555)
+        );
+    }
+
+    /**
+     * RqSocket can return remote address.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnRemoteAddress() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("POST", "X-Takes-RemoteAddress: 10.233.189.20")
+            ).getRemoteAddress(),
+            Matchers.is(InetAddress.getByName("10.233.189.20"))
+        );
+    }
+
+    /**
+     * RqSocket can return remote port.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnRemotePort() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("PUT", "X-Takes-RemotePort: 80")
+            ).getRemotePort(),
+            Matchers.is(80)
+        );
+    }
+
+    /**
+     * RqSocket can return not found remote address.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnNotFoundRemoteAddress() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("DELETE", "X-Takes-NotFoundInetAddress: x.x.x.x")
+            ).getRemoteAddress(),
+            Matchers.is(InetAddress.getByName("127.0.0.1"))
+        );
+    }
+
+    /**
+     * RqSocket can return not found local address.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnNotFoundLocalAddress() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("HEAD", "X-Takes-NotFoundInetAddress: 10.233.189.20")
+            ).getLocalAddress(),
+            Matchers.is(InetAddress.getByName("127.0.0.1"))
+        );
+    }
+
+    /**
+     * RqSocket can return not found remote port.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnNotFoundRemotePort() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("OPTIONS", "X-Takes-NotFoundPort: 22")
+            ).getRemotePort(),
+            Matchers.is(0)
+        );
+    }
+
+    /**
+     * RqSocket can return not found local port.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void returnNotFoundLocalPort() throws IOException {
+        MatcherAssert.assertThat(
+            new RqSocket(
+                new RqFake("TEST", "X-Takes-NotFoundPort: 80")
+            ).getLocalPort(),
+            Matchers.is(0)
+        );
+    }
+
+    /**
+     * Checks RqSocket equals method.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void equalsAndHashCodeEqualTest() throws Exception {
+        EqualsVerifier.forClass(RqSocket.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .withRedefinedSuperclass()
+            .verify();
+    }
+}

--- a/src/test/java/org/takes/rq/RqSocketTest.java
+++ b/src/test/java/org/takes/rq/RqSocketTest.java
@@ -25,6 +25,7 @@ package org.takes.rq;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.NoSuchElementException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
@@ -50,7 +51,9 @@ public final class RqSocketTest {
     public void returnLocalAddress() throws IOException {
         MatcherAssert.assertThat(
             new RqSocket(
-                new RqFake("GET", "X-Takes-LocalAddress: 192.168.134.1")
+                new RqWithHeader(
+                    new RqFake(), "X-Takes-LocalAddress: 192.168.134.1"
+                )
             ).getLocalAddress(),
             Matchers.is(InetAddress.getByName("192.168.134.1"))
         );
@@ -63,8 +66,9 @@ public final class RqSocketTest {
     @Test
     public void returnLocalPort() throws IOException {
         MatcherAssert.assertThat(
-            new RqSocket(new RqFake("PATCH", "X-Takes-LocalPort: 55555"))
-                .getLocalPort(),
+            new RqSocket(
+                new RqWithHeader(new RqFake(), "X-Takes-LocalPort: 55555")
+            ).getLocalPort(),
             Matchers.is(55555)
         );
     }
@@ -77,7 +81,9 @@ public final class RqSocketTest {
     public void returnRemoteAddress() throws IOException {
         MatcherAssert.assertThat(
             new RqSocket(
-                new RqFake("POST", "X-Takes-RemoteAddress: 10.233.189.20")
+                new RqWithHeader(
+                    new RqFake(), "X-Takes-RemoteAddress: 10.233.189.20"
+                )
             ).getRemoteAddress(),
             Matchers.is(InetAddress.getByName("10.233.189.20"))
         );
@@ -91,7 +97,7 @@ public final class RqSocketTest {
     public void returnRemotePort() throws IOException {
         MatcherAssert.assertThat(
             new RqSocket(
-                new RqFake("PUT", "X-Takes-RemotePort: 80")
+                new RqWithHeader(new RqFake(), "X-Takes-RemotePort: 80")
             ).getRemotePort(),
             Matchers.is(80)
         );
@@ -101,11 +107,13 @@ public final class RqSocketTest {
      * RqSocket can return not found remote address.
      * @throws IOException If some problem inside
      */
-    @Test
+    @Test(expected = NoSuchElementException.class)
     public void returnNotFoundRemoteAddress() throws IOException {
         MatcherAssert.assertThat(
             new RqSocket(
-                new RqFake("DELETE", "X-Takes-NotFoundInetAddress: x.x.x.x")
+                new RqWithHeader(
+                    new RqFake(), "X-Takes-NotFoundInetAddress: x.x.x.x"
+                )
             ).getRemoteAddress(),
             Matchers.is(InetAddress.getByName("127.0.0.1"))
         );
@@ -115,11 +123,13 @@ public final class RqSocketTest {
      * RqSocket can return not found local address.
      * @throws IOException If some problem inside
      */
-    @Test
+    @Test(expected = NoSuchElementException.class)
     public void returnNotFoundLocalAddress() throws IOException {
         MatcherAssert.assertThat(
             new RqSocket(
-                new RqFake("HEAD", "X-Takes-NotFoundInetAddress: 10.233.189.20")
+                new RqWithHeader(
+                    new RqFake(), "X-Takes-NotFoundInetAddress: 10.233.189.20"
+                )
             ).getLocalAddress(),
             Matchers.is(InetAddress.getByName("127.0.0.1"))
         );
@@ -129,10 +139,10 @@ public final class RqSocketTest {
      * RqSocket can return not found remote port.
      * @throws IOException If some problem inside
      */
-    @Test(expected = NumberFormatException.class)
+    @Test(expected = NoSuchElementException.class)
     public void returnNotFoundRemotePort() throws IOException {
         new RqSocket(
-            new RqFake("OPTIONS", "X-Takes-NotFoundPort: 22")
+            new RqWithHeader(new RqFake(), "X-Takes-NotFoundPort: 22")
         ).getRemotePort();
     }
 
@@ -140,10 +150,10 @@ public final class RqSocketTest {
      * RqSocket can return not found local port.
      * @throws IOException If some problem inside
      */
-    @Test(expected = NumberFormatException.class)
+    @Test(expected = NoSuchElementException.class)
     public void returnNotFoundLocalPort() throws IOException {
         new RqSocket(
-            new RqFake("TEST", "X-Takes-NotFoundPort: 80")
+            new RqWithHeader(new RqFake(), "X-Takes-NotFoundPort: 80")
         ).getLocalPort();
     }
 

--- a/src/test/java/org/takes/rq/RqSocketTest.java
+++ b/src/test/java/org/takes/rq/RqSocketTest.java
@@ -129,28 +129,22 @@ public final class RqSocketTest {
      * RqSocket can return not found remote port.
      * @throws IOException If some problem inside
      */
-    @Test
+    @Test(expected = NumberFormatException.class)
     public void returnNotFoundRemotePort() throws IOException {
-        MatcherAssert.assertThat(
-            new RqSocket(
-                new RqFake("OPTIONS", "X-Takes-NotFoundPort: 22")
-            ).getRemotePort(),
-            Matchers.is(0)
-        );
+        new RqSocket(
+            new RqFake("OPTIONS", "X-Takes-NotFoundPort: 22")
+        ).getRemotePort();
     }
 
     /**
      * RqSocket can return not found local port.
      * @throws IOException If some problem inside
      */
-    @Test
+    @Test(expected = NumberFormatException.class)
     public void returnNotFoundLocalPort() throws IOException {
-        MatcherAssert.assertThat(
-            new RqSocket(
-                new RqFake("TEST", "X-Takes-NotFoundPort: 80")
-            ).getLocalPort(),
-            Matchers.is(0)
-        );
+        new RqSocket(
+            new RqFake("TEST", "X-Takes-NotFoundPort: 80")
+        ).getLocalPort();
     }
 
     /**

--- a/src/test/java/org/takes/rq/RqSocketTest.java
+++ b/src/test/java/org/takes/rq/RqSocketTest.java
@@ -25,12 +25,12 @@ package org.takes.rq;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.util.NoSuchElementException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.takes.HttpException;
 
 /**
  * Test case for {@link RqSocket}.
@@ -107,54 +107,80 @@ public final class RqSocketTest {
      * RqSocket can return not found remote address.
      * @throws IOException If some problem inside
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test(expected = HttpException.class)
     public void returnNotFoundRemoteAddress() throws IOException {
-        MatcherAssert.assertThat(
+        try {
             new RqSocket(
                 new RqWithHeader(
                     new RqFake(), "X-Takes-NotFoundInetAddress: x.x.x.x"
                 )
-            ).getRemoteAddress(),
-            Matchers.is(InetAddress.getByName("127.0.0.1"))
-        );
+            ).getRemoteAddress();
+        } catch (final HttpException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.is("header \"X-Takes-RemoteAddress\" is mandatory")
+            );
+            throw ex;
+        }
     }
 
     /**
      * RqSocket can return not found local address.
      * @throws IOException If some problem inside
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test(expected = HttpException.class)
     public void returnNotFoundLocalAddress() throws IOException {
-        MatcherAssert.assertThat(
+        try {
             new RqSocket(
                 new RqWithHeader(
                     new RqFake(), "X-Takes-NotFoundInetAddress: 10.233.189.20"
                 )
-            ).getLocalAddress(),
-            Matchers.is(InetAddress.getByName("127.0.0.1"))
-        );
+            ).getLocalAddress();
+        } catch (final HttpException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.is("header \"X-Takes-LocalAddress\" is mandatory")
+            );
+            throw ex;
+        }
     }
 
     /**
      * RqSocket can return not found remote port.
      * @throws IOException If some problem inside
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test(expected = HttpException.class)
     public void returnNotFoundRemotePort() throws IOException {
-        new RqSocket(
-            new RqWithHeader(new RqFake(), "X-Takes-NotFoundPort: 22")
-        ).getRemotePort();
+        try {
+            new RqSocket(
+                new RqWithHeader(new RqFake(), "X-Takes-NotFoundPort: 22")
+            ).getRemotePort();
+        } catch (final HttpException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.is("header \"X-Takes-RemotePort\" is mandatory")
+            );
+            throw ex;
+        }
     }
 
     /**
      * RqSocket can return not found local port.
      * @throws IOException If some problem inside
      */
-    @Test(expected = NoSuchElementException.class)
+    @Test(expected = HttpException.class)
     public void returnNotFoundLocalPort() throws IOException {
-        new RqSocket(
-            new RqWithHeader(new RqFake(), "X-Takes-NotFoundPort: 80")
-        ).getLocalPort();
+        try {
+            new RqSocket(
+                new RqWithHeader(new RqFake(), "X-Takes-NotFoundPort: 80")
+            ).getLocalPort();
+        } catch (final HttpException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.is("header \"X-Takes-LocalPort\" is mandatory")
+            );
+            throw ex;
+        }
     }
 
     /**

--- a/src/test/java/org/takes/rq/RqWithHeaderTest.java
+++ b/src/test/java/org/takes/rq/RqWithHeaderTest.java
@@ -53,4 +53,24 @@ public final class RqWithHeaderTest {
         );
     }
 
+    /**
+     * RqWithHeader can add multiply additional headers.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void addsMultiplyHeaders() throws IOException {
+        MatcherAssert.assertThat(
+            new RqPrint(
+                new RqWithHeader(new RqFake(), "Header", "Value")
+                    .withAdditionalHeader("TestHeader", "TestValue")
+                    .withAdditionalHeader("SomeHeader", "SomeValue")
+            ).print(),
+            Matchers.allOf(
+                Matchers.containsString("Header: Value"),
+                Matchers.containsString("TestHeader: TestValue"),
+                Matchers.containsString("SomeHeader: SomeValue")
+            )
+        );
+    }
+
 }

--- a/src/test/java/org/takes/rq/RqWithHeaderTest.java
+++ b/src/test/java/org/takes/rq/RqWithHeaderTest.java
@@ -54,11 +54,11 @@ public final class RqWithHeaderTest {
     }
 
     /**
-     * RqWithHeader can add multiply additional headers.
+     * RqWithHeader can add multiple additional headers.
      * @throws IOException If some problem inside
      */
     @Test
-    public void addsMultiplyHeaders() throws IOException {
+    public void addsMultipleHeaders() throws IOException {
         MatcherAssert.assertThat(
             new RqPrint(
                 new RqWithHeader(new RqFake(), "Header", "Value")

--- a/src/test/java/org/takes/rq/RqWithHeadersTest.java
+++ b/src/test/java/org/takes/rq/RqWithHeadersTest.java
@@ -23,6 +23,7 @@
  */
 package org.takes.rq;
 
+import com.google.common.base.Joiner;
 import java.io.IOException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -31,37 +32,45 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link RqWithHeader}.
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * Test case for {@link RqWithHeaders}.
+ * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
  * @version $Id$
- * @since 0.9
+ * @since 1.0
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-public final class RqWithHeaderTest {
-
+public final class RqWithHeadersTest {
     /**
-     * RqWithHeader can add a header.
+     * RqWithHeaders can add headers.
      * @throws IOException If some problem inside
      */
     @Test
-    public void addsHttpHeaders() throws IOException {
+    public void addsHeadersToRequest() throws IOException {
         MatcherAssert.assertThat(
             new RqPrint(
-                new RqWithHeader(
+                new RqWithHeaders(
                     new RqFake(),
-                    "Host", "www.example.com"
+                    "TestHeader: someValue",
+                    "SomeHeader: testValue"
                 )
             ).print(),
-            Matchers.containsString("Host: www.example.com")
+            Matchers.startsWith(
+                Joiner.on("\r\n").join(
+                    "GET /",
+                    "Host: www.example.com",
+                    "TestHeader: someValue",
+                    "SomeHeader: testValue"
+                )
+            )
         );
     }
 
     /**
-     * Checks RqWithHeader equals method.
+     * Checks RqWithHeaders equals method.
      * @throws Exception If some problem inside
      */
     @Test
     public void equalsAndHashCodeEqualTest() throws Exception {
-        EqualsVerifier.forClass(RqWithHeader.class)
+        EqualsVerifier.forClass(RqWithHeaders.class)
             .suppress(Warning.TRANSIENT_FIELDS)
             .withRedefinedSuperclass()
             .verify();


### PR DESCRIPTION
This is fix for https://github.com/yegor256/takes/issues/130
Added ```RqSocket``` decorator to extract socket specific information from the request. 
Edited ```BkBasic``` to inject socket specific information into request.

