### PR TITLE
306 : Support http persistent connections

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -84,6 +84,10 @@ public final class BkBasic implements Back {
         this.take = tks;
     }
 
+    // @todo #306 30min/DEV : the server should use same socket for new coming
+    // requests if the connection is persistent.
+    // And the server should create new socket for new coming requests if the
+    // connection is not persistent
     @Override
     public void accept(final Socket socket) throws IOException {
         final InputStream input = socket.getInputStream();
@@ -96,9 +100,7 @@ public final class BkBasic implements Back {
                     keepAlive
             );
         } finally {
-            if (!keepAlive) {
-                input.close();
-            }
+            input.close();
         }
     }
 

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -84,10 +84,15 @@ public final class BkBasic implements Back {
         this.take = tks;
     }
 
-    // @todo #306 15min/DEV : the server should use same socket for new coming
-    // requests if the connection is persistent.
-    // And the server should create new socket for new coming requests if the
-    // connection is not persistent
+    /**
+     * Read from socket.
+     * @param socket TCP socket with HTTP
+     * @throws IOException if some problem occurs
+     * @todo #306 15min/DEV : the server should use same socket for new coming
+     *  requests if the connection is persistent.
+     *  And the server should create new socket for new coming requests if the
+     *  connection is not persistent
+     */
     @Override
     public void accept(final Socket socket) throws IOException {
         final InputStream input = socket.getInputStream();

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -84,7 +84,7 @@ public final class BkBasic implements Back {
         this.take = tks;
     }
 
-    // @todo #306 30min/DEV : the server should use same socket for new coming
+    // @todo #306 15min/DEV : the server should use same socket for new coming
     // requests if the connection is persistent.
     // And the server should create new socket for new coming requests if the
     // connection is not persistent

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -100,9 +100,9 @@ public final class BkBasic implements Back {
         final boolean keepAlive = this.isConnectionKeepAlive(req);
         try {
             this.print(
-                    BkBasic.addSocketHeaders(req, socket),
-                    new BufferedOutputStream(socket.getOutputStream()),
-                    keepAlive
+                BkBasic.addSocketHeaders(req, socket),
+                new BufferedOutputStream(socket.getOutputStream()),
+                keepAlive
             );
         } finally {
             input.close();
@@ -120,13 +120,13 @@ public final class BkBasic implements Back {
         final RqHeaders.Base rqHeaders = new RqHeaders.Base(req);
         if (rqHeaders.head().iterator().hasNext()) {
             final Iterator<String> values = rqHeaders.header(BkBasic.CONNECTION)
-                    .iterator();
+                .iterator();
             if (values.hasNext()) {
                 do {
                     keep = BkBasic.KEEP_ALIVE.toLowerCase(
-                            Locale.ENGLISH
-                            ).equals(
-                            values.next().toLowerCase(Locale.ENGLISH)
+                        Locale.ENGLISH
+                        ).equals(
+                        values.next().toLowerCase(Locale.ENGLISH)
                     );
                 } while (!keep && values.hasNext());
             }
@@ -143,11 +143,10 @@ public final class BkBasic implements Back {
      */
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
     private void print(final Request req, final OutputStream output,
-                       final boolean keep)
-            throws IOException {
+        final boolean keep) throws IOException {
         try {
             new RsPrint(
-                    this.retrieveResponse(req, keep)
+                this.retrieveResponse(req, keep)
             ).print(output);
         } catch (final HttpException ex) {
             new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
@@ -173,13 +172,13 @@ public final class BkBasic implements Back {
      * @throws IOException if fails
      */
     private Response retrieveResponse(final Request req, final boolean keep)
-            throws IOException {
+        throws IOException {
         final Response res;
         if (keep) {
             res = new RsWithHeader(
-                    this.take.act(req),
-                    BkBasic.CONNECTION,
-                    BkBasic.KEEP_ALIVE
+                this.take.act(req),
+                BkBasic.CONNECTION,
+                BkBasic.KEEP_ALIVE
             );
         } else {
             res = this.take.act(req);

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -84,7 +84,7 @@ public final class BkBasic implements Back {
         this.take = tks;
     }
 
-    // @todo #306 15min/DEV : the server should use same socket for new coming
+    // @todo #306 30min/DEV : the server should use same socket for new coming
     // requests if the connection is persistent.
     // And the server should create new socket for new coming requests if the
     // connection is not persistent

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -97,7 +97,7 @@ public final class BkBasic implements Back {
     public void accept(final Socket socket) throws IOException {
         final InputStream input = socket.getInputStream();
         final RqLive req = new RqLive(input);
-        final boolean keepAlive = this.isConnectionKeepAlive(req);
+        final boolean keepAlive = this.persistent(req);
         try {
             this.print(
                 BkBasic.addSocketHeaders(req, socket),
@@ -115,7 +115,7 @@ public final class BkBasic implements Back {
      * @return Boolean
      * @throws IOException if fails
      */
-    private boolean isConnectionKeepAlive(final RqLive req) throws IOException {
+    private boolean persistent(final RqLive req) throws IOException {
         boolean keep = false;
         final RqHeaders.Base rqHeaders = new RqHeaders.Base(req);
         if (rqHeaders.head().iterator().hasNext()) {
@@ -146,7 +146,7 @@ public final class BkBasic implements Back {
         final boolean keep) throws IOException {
         try {
             new RsPrint(
-                this.retrieveResponse(req, keep)
+                this.response(req, keep)
             ).print(output);
         } catch (final HttpException ex) {
             new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
@@ -171,7 +171,7 @@ public final class BkBasic implements Back {
      * @return Response
      * @throws IOException if fails
      */
-    private Response retrieveResponse(final Request req, final boolean keep)
+    private Response response(final Request req, final boolean keep)
         throws IOException {
         final Response res;
         if (keep) {

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -139,8 +139,9 @@ public final class BkBasic implements Back {
                        final boolean keep)
             throws IOException {
         try {
-            final Response res = this.retrieveResponse(req, keep);
-            new RsPrint(res).print(output);
+            new RsPrint(
+                    this.retrieveResponse(req, keep)
+            ).print(output);
         } catch (final HttpException ex) {
             new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
             // @checkstyle IllegalCatchCheck (7 lines)

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -144,7 +144,6 @@ public final class BkBasicTest {
         );
         final String connection = "Connection";
         final String keepAlive = "Keep-Alive";
-
         conn.setRequestMethod("GET");
         conn.setUseCaches(false);
         conn.setInstanceFollowRedirects(false);

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -62,6 +62,11 @@ public final class BkBasicTest {
     private static final String CRLF = "\r\n";
 
     /**
+     * Wait 2 sec for web app.
+     */
+    private static final int WAIT_APP = 2000;
+
+    /**
      * BkBasic can handle socket data.
      * @throws IOException If some problem inside
      */
@@ -130,18 +135,20 @@ public final class BkBasicTest {
                 }
         );
         app.start();
-        final HttpURLConnection persistentConnection = HttpURLConnection.class.cast(
+        Thread.sleep(BkBasicTest.WAIT_APP);
+        final HttpURLConnection persistConnection = HttpURLConnection
+                .class.cast(
                 new URL(uri).openConnection()
         );
         final String connection = "Connection";
         final String keepAlive = "Keep-Alive";
-        persistentConnection.setRequestMethod("GET");
-        persistentConnection.setUseCaches(false);
-        persistentConnection.setInstanceFollowRedirects(false);
-        persistentConnection.addRequestProperty("Host", "localhost");
-        persistentConnection.addRequestProperty(connection, keepAlive);
+        persistConnection.setRequestMethod("GET");
+        persistConnection.setUseCaches(false);
+        persistConnection.setInstanceFollowRedirects(false);
+        persistConnection.addRequestProperty("Host", "localhost");
+        persistConnection.addRequestProperty(connection, keepAlive);
         MatcherAssert.assertThat(
-                persistentConnection.getHeaderFields().get(connection),
+                persistConnection.getHeaderFields().get(connection),
                 Matchers.hasItem(keepAlive)
         );
         app.interrupt();

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -130,18 +130,18 @@ public final class BkBasicTest {
                 }
         );
         app.start();
-        final HttpURLConnection firstConnection = HttpURLConnection.class.cast(
+        final HttpURLConnection persistentConnection = HttpURLConnection.class.cast(
                 new URL(uri).openConnection()
         );
         final String connection = "Connection";
         final String keepAlive = "Keep-Alive";
-        firstConnection.setRequestMethod("GET");
-        firstConnection.setUseCaches(false);
-        firstConnection.setInstanceFollowRedirects(false);
-        firstConnection.addRequestProperty("Host", "localhost");
-        firstConnection.addRequestProperty(connection, keepAlive);
+        persistentConnection.setRequestMethod("GET");
+        persistentConnection.setUseCaches(false);
+        persistentConnection.setInstanceFollowRedirects(false);
+        persistentConnection.addRequestProperty("Host", "localhost");
+        persistentConnection.addRequestProperty(connection, keepAlive);
         MatcherAssert.assertThat(
-                firstConnection.getHeaderFields().get(connection),
+                persistentConnection.getHeaderFields().get(connection),
                 Matchers.hasItem(keepAlive)
         );
         app.interrupt();

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -133,33 +133,16 @@ public final class BkBasicTest {
         final HttpURLConnection firstConnection = HttpURLConnection.class.cast(
                 new URL(uri).openConnection()
         );
-        final String req = "GET";
-        final String host = "Host";
-        final String localhost = "localhost";
         final String connection = "Connection";
         final String keepAlive = "Keep-Alive";
-        firstConnection.setRequestMethod(req);
+        firstConnection.setRequestMethod("GET");
         firstConnection.setUseCaches(false);
         firstConnection.setInstanceFollowRedirects(false);
-        firstConnection.addRequestProperty(host, localhost);
+        firstConnection.addRequestProperty("Host", "localhost");
         firstConnection.addRequestProperty(connection, keepAlive);
-        final HttpURLConnection secondConnection = HttpURLConnection.class.cast(
-                new URL(uri).openConnection()
-        );
-        secondConnection.setRequestMethod(req);
-        secondConnection.setUseCaches(false);
-        secondConnection.setInstanceFollowRedirects(false);
-        secondConnection.addRequestProperty(host, localhost);
-        secondConnection.addRequestProperty(connection, "close");
         MatcherAssert.assertThat(
                 firstConnection.getHeaderFields().get(connection),
                 Matchers.hasItem(keepAlive)
-        );
-        MatcherAssert.assertThat(
-                secondConnection.getHeaderFields().get(connection),
-                Matchers.not(
-                        Matchers.hasItem(keepAlive)
-            )
         );
         app.interrupt();
     }

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -118,21 +118,21 @@ public final class BkBasicTest {
             }
         };
         final Thread app = new Thread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            new FtBasic(
-                                    new BkBasic(take),
-                                    port
-                            ).start(
-                                    Exit.NEVER
-                            );
-                        } catch (final IOException ex) {
-                            throw new IllegalStateException(ex);
-                        }
+            new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        new FtBasic(
+                            new BkBasic(take),
+                            port
+                        ).start(
+                            Exit.NEVER
+                        );
+                    } catch (final IOException ex) {
+                        throw new IllegalStateException(ex);
                     }
                 }
+            }
         );
         app.start();
         Thread.sleep(BkBasicTest.WAIT_APP);
@@ -148,8 +148,8 @@ public final class BkBasicTest {
         httpURLConnection.addRequestProperty("Host", "localhost");
         httpURLConnection.addRequestProperty(connection, keepAlive);
         MatcherAssert.assertThat(
-                httpURLConnection.getHeaderFields().get(connection),
-                Matchers.hasItem(keepAlive)
+            httpURLConnection.getHeaderFields().get(connection),
+            Matchers.hasItem(keepAlive)
         );
         app.interrupt();
     }
@@ -170,9 +170,9 @@ public final class BkBasicTest {
                 @Override
                 public void exec(final URI home) throws IOException {
                     new JdkRequest(String.format("%s/path/c", home))
-                            .fetch()
-                            .as(RestResponse.class)
-                            .assertStatus(HttpURLConnection.HTTP_NOT_FOUND);
+                        .fetch()
+                        .as(RestResponse.class)
+                        .assertStatus(HttpURLConnection.HTTP_NOT_FOUND);
                 }
             }
         );

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -142,18 +142,21 @@ public final class BkBasicTest {
         final HttpURLConnection conn = HttpURLConnection.class.cast(
                 new URL(uri).openConnection()
         );
+        final String connection = "Connection";
+        final String keepAlive = "Keep-Alive";
+
         conn.setRequestMethod("GET");
         conn.setUseCaches(false);
         conn.setInstanceFollowRedirects(false);
         conn.addRequestProperty("Host", "localhost");
-        final String connection = "Connection";
+        conn.addRequestProperty(connection, keepAlive);
         MatcherAssert.assertThat(
                 conn.getHeaderFields(),
                 Matchers.hasKey(connection)
         );
         MatcherAssert.assertThat(
                 conn.getHeaderFields().get(connection),
-                Matchers.hasItem("Keep-Alive")
+                Matchers.hasItem(keepAlive)
         );
         completed.countDown();
         completed.await(1L, TimeUnit.MILLISECONDS);

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -136,19 +136,19 @@ public final class BkBasicTest {
         );
         app.start();
         Thread.sleep(BkBasicTest.WAIT_APP);
-        final HttpURLConnection persistConnection = HttpURLConnection
+        final HttpURLConnection httpURLConnection = HttpURLConnection
                 .class.cast(
                 new URL(uri).openConnection()
         );
         final String connection = "Connection";
         final String keepAlive = "Keep-Alive";
-        persistConnection.setRequestMethod("GET");
-        persistConnection.setUseCaches(false);
-        persistConnection.setInstanceFollowRedirects(false);
-        persistConnection.addRequestProperty("Host", "localhost");
-        persistConnection.addRequestProperty(connection, keepAlive);
+        httpURLConnection.setRequestMethod("GET");
+        httpURLConnection.setUseCaches(false);
+        httpURLConnection.setInstanceFollowRedirects(false);
+        httpURLConnection.addRequestProperty("Host", "localhost");
+        httpURLConnection.addRequestProperty(connection, keepAlive);
         MatcherAssert.assertThat(
-                persistConnection.getHeaderFields().get(connection),
+                httpURLConnection.getHeaderFields().get(connection),
                 Matchers.hasItem(keepAlive)
         );
         app.interrupt();


### PR DESCRIPTION
 #306  :  Support http persistent connections. 
If the client sends a request which has  connection: keep-alive parameter then the server adds connection:keep-alive to the header of the response. 
If the client sends a request which has connection:close parameter then the server don't add connection:keep-alive to the header of the response. 

Puzzle: In this process the server should use the same socket for new coming requests if the connection is persistent.
And the server should create the new socket for new coming requests if the connection is not persistent.