### PR TITLE
Fix for #231 (FtRemote hides TkFork response status)

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -97,9 +97,16 @@ public final class BkBasic implements Back {
         throws IOException {
         try {
             new RsPrint(this.take.act(req)).print(output);
-            // @checkstyle IllegalCatchCheck (1 line)
+        } catch (final HttpException ex) {
+            new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
+            // @checkstyle IllegalCatchCheck (7 lines)
         } catch (final Throwable ex) {
-            new RsPrint(BkBasic.failure(ex)).print(output);
+            new RsPrint(
+                BkBasic.failure(
+                    ex,
+                    HttpURLConnection.HTTP_INTERNAL_ERROR
+                )
+            ).print(output);
         } finally {
             output.close();
         }
@@ -108,30 +115,18 @@ public final class BkBasic implements Back {
     /**
      * Make a failure response.
      * @param err Error
+     * @param code HTTP error code
      * @return Response
      */
-    private static Response failure(final Throwable err) {
+    private static Response failure(final Throwable err, final int code) {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final PrintWriter writer = new PrintWriter(baos);
         err.printStackTrace(writer);
         writer.close();
         return new RsWithStatus(
             new RsText(new ByteArrayInputStream(baos.toByteArray())),
-            BkBasic.responseCode(err)
+            code
         );
-    }
-
-    /**
-     * Returns HTTP response code for specified exception.
-     * @param err Exception
-     * @return Numeric HTTP code.
-     */
-    private static int responseCode(final Throwable err) {
-        int result = HttpURLConnection.HTTP_INTERNAL_ERROR;
-        if (err instanceof HttpException) {
-            result =  ((HttpException) err).code();
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -117,15 +117,21 @@ public final class BkBasic implements Back {
         writer.close();
         return new RsWithStatus(
             new RsText(new ByteArrayInputStream(baos.toByteArray())),
-            responseCode(err)
+            BkBasic.responseCode(err)
         );
     }
 
-    private static int responseCode(Throwable err) {
+    /**
+     * Returns HTTP response code for specified exception.
+     * @param err Exception
+     * @return Numeric HTTP code.
+     */
+    private static int responseCode(final Throwable err) {
+        int result = HttpURLConnection.HTTP_INTERNAL_ERROR;
         if (err instanceof HttpException) {
-            return ((HttpException) err).code();
+            result =  ((HttpException) err).code();
         }
-        return HttpURLConnection.HTTP_INTERNAL_ERROR;
+        return result;
     }
 
     /**

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -34,6 +34,7 @@ import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.Socket;
 import lombok.EqualsAndHashCode;
+import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -112,8 +113,15 @@ public final class BkBasic implements Back {
         writer.close();
         return new RsWithStatus(
             new RsText(new ByteArrayInputStream(baos.toByteArray())),
-            HttpURLConnection.HTTP_INTERNAL_ERROR
+            responseCode(err)
         );
+    }
+
+    private static int responseCode(Throwable err) {
+        if (err instanceof HttpException) {
+            return ((HttpException) err).code();
+        }
+        return HttpURLConnection.HTTP_INTERNAL_ERROR;
     }
 
 }

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -24,6 +24,8 @@
 package org.takes.http;
 
 import com.google.common.base.Joiner;
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -31,17 +33,12 @@ import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
-
-import com.jcabi.http.request.JdkRequest;
-import com.jcabi.http.response.RestResponse;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.takes.Response;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
-import org.takes.rq.RqFake;
 import org.takes.tk.TkText;
 
 /**
@@ -50,6 +47,7 @@ import org.takes.tk.TkText;
  * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
  * @version $Id$
  * @since 0.15.2
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class BkBasicTest {
     /**
@@ -92,11 +90,13 @@ public final class BkBasicTest {
      * @throws IOException if any I/O error occurs.
      */
     @Test
-    public void returns404OnInvalidUrl() throws IOException {
-        new FtRemote(new TkFork(
-            new FkRegex("/path/a", new TkText("a")),
-            new FkRegex("/path/b", new TkText("b"))
-        )).exec(
+    public void returnsProperResponseCodeOnInvalidUrl() throws IOException {
+        new FtRemote(
+            new TkFork(
+                new FkRegex("/path/a", new TkText("a")),
+                new FkRegex("/path/b", new TkText("b"))
+            )
+        ).exec(
             new FtRemote.Script() {
                 @Override
                 public void exec(final URI home) throws IOException {


### PR DESCRIPTION
Fix for https://github.com/yegor256/takes/issues/231 (FtRemote hides TkFork response status)

1. Wrapped failure handling at BkBasic with response code depending on exception class
1. Unit-test for response code handling