### PR TITLE
#43 PsGoogle is not tested

### DIFF
--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -70,6 +70,16 @@ public final class PsGoogle implements Pass {
     private final transient String redir;
 
     /**
+     * Google OAuth url.
+     */
+    private final transient String gauth;
+
+    /**
+     * Google API url.
+     */
+    private final transient String gapi;
+
+    /**
      * Ctor.
      * @param gapp Google app
      * @param gkey Google key
@@ -77,9 +87,31 @@ public final class PsGoogle implements Pass {
      */
     public PsGoogle(final String gapp, final String gkey,
         final String uri) {
+        this(
+            gapp,
+            gkey,
+            uri,
+            "https://accounts.google.com",
+            "https://www.googleapis.com"
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param gapp Google app
+     * @param gkey Google key
+     * @param uri Redirect URI (exactly as registered in Google console)
+     * @param gurl Google OAuth url
+     * @param aurl Google API url
+     * @checkstyle ParameterNumberCheck (2 lines)
+     */
+    PsGoogle(final String gapp, final String gkey,
+        final String uri, final String gurl, final String aurl) {
         this.app = gapp;
         this.key = gkey;
         this.redir = uri;
+        this.gauth = gurl;
+        this.gapi = aurl;
     }
 
     @Override
@@ -93,7 +125,7 @@ public final class PsGoogle implements Pass {
             );
         }
         return Collections.singleton(
-            PsGoogle.fetch(this.token(code.next()))
+            this.fetch(this.token(code.next()))
         ).iterator();
     }
 
@@ -109,9 +141,9 @@ public final class PsGoogle implements Pass {
      * @return The user found in Google
      * @throws IOException If fails
      */
-    private static Identity fetch(final String token) throws IOException {
+    private Identity fetch(final String token) throws IOException {
         // @checkstyle LineLength (1 line)
-        final String uri = new Href("https://www.googleapis.com/oauth2/v1/userinfo")
+        final String uri = new Href(this.gapi).path("oauth2/v1/userinfo")
             .with("alt", "json")
             .with("access_token", token)
             .toString();
@@ -129,8 +161,9 @@ public final class PsGoogle implements Pass {
      * @throws IOException If failed
      */
     private String token(final String code) throws IOException {
-        return new JdkRequest("https://accounts.google.com/o/oauth2/token")
-            .body()
+        return new JdkRequest(
+            new Href(this.gauth).path("o/oauth2/token").toString()
+        ).body()
             .formParam("client_id", this.app)
             .formParam("redirect_uri", this.redir)
             .formParam("client_secret", this.key)

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -1,0 +1,160 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.social;
+
+import java.io.IOException;
+import java.net.URI;
+import javax.json.Json;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.facets.auth.Identity;
+import org.takes.facets.fork.FkRegex;
+import org.takes.facets.fork.TkFork;
+import org.takes.http.FtRemote;
+import org.takes.rq.RqFake;
+import org.takes.rq.RqForm;
+import org.takes.rq.RqGreedy;
+import org.takes.rq.RqHref;
+import org.takes.rs.RsJSON;
+
+/**
+ * Test case for {@link PsGoogle}.
+ *
+ * <p>The class is immutable and thread-safe.
+ * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
+ * @version $Id$
+ * @since 0.16.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class PsGoogleTest {
+    /**
+     * PsGoogle can login.
+     * @throws IOException If some problem inside
+     * @checkstyle MultipleStringLiteralsCheck (100 lines)
+     */
+    @Test
+    public void canLogin() throws IOException {
+        final Take take = new TkFork(
+            new FkRegex(
+                "/o/oauth2/token",
+                // @checkstyle AnonInnerLengthCheck (1 line)
+                new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        final Request greq = new RqGreedy(req);
+                        PsGoogleTest.assertParam(greq, "client_id", "app");
+                        PsGoogleTest.assertParam(
+                            greq,
+                            "redirect_uri",
+                            "http://localhost/account"
+                        );
+                        PsGoogleTest.assertParam(greq, "client_secret", "key");
+                        PsGoogleTest.assertParam(
+                            greq,
+                            "grant_type",
+                            "authorization_code"
+                        );
+                        PsGoogleTest.assertParam(greq, "code", "code");
+                        return new RsJSON(
+                            Json.createObjectBuilder()
+                                .add("access_token", "GoogleToken")
+                                .add("expires_in", 1)
+                                .add("token_type", "Bearer")
+                                .build()
+                        );
+                    }
+                }
+            ),
+            new FkRegex(
+                "/oauth2/v1/userinfo",
+                new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        MatcherAssert.assertThat(
+                            new RqHref.Base(req).href().param("access_token")
+                                .iterator().next(),
+                            Matchers.containsString("GoogleToken")
+                        );
+                        return new RsJSON(
+                            Json.createObjectBuilder()
+                                .add("name", "octocat")
+                                .add("id", "1")
+                                .add(
+                                    "picture",
+                                    "https://google.com/img/octocat.gif"
+                                )
+                                .build()
+                        );
+                    }
+                }
+            )
+        );
+        new FtRemote(take).exec(
+            // @checkstyle AnonInnerLengthCheck (100 lines)
+            new FtRemote.Script() {
+                @Override
+                public void exec(final URI home) throws IOException {
+                    final Identity identity = new PsGoogle(
+                        "app",
+                        "key",
+                        "http://localhost/account",
+                        home.toString(),
+                        home.toString()
+                    ).enter(new RqFake("GET", "?code=code")).next();
+                    MatcherAssert.assertThat(
+                        identity.urn(),
+                        Matchers.equalTo("urn:google:1")
+                    );
+                    MatcherAssert.assertThat(
+                        identity.properties().get("name"),
+                        Matchers.equalTo("octocat")
+                    );
+                    MatcherAssert.assertThat(
+                        identity.properties().get("picture"),
+                        Matchers.equalTo("https://google.com/img/octocat.gif")
+                    );
+                }
+            }
+        );
+    }
+
+    /**
+     * Checks the parameter value for the expected value.
+     * @param req Request
+     * @param param Parameter name
+     * @param value Parameter value
+     * @throws IOException  If some problem inside
+     */
+    private static void assertParam(final Request req,
+        final CharSequence param, final String value)  throws IOException {
+        MatcherAssert.assertThat(
+            new RqForm.Smart(new RqForm.Base(req)).single(param),
+            Matchers.equalTo(value)
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -53,12 +53,13 @@ import org.takes.rs.RsJSON;
  */
 public final class PsGoogleTest {
     /**
-     * PsGoogle can login.
+     * PsGoogle login.
      * @throws IOException If some problem inside
      * @checkstyle MultipleStringLiteralsCheck (100 lines)
+     * @throws IOException  If some problem inside
      */
     @Test
-    public void canLogin() throws IOException {
+    public void logsIn() throws IOException {
         final Take take = new TkFork(
             new FkRegex(
                 "/o/oauth2/token",
@@ -151,7 +152,7 @@ public final class PsGoogleTest {
      * @throws IOException  If some problem inside
      */
     private static void assertParam(final Request req,
-        final CharSequence param, final String value)  throws IOException {
+        final CharSequence param, final String value) throws IOException {
         MatcherAssert.assertThat(
             new RqForm.Smart(new RqForm.Base(req)).single(param),
             Matchers.equalTo(value)

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -54,12 +54,11 @@ import org.takes.rs.RsJSON;
 public final class PsGoogleTest {
     /**
      * PsGoogle login.
-     * @throws IOException If some problem inside
      * @checkstyle MultipleStringLiteralsCheck (100 lines)
-     * @throws IOException  If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void logsIn() throws IOException {
+    public void logsIn() throws Exception {
         final Take take = new TkFork(
             new FkRegex(
                 "/o/oauth2/token",
@@ -149,7 +148,7 @@ public final class PsGoogleTest {
      * @param req Request
      * @param param Parameter name
      * @param value Parameter value
-     * @throws IOException  If some problem inside
+     * @throws IOException If some problem inside
      */
     private static void assertParam(final Request req,
         final CharSequence param, final String value) throws IOException {


### PR DESCRIPTION
For #43 

* added unit test for PsGoogle

The test's implementation is not originally proposed.
PsGoggle makes two http-request inside but FakeRequest can simulate one only. Similar case was discussed in the #42 and  @yegor256 [suggested](https://github.com/jcabi/jcabi-http/pull/83#issuecomment-97580978) to use Takes as moked OAuth server.