### PR TITLE
Implements HsRqHeader and HsRsHeader #260

### DIFF
--- a/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
@@ -1,0 +1,94 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map.Entry;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.takes.Request;
+import org.takes.rq.RqHeaders;
+
+/**
+ * Response Header Matcher.
+ *
+ * <p>This "matcher" tests given response header.
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
+ * @version $Id$
+ * @since 0.16.2
+ */
+public final class HmRqHeader extends TypeSafeMatcher<Request> {
+
+    /**
+     * Expected request header matcher.
+     */
+    private final transient Matcher<? extends Entry<String, String>> matcher;
+
+    /**
+     * Expected matcher.
+     * @param mtchr Is expected header matcher.
+     */
+    public HmRqHeader(final Matcher<? extends Entry<String, String>> mtchr) {
+        super();
+        this.matcher = mtchr;
+    }
+
+    /**
+     * Fail description.
+     * @param description Fail result description.
+     */
+    @Override
+    public void describeTo(final Description description) {
+        this.matcher.describeTo(description);
+    }
+
+    /**
+     * Type safe matcher.
+     * @param item Is tested element
+     * @return True when expected type matched.
+     */
+    @Override
+    public boolean matchesSafely(final Request item) {
+        try {
+            final RqHeaders headers = new RqHeaders.Base(item);
+            for (final String name: headers.names()) {
+                for (final String value: headers.header(name)) {
+                    if (this.matcher.matches(
+                            Collections.singletonMap(name, value)
+                    )) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+}

--- a/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
@@ -46,9 +46,9 @@ import org.takes.rq.RqHeaders;
  *  According to #260 there should be also available such constructors:
  *  public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
  *  public HmRsHeader(final String header,
- *      final Matcher<? extends Iterable<String>> mtchr);
+ *  final Matcher<? extends Iterable<String>> mtchr);
  *  public HmRsHeader(final String header,
- *      final Matcher<? extends String> mtchr);
+ *  final Matcher<? extends String> mtchr);
  *  public HmRsHeader(final String header, final String value);
  */
 public final class HmRqHeader extends TypeSafeMatcher<Request> {

--- a/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
@@ -57,14 +57,14 @@ public final class HmRqHeader extends TypeSafeMatcher<Request> {
      * Expected request header matcher.
      */
     private final transient Matcher<? extends Map<? extends CharSequence,
-            ? extends CharSequence>> matcher;
+        ? extends CharSequence>> matcher;
 
     /**
      * Expected matcher.
      * @param mtchr Is expected header matcher.
      */
     public HmRqHeader(final Matcher<? extends Map<? extends CharSequence,
-            ? extends CharSequence>> mtchr) {
+        ? extends CharSequence>> mtchr) {
         super();
         this.matcher = mtchr;
     }
@@ -107,11 +107,11 @@ public final class HmRqHeader extends TypeSafeMatcher<Request> {
      * @return True when expected type matched.
      */
     private boolean matchHeader(final String name,
-            final Iterable<String> values) {
+        final Iterable<String> values) {
         boolean result = false;
         for (final String value: values) {
             if (this.matcher.matches(
-                    Collections.singletonMap(name, value)
+                Collections.singletonMap(name, value)
             )) {
                 result = true;
                 break;

--- a/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
@@ -43,13 +43,13 @@ import org.takes.rq.RqHeaders;
  * @version $Id$
  * @since 0.23.3
  * @todo #260:30min Implement additional constructors.
- * According to #260 there should be also available such constructors:
- * public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
- * public HmRsHeader(final String header,
- *     final Matcher<? extends Iterable<String>> mtchr);
- * public HmRsHeader(final String header,
- *     final Matcher<? extends String> mtchr);
- * public HmRsHeader(final String header, final String value);
+ *  According to #260 there should be also available such constructors:
+ *  public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
+ *  public HmRsHeader(final String header,
+ *      final Matcher<? extends Iterable<String>> mtchr);
+ *  public HmRsHeader(final String header,
+ *      final Matcher<? extends String> mtchr);
+ *  public HmRsHeader(final String header, final String value);
  */
 public final class HmRqHeader extends TypeSafeMatcher<Request> {
 

--- a/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
@@ -36,11 +36,20 @@ import org.takes.rq.RqHeaders;
  * Response Header Matcher.
  *
  * <p>This "matcher" tests given response header.
+ * <p>The header name(s) should be provided in lowercase.
  * <p>The class is immutable and thread-safe.
  *
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @version $Id$
- * @since 0.16.2
+ * @since 0.23.3
+ * @todo #260:30min Implement additional constructors.
+ * According to #260 there should be also available such constructors:
+ * public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
+ * public HmRsHeader(final String header,
+ *     final Matcher<? extends Iterable<String>> mtchr);
+ * public HmRsHeader(final String header,
+ *     final Matcher<? extends String> mtchr);
+ * public HmRsHeader(final String header, final String value);
  */
 public final class HmRqHeader extends TypeSafeMatcher<Request> {
 
@@ -48,14 +57,14 @@ public final class HmRqHeader extends TypeSafeMatcher<Request> {
      * Expected request header matcher.
      */
     private final transient Matcher<? extends Map<? extends CharSequence,
-                                        ? extends CharSequence>> matcher;
+            ? extends CharSequence>> matcher;
 
     /**
      * Expected matcher.
      * @param mtchr Is expected header matcher.
      */
     public HmRqHeader(final Matcher<? extends Map<? extends CharSequence,
-                                        ? extends CharSequence>> mtchr) {
+            ? extends CharSequence>> mtchr) {
         super();
         this.matcher = mtchr;
     }

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -47,9 +47,9 @@ import org.takes.Response;
  *  According to #260 there should be also available such constructors
  *  public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
  *  public HmRsHeader(final String header,
- *      final Matcher<? extends Iterable<String>> mtchr);
+ *  final Matcher<? extends Iterable<String>> mtchr);
  *  public HmRsHeader(final String header,
- *      final Matcher<? extends String> mtchr);
+ *  final Matcher<? extends String> mtchr);
  *  public HmRsHeader(final String header, final String value);
  */
 public final class HmRsHeader extends TypeSafeMatcher<Response> {

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -37,11 +37,20 @@ import org.takes.Response;
  * Response Header Matcher.
  *
  * <p>This "matcher" tests given response header.
+ * <p>The header name(s) should be provided in lowercase.
  * <p>The class is immutable and thread-safe.
  *
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @version $Id$
- * @since 0.16.2
+ * @since 0.23.3
+ * @todo #260:30min Implement additional constructors.
+ * According to #260 there should be also available such constructors
+ * public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
+ * public HmRsHeader(final String header,
+ *     final Matcher<? extends Iterable<String>> mtchr);
+ * public HmRsHeader(final String header,
+ *     final Matcher<? extends String> mtchr);
+ * public HmRsHeader(final String header, final String value);
  */
 public final class HmRsHeader extends TypeSafeMatcher<Response> {
 
@@ -49,7 +58,7 @@ public final class HmRsHeader extends TypeSafeMatcher<Response> {
      * Expected request header matcher.
      */
     private final transient Matcher<? extends Map<? extends CharSequence,
-                                        ? extends CharSequence>> matcher;
+            ? extends CharSequence>> matcher;
 
     /**
      * Expected matcher.

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -1,0 +1,111 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.takes.Response;
+
+/**
+ * Response Header Matcher.
+ *
+ * <p>This "matcher" tests given response header.
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
+ * @version $Id$
+ * @since 0.16.2
+ */
+public final class HmRsHeader extends TypeSafeMatcher<Response> {
+
+    /**
+     * Expected request header matcher.
+     */
+    private final transient Matcher<? extends Map<? extends CharSequence,
+                                        ? extends CharSequence>> matcher;
+
+    /**
+     * Expected matcher.
+     * @param mtchr Is expected header matcher.
+     */
+    public HmRsHeader(final Matcher<? extends Map<? extends CharSequence,
+            ? extends CharSequence>> mtchr) {
+        super();
+        this.matcher = mtchr;
+    }
+
+    /**
+     * Fail description.
+     * @param description Fail result description.
+     */
+    @Override
+    public void describeTo(final Description description) {
+        this.matcher.describeTo(description);
+    }
+
+    /**
+     * Type safe matcher.
+     * @param item Is tested element
+     * @return True when expected type matched.
+     */
+    @Override
+    public boolean matchesSafely(final Response item) {
+        try {
+            final Iterator<String> headers = item.head().iterator();
+            headers.next();
+            boolean result = false;
+            while (headers.hasNext()) {
+                if (this.matchHeader(headers.next())) {
+                    result = true;
+                    break;
+                }
+            }
+            return result;
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Runs matcher against each header.
+     * @param header Is header name and value
+     * @return True when expected type matched.
+     */
+    private boolean matchHeader(final String header) {
+        final String[] parts = header.split(":", 2);
+        return this.matcher.matches(
+            Collections.singletonMap(
+                parts[0].trim().toLowerCase(Locale.ENGLISH),
+                parts[1].trim()
+            )
+        );
+    }
+
+}

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -44,13 +44,13 @@ import org.takes.Response;
  * @version $Id$
  * @since 0.23.3
  * @todo #260:30min Implement additional constructors.
- * According to #260 there should be also available such constructors
- * public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
- * public HmRsHeader(final String header,
- *     final Matcher<? extends Iterable<String>> mtchr);
- * public HmRsHeader(final String header,
- *     final Matcher<? extends String> mtchr);
- * public HmRsHeader(final String header, final String value);
+ *  According to #260 there should be also available such constructors
+ *  public HmRsHeader(final Matcher<? extends Map.Entry<String,String>> mtchr);
+ *  public HmRsHeader(final String header,
+ *      final Matcher<? extends Iterable<String>> mtchr);
+ *  public HmRsHeader(final String header,
+ *      final Matcher<? extends String> mtchr);
+ *  public HmRsHeader(final String header, final String value);
  */
 public final class HmRsHeader extends TypeSafeMatcher<Response> {
 

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -58,14 +58,14 @@ public final class HmRsHeader extends TypeSafeMatcher<Response> {
      * Expected request header matcher.
      */
     private final transient Matcher<? extends Map<? extends CharSequence,
-            ? extends CharSequence>> matcher;
+        ? extends CharSequence>> matcher;
 
     /**
      * Expected matcher.
      * @param mtchr Is expected header matcher.
      */
     public HmRsHeader(final Matcher<? extends Map<? extends CharSequence,
-            ? extends CharSequence>> mtchr) {
+        ? extends CharSequence>> mtchr) {
         super();
         this.matcher = mtchr;
     }

--- a/src/test/java/org/takes/facets/hamcrest/HmRqHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqHeaderTest.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.rq.RqFake;
+
+/**
+ * Test case for {@link org.takes.facets.hamcrest.HmRqHeader}.
+ * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
+ * @version $Id$
+ * @since 0.16.2
+ */
+public final class HmRqHeaderTest {
+
+    /**
+     * HmRqHeader can test header available.
+     * @throws java.io.IOException If some problem inside
+     */
+    @Test
+    public void testsHeaderAvailable() throws IOException {
+        MatcherAssert.assertThat(
+            new RqFake(
+                Arrays.asList(
+                    "GET /f?a=3&b-6",
+                    "Host: example.com",
+                    "Accept: text/xml",
+                    "Accept: text/html"
+                ),
+                ""
+            ),
+            new HmRqHeader(Matchers.hasEntry("accept", "text/xml"))
+        );
+    }
+
+    /**
+     * HmRqHeader can test header not available.
+     * @throws java.io.IOException If some problem inside
+     */
+    @Test
+    public void testsHeaderNotAvailable() throws IOException {
+        MatcherAssert.assertThat(
+            new RqFake(
+                Arrays.asList(
+                    "GET /f?a=3",
+                    "Host: www.example.com",
+                    "Accept: text/json"
+                ),
+                ""
+            ),
+            new HmRqHeader(
+                Matchers.not(
+                    Matchers.hasEntry("host", "fake.org")
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/hamcrest/HmRqHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqHeaderTest.java
@@ -23,7 +23,6 @@
  */
 package org.takes.facets.hamcrest;
 
-import java.io.IOException;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -34,16 +33,16 @@ import org.takes.rq.RqFake;
  * Test case for {@link org.takes.facets.hamcrest.HmRqHeader}.
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @version $Id$
- * @since 0.16.2
+ * @since 0.23.3
  */
 public final class HmRqHeaderTest {
 
     /**
      * HmRqHeader can test header available.
-     * @throws java.io.IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void testsHeaderAvailable() throws IOException {
+    public void testsHeaderAvailable() throws Exception {
         MatcherAssert.assertThat(
             new RqFake(
                 Arrays.asList(
@@ -60,10 +59,10 @@ public final class HmRqHeaderTest {
 
     /**
      * HmRqHeader can test header not available.
-     * @throws java.io.IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void testsHeaderNotAvailable() throws IOException {
+    public void testsHeaderNotAvailable() throws Exception {
         MatcherAssert.assertThat(
             new RqFake(
                 Arrays.asList(

--- a/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
@@ -46,7 +46,7 @@ public final class HmRsHeaderTest {
         MatcherAssert.assertThat(
             new RsWithHeader(
                 new RsWithBody("<html>Hello</html>"),
-                    "content-encoding: gzip"
+                "content-encoding: gzip"
             ),
             new HmRsHeader(Matchers.hasEntry("content-encoding", "gzip"))
         );

--- a/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
@@ -23,7 +23,6 @@
  */
 package org.takes.facets.hamcrest;
 
-import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -34,16 +33,16 @@ import org.takes.rs.RsWithHeader;
  * Test case for {@link HmRsHeader}.
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @version $Id$
- * @since 0.16.2
+ * @since 0.23.3
  */
 public final class HmRsHeaderTest {
 
     /**
      * HmRsHeader can test header available.
-     * @throws java.io.IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void testsHeaderAvailable() throws IOException {
+    public void testsHeaderAvailable() throws Exception {
         MatcherAssert.assertThat(
             new RsWithHeader(
                 new RsWithBody("<html>Hello</html>"),
@@ -55,10 +54,10 @@ public final class HmRsHeaderTest {
 
     /**
      * HmRsHeader can test header not available.
-     * @throws java.io.IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void testsHeaderNotAvailable() throws IOException {
+    public void testsHeaderNotAvailable() throws Exception {
         MatcherAssert.assertThat(
             new RsWithBody("<html></html>"),
             new HmRsHeader(

--- a/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
@@ -1,0 +1,74 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.rs.RsWithBody;
+import org.takes.rs.RsWithHeader;
+
+/**
+ * Test case for {@link HmRsHeader}.
+ * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
+ * @version $Id$
+ * @since 0.16.2
+ */
+public final class HmRsHeaderTest {
+
+    /**
+     * HmRsHeader can test header available.
+     * @throws java.io.IOException If some problem inside
+     */
+    @Test
+    public void testsHeaderAvailable() throws IOException {
+        MatcherAssert.assertThat(
+            new RsWithHeader(
+                new RsWithBody("<html>Hello</html>"),
+                    "content-encoding: gzip"
+            ),
+            new HmRsHeader(Matchers.hasEntry("content-encoding", "gzip"))
+        );
+    }
+
+    /**
+     * HmRsHeader can test header not available.
+     * @throws java.io.IOException If some problem inside
+     */
+    @Test
+    public void testsHeaderNotAvailable() throws IOException {
+        MatcherAssert.assertThat(
+            new RsWithBody("<html></html>"),
+            new HmRsHeader(
+                Matchers.not(
+                    Matchers.hasEntry(
+                        "cache-control",
+                        "no-cache, no-store"
+                    )
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Referenced to #260 issue.
Please take a look at this PR implementingHsRqHeader and HsRsHeader + relevant test.

The constructor for both accepts `final Matcher<? extends Map<? extends CharSequence, ? extends CharSequence>> mtchr)` which is different from what was originally reported, but that was already discussed with reporter. 
Additionally `Map` parametrisation was changed from `String` to `CharSequence` since it is not possible to have wild card with final `String` class.

Note the usage 
`new HmRsHeader(Matchers.hasEntry("content-encoding", "gzip"))` 
which expects lower value header name in order to work correctly.