### PR TITLE
#205 stream reading is too slow 

### DIFF
--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -133,32 +133,7 @@ public interface RqMultipart extends Request {
                     )
                 );
             }
-            final Matcher matcher = RqMultipart.Base.BOUNDARY.matcher(header);
-            if (!matcher.matches()) {
-                throw new HttpException(
-                    HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        // @checkstyle LineLength (1 line)
-                        "boundary is not specified in Content-Type header: \"%s\"",
-                        header
-                    )
-                );
-            }
-            final Collection<Request> requests = new LinkedList<Request>();
-            final byte[] boundary = String.format(
-                "\r\n--%s", matcher.group(1)
-            ).getBytes();
-            final InputStream body = new RqLengthAware(req).body();
-            RqMultipart.Base.skip(body, boundary.length - 2);
-            while (body.available() > 0) {
-                final int data = body.read();
-                if (data < 0 || data == '-') {
-                    break;
-                }
-                RqMultipart.Base.skip(body, 1);
-                requests.add(this.make(body, boundary));
-            }
-            this.map = RqMultipart.Base.asMap(requests);
+            this.map = this.process(req, header);
         }
         @Override
         public Iterable<Request> part(final CharSequence name) {
@@ -187,6 +162,43 @@ public interface RqMultipart extends Request {
         @Override
         public Iterable<String> names() {
             return this.map.keySet();
+        }
+
+        /**
+         * Process original request.
+         * @param req Original Request
+         * @param header Request header
+         * @return A map of the Requests
+         * @throws IOException If fails
+         */
+        private ConcurrentMap<String, List<Request>> process(final Request req,
+            final String header) throws IOException {
+            final Matcher matcher = RqMultipart.Base.BOUNDARY.matcher(header);
+            if (!matcher.matches()) {
+                throw new HttpException(
+                    HttpURLConnection.HTTP_BAD_REQUEST,
+                    String.format(
+                        // @checkstyle LineLength (1 line)
+                        "boundary is not specified in Content-Type header: \"%s\"",
+                        header
+                    )
+                );
+            }
+            final Collection<Request> requests = new LinkedList<Request>();
+            final byte[] boundary = String.format(
+                "\r\n--%s", matcher.group(1)
+            ).getBytes();
+            final InputStream body = new RqLengthAware(req).body();
+            RqMultipart.Base.skip(body, boundary.length - 2);
+            while (body.available() > 0) {
+                final int data = body.read();
+                if (data < 0 || data == '-') {
+                    break;
+                }
+                RqMultipart.Base.skip(body, 1);
+                requests.add(this.make(body, boundary));
+            }
+            return RqMultipart.Base.asMap(requests);
         }
         /**
          * Skip a few bytes in a stream.

--- a/src/main/java/org/takes/rq/RqPrint.java
+++ b/src/main/java/org/takes/rq/RqPrint.java
@@ -121,11 +121,11 @@ public final class RqPrint extends RqWrap {
         //@checkstyle MagicNumberCheck (1 line)
         final byte[] buf = new byte[4096];
         while (true) {
-            final int actual = input.read(buf);
-            if (actual < 0) {
+            final int bytes = input.read(buf);
+            if (bytes < 0) {
                 break;
             }
-            output.write(buf, 0, actual);
+            output.write(buf, 0, bytes);
         }
     }
 

--- a/src/main/java/org/takes/rq/RqPrint.java
+++ b/src/main/java/org/takes/rq/RqPrint.java
@@ -118,12 +118,14 @@ public final class RqPrint extends RqWrap {
      */
     public void printBody(final OutputStream output) throws IOException {
         final InputStream input = new RqLengthAware(this).body();
-        while (input.available() > 0) {
-            final int data = input.read();
-            if (data < 0) {
+        //@checkstyle MagicNumberCheck (1 line)
+        final byte[] buf = new byte[4096];
+        while (true) {
+            final int actual = input.read(buf);
+            if (actual < 0) {
                 break;
             }
-            output.write(data);
+            output.write(buf, 0, actual);
         }
     }
 

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -160,11 +160,11 @@ public final class RsPrint extends RsWrap {
             //@checkstyle MagicNumberCheck (1 line)
             final byte[] buf = new byte[4096];
             while (true) {
-                final int actual = body.read(buf);
-                if (actual < 0) {
+                final int bytes = body.read(buf);
+                if (bytes < 0) {
                     break;
                 }
-                output.write(buf, 0, actual);
+                output.write(buf, 0, bytes);
             }
         } finally {
             body.close();

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -157,12 +157,14 @@ public final class RsPrint extends RsWrap {
     public void printBody(final OutputStream output) throws IOException {
         final InputStream body = this.body();
         try {
-            while (body.available() > 0) {
-                final int data = body.read();
-                if (data < 0) {
+            //@checkstyle MagicNumberCheck (1 line)
+            final byte[] buf = new byte[4096];
+            while (true) {
+                final int actual = body.read(buf);
+                if (actual < 0) {
                     break;
                 }
-                output.write(data);
+                output.write(buf, 0, actual);
             }
         } finally {
             body.close();

--- a/src/main/java/org/takes/rs/RsXSLT.java
+++ b/src/main/java/org/takes/rs/RsXSLT.java
@@ -169,16 +169,17 @@ public final class RsXSLT extends RsWrap {
      */
     private static byte[] consume(final InputStream input) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        //@checkstyle MagicNumberCheck (1 line)
+        final byte[] buf = new byte[4096];
         while (true) {
-            final int data = input.read();
-            if (data < 0) {
+            final int actual = input.read(buf);
+            if (actual < 0) {
                 break;
             }
-            baos.write(data);
+            baos.write(buf, 0, actual);
         }
         return baos.toByteArray();
     }
-
     /**
      * Retrieve a stylesheet from this XML (throws an exception if
      * no stylesheet is attached).

--- a/src/main/java/org/takes/rs/RsXSLT.java
+++ b/src/main/java/org/takes/rs/RsXSLT.java
@@ -172,11 +172,11 @@ public final class RsXSLT extends RsWrap {
         //@checkstyle MagicNumberCheck (1 line)
         final byte[] buf = new byte[4096];
         while (true) {
-            final int actual = input.read(buf);
-            if (actual < 0) {
+            final int bytes = input.read(buf);
+            if (bytes < 0) {
                 break;
             }
-            baos.write(buf, 0, actual);
+            baos.write(buf, 0, bytes);
         }
         return baos.toByteArray();
     }


### PR DESCRIPTION
For #205 

* `RqLengthAware` is an `InputStream` implementation. It's out of the scope of the task.
* `RqLive` parses using `read()` the request header only. Usually  it has very small size. No needs to be buffered
* `RqMultipart` buffered read will be implemented in PR #255 
* `RqPrint` `read()` replaced with  `read(byte[])` 
* `RsGzip` uses `read(byte[])`  already
* `RsPrint` `read()` replaced with  `read(byte[])` 
* `RsXSLT` `read()` replaced with  `read(byte[])` 

No needs to create a new unit tests. The classes has tests already.