### PR TITLE
#253 Enabled RqMultipartTest.consumesHttpRequest

### DIFF
--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.Request;
 import org.takes.Response;
@@ -274,8 +273,6 @@ public final class RqMultipartTest {
      * @throws IOException if some problem inside
      */
     @Test
-    // see https://github.com/yegor256/takes/issues/253
-    @Ignore
     public void consumesHttpRequest() throws IOException {
         final Take take = new Take() {
             @Override


### PR DESCRIPTION
Pull request for issue #253. I simply re-enabled ignored test and ran it 1000 times locally to make sure it is working. Looks like it is already fixed by previous commits as outlined in https://github.com/yegor256/takes/issues/291#issuecomment-106116283.