### PR TITLE
Made RqMultipart.Base delete its temporary files as soon as possible.

### DIFF
--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -226,7 +226,7 @@ public interface RqMultipart extends Request {
         /**
          * Make a request.
          *  Scans the origin request until the boundary reached. Caches
-         *  the  content into a temporary file and returns it as a new request.
+         *  the content into a temporary file and returns it as a new request.
          * @param boundary Boundary
          * @return Request
          * @throws IOException If fails
@@ -235,7 +235,6 @@ public interface RqMultipart extends Request {
             final File file = File.createTempFile(
                 RqMultipart.class.getName(), ".tmp"
             );
-            file.deleteOnExit();
             final FileChannel channel = new RandomAccessFile(
                 file, "rw"
             ).getChannel();
@@ -250,9 +249,12 @@ public interface RqMultipart extends Request {
                 channel.close();
             }
             return new RqLive(
-                new CapInputStream(
-                    new FileInputStream(file),
-                    file.length()
+                new TempInputStream(
+                    new CapInputStream(
+                        new FileInputStream(file),
+                        file.length()
+                    ),
+                    file
                 )
             );
         }

--- a/src/main/java/org/takes/rq/TempInputStream.java
+++ b/src/main/java/org/takes/rq/TempInputStream.java
@@ -1,0 +1,98 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rq;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Input stream using a temporary cache file.
+ *
+ * <p>All implementations of this interface must be immutable and thread-safe.
+ *
+ * @author Yegor Bugayenko (yegor@teamed.io)
+ * @version $Id$
+ * @since 0.16
+ */
+final class TempInputStream extends InputStream {
+
+    /**
+     * Original stream.
+     */
+    private final transient InputStream origin;
+
+    /**
+     * Temporary file used as a cache.
+     */
+    private final transient File file;
+
+    /**
+     * Ctor.
+     * @param stream Original stream
+     * @param temp Temporary file used as a cache.
+     */
+    TempInputStream(final InputStream stream, final File temp) {
+        super();
+        this.origin = stream;
+        this.file = temp;
+    }
+
+    /**
+     * Closes the Input stream, deleting the now useless temporary file.
+     * @throws IOException if some problem occurs.
+     */
+    @Override
+    public void close() throws IOException {
+        super.close();
+        this.origin.close();
+        this.file.delete();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return this.origin.read();
+    }
+
+    @Override
+    public int read(final byte[] buf) throws IOException {
+        return this.origin.read(buf, 0, buf.length);
+    }
+
+    @Override
+    public int read(final byte[] buf, final int off,
+        final int len) throws IOException {
+        return this.origin.read(buf, off, len);
+    }
+
+    @Override
+    public long skip(final long num) throws IOException {
+        return this.origin.skip(num);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return this.origin.available();
+    }
+}

--- a/src/main/java/org/takes/rq/TempInputStream.java
+++ b/src/main/java/org/takes/rq/TempInputStream.java
@@ -34,7 +34,7 @@ import java.io.InputStream;
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
- * @since 0.16
+ * @since 0.21
  */
 final class TempInputStream extends InputStream {
 

--- a/src/main/java/org/takes/rq/TempInputStream.java
+++ b/src/main/java/org/takes/rq/TempInputStream.java
@@ -32,7 +32,7 @@ import java.io.InputStream;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Yohann Ferreira (yohann.ferreira@orange.fr)
  * @version $Id$
  * @since 0.21
  */

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Arrays;

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Arrays;
@@ -432,33 +431,5 @@ public final class RqMultipartTest {
             );
         }
         temp.delete();
-    }
-
-    /**
-     * Test the TempInputStream class for correct deletion of the temp file,
-     * as used in multipart requests.
-     * @throws IOException if some problem occurs.
-     */
-    @Test
-    public void testTempFileDeletion() throws IOException {
-        final File file = File.createTempFile("tempfile", ".tmp");
-        final BufferedWriter out = new BufferedWriter(new FileWriter(file));
-        out.write("takes is fun!\n");
-        out.write("Temp file deletion test.\n");
-        out.close();
-        final InputStream body = new TempInputStream(
-            new FileInputStream(file), file
-        );
-        MatcherAssert.assertThat(
-            "File exists.",
-            file.exists(),
-            Matchers.equalTo(true)
-        );
-        body.close();
-        MatcherAssert.assertThat(
-            "File doesn't exist anymore.",
-            file.exists(),
-            Matchers.equalTo(false)
-        );
     }
 }

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -383,6 +383,7 @@ public final class RqMultipartTest {
         );
         temp.delete();
     }
+
     /**
      * RqMultipart.Base doesn't distort the content.
      * @throws IOException If some problem inside
@@ -431,5 +432,33 @@ public final class RqMultipartTest {
             );
         }
         temp.delete();
+    }
+
+    /**
+     * Test the TempInputStream class for correct deletion of the temp file,
+     * as used in multipart requests.
+     * @throws IOException if some problem occurs.
+     */
+    @Test
+    public void testTempFileDeletion() throws IOException {
+        final File file = File.createTempFile("tempfile", ".tmp");
+        final BufferedWriter out = new BufferedWriter(new FileWriter(file));
+        out.write("takes is fun!\n");
+        out.write("Temp file deletion test.\n");
+        out.close();
+        final InputStream body = new TempInputStream(
+            new FileInputStream(file), file
+        );
+        MatcherAssert.assertThat(
+            "File exists.",
+            file.exists(),
+            Matchers.equalTo(true)
+        );
+        body.close();
+        MatcherAssert.assertThat(
+            "File doesn't exist anymore.",
+            file.exists(),
+            Matchers.equalTo(false)
+        );
     }
 }

--- a/src/test/java/org/takes/rq/TempInputStreamTest.java
+++ b/src/test/java/org/takes/rq/TempInputStreamTest.java
@@ -35,15 +35,14 @@ import org.junit.Test;
 
 /**
  * Test case for {@link TempInputStream}.
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Yohann Ferreira (yohann.ferreira@orange.fr)
  * @version $Id$
  * @since 0.21
  */
 public final class TempInputStreamTest {
 
     /**
-     * TempInputStream can delete the temporary cache file
-     * when it calls close().
+     * TempInputStream can delete the temporary cache file when closed.
      * @throws IOException if some problem occurs.
      */
     @Test

--- a/src/test/java/org/takes/rq/TempInputStreamTest.java
+++ b/src/test/java/org/takes/rq/TempInputStreamTest.java
@@ -1,0 +1,71 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rq;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link TempInputStream}.
+ * @author Yegor Bugayenko (yegor@teamed.io)
+ * @version $Id$
+ * @since 0.21
+ */
+public final class TempInputStreamTest {
+
+    /**
+     * TempInputStream can delete the temporary cache file
+     * when it calls close().
+     * @throws IOException if some problem occurs.
+     */
+    @Test
+    public void deletesTempFile() throws IOException {
+        final File file = File.createTempFile("tempfile", ".tmp");
+        final BufferedWriter out = new BufferedWriter(new FileWriter(file));
+        out.write("takes is fun!\n");
+        out.write("Temp file deletion test.\n");
+        out.close();
+        final InputStream body = new TempInputStream(
+            new FileInputStream(file), file
+        );
+        MatcherAssert.assertThat(
+            "File exists.",
+            file.exists(),
+            Matchers.equalTo(true)
+        );
+        body.close();
+        MatcherAssert.assertThat(
+            "File doesn't exist anymore.",
+            file.exists(),
+            Matchers.equalTo(false)
+        );
+    }
+}


### PR DESCRIPTION
For #254

I thus added a decorator to InputStream to permit deletion of the temp file
when calling close() as advised by @dmzaytsev

Thanks to @yegor256 and @dmzaytsev for the hints.

I also added a test to the new `TempInputStream` class to actually test the change.