### PR TITLE
Fix for  "RsWithType overrides status code"

### DIFF
--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -50,12 +50,7 @@ public final class RsWithType extends RsWrap {
      */
     public RsWithType(final Response res, final CharSequence type) {
         super(
-            new RsWithHeader(
-                new RsWithoutHeader(
-                    res,
-                    HEADER
-            ), HEADER, type
-        )
+            new RsWithHeader(new RsWithoutHeader(res, HEADER), HEADER, type)
         );
     }
 }

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -23,7 +23,6 @@
  */
 package org.takes.rs;
 
-import java.net.HttpURLConnection;
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
 
@@ -53,7 +52,7 @@ public final class RsWithType extends RsWrap {
         super(
             new RsWithHeader(
                 new RsWithoutHeader(
-                    new RsWithStatus(res, HttpURLConnection.HTTP_OK),
+                    res,
                     HEADER
             ), HEADER, type
         )

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -24,7 +24,7 @@
 package org.takes.rs;
 
 import com.google.common.base.Joiner;
-import java.io.IOException;
+import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -44,10 +44,10 @@ public final class RsWithTypeTest {
 
     /**
      * RsWithType can replace an existing type.
-     * @throws IOException If a problem occurs.
+     * @throws java.lang.Exception If a problem occurs.
      */
     @Test
-    public void replaceTypeToResponse() throws IOException {
+    public void replaceTypeToResponse() throws Exception {
         final String type = "text/plain";
         MatcherAssert.assertThat(
             new RsPrint(
@@ -58,28 +58,29 @@ public final class RsWithTypeTest {
             ).print(),
             Matchers.equalTo(
                 Joiner.on(CRLF).join(
-                        "HTTP/1.1 200 OK",
-                        String.format("Content-Type: %s", type),
-                        "",
-                        ""
+                    "HTTP/1.1 200 OK",
+                    String.format("Content-Type: %s", type),
+                    "",
+                    ""
                 )
             )
         );
     }
 
     /**
-     * RsWithType can not replace response code.
-     * @throws java.io.IOException If a problem occurs.
+     * RsWithType does not replace response code.
+     * @throws java.lang.Exception If a problem occurs.
      */
     @Test
-    public void notReplacesResponseCode() throws IOException {
-        final int code = 500;
+    public void doesNotReplaceResponseCode() throws Exception {
         final String body = "Error!";
         MatcherAssert.assertThat(
             new RsPrint(
                 new RsWithType(
                     new RsWithBody(
-                        new RsWithStatus(code),
+                        new RsWithStatus(
+                            HttpURLConnection.HTTP_INTERNAL_ERROR
+                        ),
                         body
                     ),
                     "text/html"

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -38,6 +38,11 @@ import org.junit.Test;
 public final class RsWithTypeTest {
 
     /**
+     * Carriage return constant.
+     */
+    private static final String CRLF = "\r\n";
+
+    /**
      * RsWithType can replace an existing type.
      * @throws IOException If a problem occurs.
      */
@@ -52,11 +57,41 @@ public final class RsWithTypeTest {
                 )
             ).print(),
             Matchers.equalTo(
-                Joiner.on("\r\n").join(
-                    "HTTP/1.1 200 OK",
-                    String.format("Content-Type: %s", type),
+                Joiner.on(CRLF).join(
+                        "HTTP/1.1 200 OK",
+                        String.format("Content-Type: %s", type),
+                        "",
+                        ""
+                )
+            )
+        );
+    }
+
+    /**
+     * RsWithType can not replace response code.
+     * @throws java.io.IOException If a problem occurs.
+     */
+    @Test
+    public void notReplacesResponseCode() throws IOException {
+        final int code = 500;
+        final String body = "Error!";
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsWithType(
+                    new RsWithBody(
+                        new RsWithStatus(code),
+                        body
+                    ),
+                    "text/html"
+                )
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    "HTTP/1.1 500 Internal Error",
+                    "Content-Length: 6",
+                    "Content-Type: text/html",
                     "",
-                    ""
+                    body
                 )
             )
         );


### PR DESCRIPTION
Please review this PR fixing "RsWithType overrides status code" #298

The fix actually removes passing HTTP OK status code. 