### PR TITLE
Fixed RsWithType duplicating headers. (#217)

### DIFF
--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -47,10 +47,12 @@ public final class RsWithType extends RsWrap {
     public RsWithType(final Response res, final CharSequence type) {
         super(
             new RsWithHeader(
-                new RsWithStatus(res, HttpURLConnection.HTTP_OK),
+                new RsWithoutHeader(
+                    new RsWithStatus(res, HttpURLConnection.HTTP_OK),
+                    "Content-Type"
+                ),
                 "Content-Type", type
-        )
+            )
         );
     }
-
 }

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -1,0 +1,84 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rs;
+
+import com.google.common.base.Joiner;
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RsWithType}.
+ * @author Yohann Ferreira (yohann.ferreira@orange.fr)
+ * @version $Id$
+ * @since 0.16.9
+ */
+public final class RsWithTypeTest {
+
+    /**
+     * RsWithType can add a type.
+     * @throws IOException If a problem occurs.
+     */
+    @Test
+    public void addTypeToResponse() throws IOException {
+        MatcherAssert.assertThat(
+            new RsPrint(
+                    new RsWithType(new RsEmpty(), "text/xml")
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on("\r\n").join(
+                    "HTTP/1.1 200 OK",
+                    "Content-Type: text/xml",
+                    "",
+                    ""
+                )
+            )
+        );
+    }
+
+    /**
+     * RsWithType can replace an existing type.
+     * @throws IOException If a problem occurs.
+     */
+    @Test
+    public void replaceTypeToResponse() throws IOException {
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsWithType(
+                    new RsWithType(new RsEmpty(), "text/xml"),
+                    "text/plain"
+                )
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on("\r\n").join(
+                    "HTTP/1.1 200 OK",
+                    "Content-Type: text/plain",
+                    "",
+                    ""
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
RsWithType will now also use RsWithoutHeader to make sure it replaces
any previous types before adding the new one.

I also added tests for RsWithType.

As it is my very first PR for the team, feel free to point out anything so I can improve my future changes.