### PR TITLE
#310 RsText maintains status code

### DIFF
--- a/src/main/java/org/takes/rs/RsText.java
+++ b/src/main/java/org/takes/rs/RsText.java
@@ -24,7 +24,6 @@
 package org.takes.rs;
 
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
@@ -125,10 +124,7 @@ public final class RsText extends RsWrap {
      */
     public RsText(final Response res) {
         super(
-            new RsWithType(
-                new RsWithStatus(res, HttpURLConnection.HTTP_OK),
-                "text/plain"
-        )
+            new RsWithType(res, "text/plain")
         );
     }
 

--- a/src/test/java/org/takes/rs/RsTextTest.java
+++ b/src/test/java/org/takes/rs/RsTextTest.java
@@ -25,6 +25,7 @@ package org.takes.rs;
 
 import com.google.common.base.Joiner;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -58,4 +59,22 @@ public final class RsTextTest {
         );
     }
 
+    /**
+     * RsText can build a response with a status.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void makesTextResponseWithStatus() throws IOException {
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsText(
+                    new RsWithStatus(HttpURLConnection.HTTP_NOT_FOUND),
+                    "something not found"
+                )
+            ).printHead(),
+            Matchers.containsString(
+                Integer.toString(HttpURLConnection.HTTP_NOT_FOUND)
+            )
+        );
+    }
 }


### PR DESCRIPTION
Changed the RsText constructor to pass the response in the parameter instead of forcing a 200 response status.
Fixes #310 