### PR TITLE
#339 RsPrettyXML retains html5 doctype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     </distributionManagement>
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>
-        <saxon.version>9.1.0.8</saxon.version>
+        <saxon.version>9.6.0-6</saxon.version>
     </properties>
     <dependencies>
         <!--
@@ -182,16 +182,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.saxon</groupId>
-            <artifactId>saxon</artifactId>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
             <version>${saxon.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.saxon</groupId>
-            <artifactId>saxon</artifactId>
-            <version>${saxon.version}</version>
-            <classifier>dom</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-aspects</artifactId>
+            <version>0.20.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <optional>true</optional>

--- a/src/main/java/org/takes/rs/RsPrettyXML.java
+++ b/src/main/java/org/takes/rs/RsPrettyXML.java
@@ -39,7 +39,6 @@ import javax.xml.transform.stream.StreamResult;
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
 import org.w3c.dom.Document;
-import org.w3c.dom.DocumentType;
 import org.xml.sax.InputSource;
 
 /**
@@ -134,37 +133,28 @@ public final class RsPrettyXML implements Response {
      * Checks if the input is an html5 document.
      * @param body The body to be checked.
      * @return True if the input is an html5 document.
-     * @checkstyle MethodNameCheck (4 lines)
+     * @checkstyle MethodNameCheck (3 lines)
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException",
-        "PMD.OnlyOneReturn" })
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private static boolean isHtml5(final InputStream body) {
-        final Document document;
+        Document document = null;
+        boolean valid = true;
         try {
             body.mark(Integer.MAX_VALUE);
-            document = parseBody(body);
+            final DocumentBuilderFactory factory =
+                DocumentBuilderFactory.newInstance();
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            document = builder.parse(body);
             body.reset();
             // @checkstyle IllegalCatchCheck (1 line)
         } catch (final Exception ex) {
-            return false;
+            valid = false;
         }
-        final DocumentType doctype = document.getDoctype();
-        return doctype != null
-            && "html".equalsIgnoreCase(doctype.getName())
-            && doctype.getSystemId() == null
-            && doctype.getPublicId() == null;
-    }
-
-    /**
-     * Parses the input stream and returns the Document built.
-     * @param body The body to be parsed.
-     * @return The document built.
-     * @throws Exception if something goes wrong.
-     */
-    private static Document parseBody(final InputStream body) throws Exception {
-        final DocumentBuilderFactory factory =
-            DocumentBuilderFactory.newInstance();
-        final DocumentBuilder builder = factory.newDocumentBuilder();
-        return builder.parse(body);
+        // @checkstyle BooleanExpressionComplexityCheck (5 lines)
+        return valid
+            && document.getDoctype() != null
+            && "html".equalsIgnoreCase(document.getDoctype().getName())
+            && document.getDoctype().getSystemId() == null
+            && document.getDoctype().getPublicId() == null;
     }
 }

--- a/src/main/java/org/takes/rs/RsPrettyXML.java
+++ b/src/main/java/org/takes/rs/RsPrettyXML.java
@@ -134,10 +134,10 @@ public final class RsPrettyXML implements Response {
      * Checks if the input is an html5 document.
      * @param body The body to be checked.
      * @return True if the input is an html5 document.
-     * @checkstyle MethodNameCheck (2 lines)
+     * @checkstyle MethodNameCheck (4 lines)
      */
-    @SuppressWarnings({"PMD.AvoidCatchingGenericException",
-        "PMD.OnlyOneReturn"})
+    @SuppressWarnings({ "PMD.AvoidCatchingGenericException",
+        "PMD.OnlyOneReturn" })
     private static boolean isHtml5(final InputStream body) {
         final Document document;
         try {

--- a/src/main/java/org/takes/rs/RsPrettyXML.java
+++ b/src/main/java/org/takes/rs/RsPrettyXML.java
@@ -39,6 +39,7 @@ import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
+import org.takes.misc.Opt;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -50,6 +51,7 @@ import org.xml.sax.SAXException;
  * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
  * @version $Id$
  * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (100 lines)
  */
 @EqualsAndHashCode(of = "origin")
 public final class RsPrettyXML implements Response {
@@ -135,19 +137,21 @@ public final class RsPrettyXML implements Response {
      * Checks if the input is an html5 document.
      * @param body The body to be checked.
      * @return True if the input is an html5 document.
-     * @checkstyle MethodNameCheck (4 lines)
      * @throws IOException If there are problems reading the input.
+     * @checkstyle MethodNameCheck (4 lines)
      */
     @LogExceptions
     private static boolean isHtml5(final InputStream body) throws IOException {
-        Document document = null;
+        Opt<Document> document = new Opt.Empty<Document>();
         boolean valid = true;
         try {
             body.mark(Integer.MAX_VALUE);
-            document = DocumentBuilderFactory
-                .newInstance()
-                .newDocumentBuilder()
-                .parse(body);
+            document = new Opt.Single<Document>(
+                DocumentBuilderFactory
+                    .newInstance()
+                    .newDocumentBuilder()
+                    .parse(body)
+            );
             body.reset();
         } catch (final SAXException ex) {
             valid = false;
@@ -156,9 +160,9 @@ public final class RsPrettyXML implements Response {
         }
         // @checkstyle BooleanExpressionComplexityCheck (5 lines)
         return valid
-            && document.getDoctype() != null
-            && "html".equalsIgnoreCase(document.getDoctype().getName())
-            && document.getDoctype().getSystemId() == null
-            && document.getDoctype().getPublicId() == null;
+            && document.get().getDoctype() != null
+            && "html".equalsIgnoreCase(document.get().getDoctype().getName())
+            && document.get().getDoctype().getSystemId() == null
+            && document.get().getDoctype().getPublicId() == null;
     }
 }

--- a/src/main/java/org/takes/rs/RsPrettyXML.java
+++ b/src/main/java/org/takes/rs/RsPrettyXML.java
@@ -23,13 +23,14 @@
  */
 package org.takes.rs;
 
+import com.jcabi.aspects.LogExceptions;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -40,6 +41,7 @@ import lombok.EqualsAndHashCode;
 import org.takes.Response;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * Response with properly indented XML body.
@@ -133,22 +135,24 @@ public final class RsPrettyXML implements Response {
      * Checks if the input is an html5 document.
      * @param body The body to be checked.
      * @return True if the input is an html5 document.
-     * @checkstyle MethodNameCheck (3 lines)
+     * @checkstyle MethodNameCheck (4 lines)
+     * @throws IOException If there are problems reading the input.
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private static boolean isHtml5(final InputStream body) {
+    @LogExceptions
+    private static boolean isHtml5(final InputStream body) throws IOException {
         Document document = null;
         boolean valid = true;
         try {
             body.mark(Integer.MAX_VALUE);
-            final DocumentBuilderFactory factory =
-                DocumentBuilderFactory.newInstance();
-            final DocumentBuilder builder = factory.newDocumentBuilder();
-            document = builder.parse(body);
+            document = DocumentBuilderFactory
+                .newInstance()
+                .newDocumentBuilder()
+                .parse(body);
             body.reset();
-            // @checkstyle IllegalCatchCheck (1 line)
-        } catch (final Exception ex) {
+        } catch (final SAXException ex) {
             valid = false;
+        } catch (final ParserConfigurationException ex) {
+            throw new IOException(ex);
         }
         // @checkstyle BooleanExpressionComplexityCheck (5 lines)
         return valid

--- a/src/test/java/org/takes/rs/RsPrettyXMLTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXMLTest.java
@@ -51,7 +51,25 @@ public final class RsPrettyXMLTest {
                     new RsWithBody("<test><a>foo</a></test>")
                 )
             ).printBody(),
-            Matchers.is("<test>\n   <a>foo</a>\n</test>")
+            Matchers.is("<test>\n   <a>foo</a>\n</test>\n")
+        );
+    }
+
+    /**
+     * RsPrettyXML retails the Doctype declaration when specified.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void retainsDoctypeDeclaration() throws IOException {
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsPrettyXML(
+                    new RsWithBody(
+                        "<!DOCTYPE html><html><head></head><body></body></html>"
+                    )
+                )
+            ).printBody(),
+            Matchers.containsString("<!DOCTYPE HTML>")
         );
     }
 
@@ -73,7 +91,7 @@ public final class RsPrettyXMLTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new RsPrint(
             new RsWithBody(
-                "<test>\n   <a>test</a>\n</test>"
+                "<test>\n   <a>test</a>\n</test>\n"
             )
         ).printBody(baos);
         MatcherAssert.assertThat(


### PR DESCRIPTION
Checks if the provided doctype is for HTML 5, if so it preserves the doctype declaration.
To do that I also needed to upgrade to latest SAX version.

Fixes #339