### PR TITLE
#160 let's get rid of List.add() - Part 3

### DIFF
--- a/src/main/java/org/takes/misc/Transform.java
+++ b/src/main/java/org/takes/misc/Transform.java
@@ -30,7 +30,7 @@ import java.util.Iterator;
  *
  * @author Jason Wong (super132j@yahoo.com)
  * @version $Id$
- * @since 0.13.8
+ * @since 0.15.2
  */
 public class Transform<T, K> implements Iterable<K> {
 

--- a/src/main/java/org/takes/misc/Transform.java
+++ b/src/main/java/org/takes/misc/Transform.java
@@ -63,6 +63,8 @@ public class Transform<T, K> implements Iterable<K> {
     /**
      * The iterator to iterator through the original type B and return the
      * transformed element in type A.
+     *
+     * <p>This class is NOT thread-safe.
      */
     private static class TransformIterator<B, A> implements Iterator<A> {
 

--- a/src/main/java/org/takes/misc/Transform.java
+++ b/src/main/java/org/takes/misc/Transform.java
@@ -45,7 +45,7 @@ public class Transform<T, K> implements Iterable<K> {
     private final transient TransformAction<T, K> action;
 
     /**
-     * Transform elements in the supplied iterable by the action supplied.
+     * Ctor.
      * @param itb Iterable to be transformed
      * @param act The actual transformation implementation
      */

--- a/src/main/java/org/takes/misc/Transform.java
+++ b/src/main/java/org/takes/misc/Transform.java
@@ -1,0 +1,107 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.util.Iterator;
+
+/**
+ * Transform elements in an iterable (in type T) into others (in type K).
+ *
+ * @author Jason Wong (super132j@yahoo.com)
+ * @version $Id$
+ * @since 0.13.8
+ */
+public class Transform<T, K> implements Iterable<K> {
+
+    /**
+     * Internal storage.
+     */
+    private final transient Iterable<T> list;
+
+    /**
+     * The action to transform the elements in the iterator.
+     */
+    private final transient TransformAction<T, K> action;
+
+    /**
+     * Transform elements in the supplied iterable by the action supplied.
+     * @param itb Iterable to be transformed
+     * @param act The actual transformation implementation
+     */
+    public Transform(final Iterable<T> itb,
+        final TransformAction<T, K> act) {
+        this.list = itb;
+        this.action = act;
+    }
+
+    @Override
+    public final Iterator<K> iterator() {
+        return new TransformIterator<T, K>(this.list.iterator(), this.action);
+    }
+
+    /**
+     * The iterator to iterator through the original type B and return the
+     * transformed element in type A.
+     */
+    private static class TransformIterator<B, A> implements Iterator<A> {
+
+        /**
+         * The iterator to reflect the traverse state.
+         */
+        private final transient Iterator<B> iterator;
+
+        /**
+         * The action to transform the elements in the iterator.
+         */
+        private final transient TransformAction<B, A> action;
+
+        /**
+         * Ctor. ConcatIterator traverses the element.
+         * @param itr Iterator of the original iterable
+         * @param act Action to transform elements
+         */
+        public TransformIterator(final Iterator<B> itr,
+            final TransformAction<B, A> act) {
+            this.action = act;
+            this.iterator = itr;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.iterator.hasNext();
+        }
+
+        @Override
+        public A next() {
+            return this.action.transform(this.iterator.next());
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException(
+                "This iterable is immutable and cannot remove anything"
+            );
+        }
+    }
+}

--- a/src/main/java/org/takes/misc/TransformAction.java
+++ b/src/main/java/org/takes/misc/TransformAction.java
@@ -1,0 +1,63 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+/**
+ * Action for {@link Transform} to perform actual transformation.
+ *
+ * @author Jason Wong (super132j@yahoo.com)
+ * @version $Id$
+ * @since 0.13.8
+ */
+public interface TransformAction<T, K> {
+    /**
+     * The transform action of the element of type T to K.
+     * @param element Element of the iterable
+     * @return Transformed element
+     */
+    K transform(T element);
+
+    /**
+     * Trimming action used with {@link Transform}.
+     */
+    class Trim implements TransformAction<String, String> {
+
+        @Override
+        public String transform(final String element) {
+            return element.trim();
+        }
+    }
+
+    /**
+     * Convert CharSequence into String.
+     */
+    class ToString implements TransformAction<CharSequence, String> {
+
+        @Override
+        public String transform(final CharSequence element) {
+            return element.toString();
+        }
+
+    }
+}

--- a/src/main/java/org/takes/misc/TransformAction.java
+++ b/src/main/java/org/takes/misc/TransformAction.java
@@ -28,7 +28,7 @@ package org.takes.misc;
  *
  * @author Jason Wong (super132j@yahoo.com)
  * @version $Id$
- * @since 0.13.8
+ * @since 0.15.2
  */
 public interface TransformAction<T, K> {
     /**

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -57,7 +57,9 @@ public final class RsWithHeaders extends RsWrap {
      * @todo #160:DEV To implement the concatenation and
      *  transformation with conjunction of Concat class
      *  and Transform class to get rid of the use of List.add()
-     *  in the anonymous Response class head() method.
+     *  in the anonymous Response class head() method. That is,
+     *  we are going to do something like this:
+     *  return new Concat(res.head(), new Transform(headers, new Trim()))
      * @param res Original response
      * @param headers Headers
      */

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -52,12 +52,12 @@ public final class RsWithHeaders extends RsWrap {
         this(res, Arrays.asList(headers));
     }
 
-    //@todo #160:DEV To implement the concatenation and
-    // transformation with conjunction of Concat class
-    // and Transform class to get rid of the use of List.add()
-    // in the anonymous Response class head() nethod.
     /**
      * Ctor.
+     * @todo #160:DEV To implement the concatenation and
+     *  transformation with conjunction of Concat class
+     *  and Transform class to get rid of the use of List.add()
+     *  in the anonymous Response class head() method.
      * @param res Original response
      * @param headers Headers
      */

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -52,6 +52,10 @@ public final class RsWithHeaders extends RsWrap {
         this(res, Arrays.asList(headers));
     }
 
+    //@todo #160:DEV To implement the concatenation and
+    // transformation with conjunction of Concat class
+    // and Transform class to get rid of the use of List.add()
+    // in the anonymous Response class head() nethod.
     /**
      * Ctor.
      * @param res Original response
@@ -63,9 +67,6 @@ public final class RsWithHeaders extends RsWrap {
             new Response() {
                 @Override
                 public List<String> head() throws IOException {
-                    //@todo #160:DEV To implement the concatenation and
-                    // transformation with conjunction of Concat class 
-                    // and Transform class to get rid of the use of List.add()
                     final List<String> head = new LinkedList<String>();
                     for (final String hdr : res.head()) {
                         head.add(hdr);

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -54,7 +54,7 @@ public final class RsWithHeaders extends RsWrap {
 
     /**
      * Ctor.
-     * @todo #160:DEV To implement the concatenation and
+     * @todo #160:30min/DEV To implement the concatenation and
      *  transformation with conjunction of Concat class
      *  and Transform class to get rid of the use of List.add()
      *  in the anonymous Response class head() method. That is,

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -63,6 +63,9 @@ public final class RsWithHeaders extends RsWrap {
             new Response() {
                 @Override
                 public List<String> head() throws IOException {
+                    //@todo #160:DEV To implement the concatenation and
+                    // transformation with conjunction of Concat class 
+                    // and Transform class to get rid of the use of List.add()
                     final List<String> head = new LinkedList<String>();
                     for (final String hdr : res.head()) {
                         head.add(hdr);

--- a/src/test/java/org/takes/misc/TransformTest.java
+++ b/src/test/java/org/takes/misc/TransformTest.java
@@ -1,0 +1,64 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link Transform}.
+ *
+ * @author Jason Wong (super132j@yahoo.com)
+ * @version $Id$
+ * @since 0.13.8
+ */
+public final class TransformTest {
+
+    /**
+     * Transform can transform list.
+     */
+    @Test
+    public void transformList() {
+        final List<String> alist = new ArrayList<String>(3);
+        alist.add("a1");
+        alist.add("b1");
+        alist.add("c1");
+        MatcherAssert.assertThat(
+            new Transform<String, String>(
+                alist,
+                new TransformAction<String, String>() {
+                    @Override
+                    public String transform(final String element) {
+                        return element.concat("t");
+                    }
+                }
+            ),
+            Matchers.hasItems("a1t", "b1t", "c1t")
+        );
+    }
+
+}

--- a/src/test/java/org/takes/misc/TransformTest.java
+++ b/src/test/java/org/takes/misc/TransformTest.java
@@ -23,8 +23,8 @@
  */
 package org.takes.misc;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -43,21 +43,19 @@ public final class TransformTest {
      */
     @Test
     public void transformsList() {
-        final List<String> alist = new ArrayList<String>(3);
-        alist.add("a1");
-        alist.add("b1");
-        alist.add("c1");
         MatcherAssert.assertThat(
-            new Transform<String, String>(
-                alist,
-                new TransformAction<String, String>() {
-                    @Override
-                    public String transform(final String element) {
-                        return element.concat("t");
+            Joiner.on(" ").join(
+                new Transform<String, String>(
+                    Arrays.asList("one", "two", "three"),
+                    new TransformAction<String, String>() {
+                        @Override
+                        public String transform(final String element) {
+                            return element.concat("t");
+                        }
                     }
-                }
+                )
             ),
-            Matchers.hasItems("a1t", "b1t", "c1t")
+            Matchers.equalTo("onet twot threet")
         );
     }
 

--- a/src/test/java/org/takes/misc/TransformTest.java
+++ b/src/test/java/org/takes/misc/TransformTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  *
  * @author Jason Wong (super132j@yahoo.com)
  * @version $Id$
- * @since 0.13.8
+ * @since 0.15.2
  */
 public final class TransformTest {
 
@@ -42,7 +42,7 @@ public final class TransformTest {
      * Transform can transform list.
      */
     @Test
-    public void transformList() {
+    public void transformsList() {
         final List<String> alist = new ArrayList<String>(3);
         alist.add("a1");
         alist.add("b1");


### PR DESCRIPTION
For task #160, introducing Transform for eliminating the use of `List.add()` in `RsWithHeaders`. This PR is split from #183 