### PR TITLE
Implementation of #227

### DIFF
--- a/src/test/java/org/takes/http/BkParallelTest.java
+++ b/src/test/java/org/takes/http/BkParallelTest.java
@@ -23,15 +23,32 @@
  */
 package org.takes.http;
 
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 /**
  * Test case for {@link BkParallel}.
  *
  * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
  * @version $Id$
  * @since 0.15.2
- * @todo #220:30min/DEV This unit test not implemented but has to be.
- *  E.g. you could pass your own a ExecutorService implementation to the ctor
- *  and verify execute() calls.  But feel free to try another way.
  */
-public class BkParallelTest {
+public final class BkParallelTest {
+    /**
+     * BkParallel can call execute() when called accept().
+     */
+    @Test
+    public void callsExecuteOnAccept() {
+        final ExecutorService executor = Mockito.mock(ExecutorService.class);
+        final BkParallel parallel = new BkParallel(
+            Mockito.mock(Back.class),
+            executor
+        );
+        parallel.accept(Mockito.mock(Socket.class));
+        Mockito.verify(executor, Mockito.times(1)).execute(
+            Mockito.<Runnable>any()
+        );
+    }
 }

--- a/src/test/java/org/takes/http/BkParallelTest.java
+++ b/src/test/java/org/takes/http/BkParallelTest.java
@@ -40,6 +40,7 @@ public final class BkParallelTest {
      * BkParallel can call execute() when called accept().
      */
     @Test
+    @SuppressWarnings("PMD.DoNotUseThreads")
     public void callsExecuteOnAccept() {
         final ExecutorService executor = Mockito.mock(ExecutorService.class);
         final BkParallel parallel = new BkParallel(
@@ -47,7 +48,7 @@ public final class BkParallelTest {
             executor
         );
         parallel.accept(Mockito.mock(Socket.class));
-        Mockito.verify(executor, Mockito.times(1)).execute(
+        Mockito.verify(executor).execute(
             Mockito.<Runnable>any()
         );
     }


### PR DESCRIPTION
Resolved puzzle https://github.com/yegor256/takes/issues/227  in src/test/java/org/takes/http/BkParallelTest.java:32-34 This unit test not implemented but has to be. E.g. you could pass your own a ExecutorService implementation to the ctor and verify execute() calls. But feel free to try another way....

1. Implemented unit-test