### PR TITLE
#239 PsLinkedin passes the request parameters to the URI.

### DIFF
--- a/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
+++ b/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
@@ -123,15 +123,17 @@ public final class PsLinkedin implements Pass {
         throws IOException {
         final String uri = new Href(
             "https://www.linkedin.com/uas/oauth2/accessToken"
-        ).with("grant_type", "authorization_code")
-            .with("client_id", this.app)
-            .with("redirect_uri", home)
-            .with("client_secret", this.key)
-            .with("code", code)
-            .toString();
+        ).toString();
         return new JdkRequest(uri)
             .method("POST")
             .header("Accept", "application/xml")
+            .body()
+            .formParam("grant_type", "authorization_code")
+            .formParam("client_id", this.app)
+            .formParam("redirect_uri", home)
+            .formParam("client_secret", this.key)
+            .formParam("code", code)
+            .back()
             .fetch().as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)
             .as(JsonResponse.class)

--- a/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
@@ -79,16 +79,13 @@ public final class PsLinkedinTest {
                             Matchers.stringContainsInOrder(
                                 Arrays.asList(
                                     "grant_type=authorization_code",
-                                    new StringBuffer("client_id=")
-                                        .append(lapp)
-                                        .toString(),
+                                    String.format("client_id=%s", lapp),
                                     "redirect_uri=",
-                                    new StringBuffer("client_secret=")
-                                        .append(lkey)
-                                        .toString(),
-                                    new StringBuffer("code=")
-                                        .append(code)
-                                        .toString()
+                                    String.format(
+                                        "client_secret=%s",
+                                        lkey
+                                    ),
+                                    String.format("code=%s", code)
                                 )
                             )
                         );

--- a/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
@@ -24,7 +24,6 @@
 
 package org.takes.facets.auth.social;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -44,6 +43,7 @@ import org.takes.http.FtRemote;
 import org.takes.misc.Href;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqHref;
+import org.takes.rq.RqPrint;
 import org.takes.rs.RsJSON;
 
 /**
@@ -74,12 +74,8 @@ public final class PsLinkedinTest {
                 new Take() {
                     @Override
                     public Response act(final Request req) throws IOException {
-                        final BufferedInputStream buffer =
-                            new BufferedInputStream(req.body());
-                        final byte[] bytes = new byte[1024];
-                        buffer.read(bytes);
                         MatcherAssert.assertThat(
-                            new String(bytes),
+                            new RqPrint(req).printBody(),
                             Matchers.stringContainsInOrder(
                                 Arrays.asList(
                                     "grant_type=authorization_code",


### PR DESCRIPTION
For task #239, removing request parameters in `Href` object and move them into body.