### PR TITLE
Fixed #257: changed RqWithHeader to use RqWithHeaders

### DIFF
--- a/src/main/java/org/takes/rq/RqWithHeader.java
+++ b/src/main/java/org/takes/rq/RqWithHeader.java
@@ -23,12 +23,9 @@
  */
 package org.takes.rq;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collections;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
-import org.takes.misc.Concat;
 
 /**
  * Request with extra header.
@@ -59,20 +56,6 @@ public final class RqWithHeader extends RqWrap {
      * @param header Header to add
      */
     public RqWithHeader(final Request req, final CharSequence header) {
-        super(
-            new Request() {
-                @Override
-                public Iterable<String> head() throws IOException {
-                    return new Concat<String>(
-                        req.head(),
-                        Collections.singleton(header.toString())
-                    );
-                }
-                @Override
-                public InputStream body() throws IOException {
-                    return req.body();
-                }
-            }
-        );
+        super(new RqWithHeaders(req, Collections.singleton(header)));
     }
 }


### PR DESCRIPTION
Please review this PR fixing #257.

I've changed `RqWithHeader` to make use of `RqWithHeaders` passing singleton collection as second arg.