### PR TITLE
#120: RqFake equals()

### DIFF
--- a/src/main/java/org/takes/rq/RqBytes.java
+++ b/src/main/java/org/takes/rq/RqBytes.java
@@ -1,0 +1,72 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rq;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+
+/**
+ * Request in which the body is a byte array.
+ *
+ * @author Dragan Bozanovic (bozanovicdr@gmail.com)
+ * @version $Id$
+ * @since 0.24
+ */
+@EqualsAndHashCode
+public final class RqBytes implements Request {
+    /**
+     * Head.
+     */
+    private final transient List<String> hed;
+
+    /**
+     * Body.
+     */
+    private final transient byte[] bdy;
+
+    /**
+     * Ctor.
+     * @param head Head
+     * @param body Body
+     */
+    public RqBytes(final List<String> head, final byte[] body) {
+        this.hed = Collections.unmodifiableList(head);
+        this.bdy = Arrays.copyOf(body, body.length);
+    }
+
+    @Override
+    public Iterable<String> head() {
+        return this.hed;
+    }
+
+    @Override
+    public InputStream body() {
+        return new ByteArrayInputStream(this.bdy);
+    }
+}

--- a/src/main/java/org/takes/rq/RqFake.java
+++ b/src/main/java/org/takes/rq/RqFake.java
@@ -23,7 +23,6 @@
  */
 package org.takes.rq;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
@@ -99,7 +98,7 @@ public final class RqFake extends RqWrap {
      * @param body Body
      */
     public RqFake(final List<String> head, final byte[] body) {
-        super(new RqFakeRequest(head, body));
+        super(new RqBytes(head, body));
     }
 
     /**
@@ -120,41 +119,5 @@ public final class RqFake extends RqWrap {
                 }
             }
         );
-    }
-
-    /**
-     * The request which is used when the body is a byte array.
-     */
-    @EqualsAndHashCode
-    static final class RqFakeRequest implements Request {
-        /**
-         * Head.
-         */
-        private final transient List<String> hed;
-
-        /**
-         * Body.
-         */
-        private final transient byte[] bdy;
-
-        /**
-         * Ctor.
-         * @param head Head
-         * @param body Body
-         */
-        public RqFakeRequest(final List<String> head, final byte[] body) {
-            this.hed = head;
-            this.bdy = Arrays.copyOf(body, body.length);
-        }
-
-        @Override
-        public Iterable<String> head() {
-            return Collections.unmodifiableList(this.hed);
-        }
-
-        @Override
-        public InputStream body() {
-            return new ByteArrayInputStream(this.bdy);
-        }
     }
 }

--- a/src/main/java/org/takes/rq/RqFake.java
+++ b/src/main/java/org/takes/rq/RqFake.java
@@ -99,18 +99,7 @@ public final class RqFake extends RqWrap {
      * @param body Body
      */
     public RqFake(final List<String> head, final byte[] body) {
-        super(
-            new Request() {
-                @Override
-                public Iterable<String> head() {
-                    return Collections.unmodifiableList(head);
-                }
-                @Override
-                public InputStream body() {
-                    return new ByteArrayInputStream(body);
-                }
-            }
-        );
+        super(new RqFakeRequest(head, body));
     }
 
     /**
@@ -133,4 +122,39 @@ public final class RqFake extends RqWrap {
         );
     }
 
+    /**
+     * The request which is used when the body is a byte array.
+     */
+    @EqualsAndHashCode
+    static final class RqFakeRequest implements Request {
+        /**
+         * Head.
+         */
+        private final transient List<String> hed;
+
+        /**
+         * Body.
+         */
+        private final transient byte[] bdy;
+
+        /**
+         * Ctor.
+         * @param head Head
+         * @param body Body
+         */
+        public RqFakeRequest(final List<String> head, final byte[] body) {
+            this.hed = head;
+            this.bdy = Arrays.copyOf(body, body.length);
+        }
+
+        @Override
+        public Iterable<String> head() {
+            return Collections.unmodifiableList(this.hed);
+        }
+
+        @Override
+        public InputStream body() {
+            return new ByteArrayInputStream(this.bdy);
+        }
+    }
 }

--- a/src/test/java/org/takes/rq/RqFakeTest.java
+++ b/src/test/java/org/takes/rq/RqFakeTest.java
@@ -1,0 +1,48 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rq;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test case for {@link RqFake}.
+ * @author Dragan Bozanovic (bozanovicdr@gmail.com)
+ * @version $Id$
+ * @since 0.24
+ */
+public final class RqFakeTest {
+
+    /**
+     * Two RqFakes are equal if they contain the same head and body.
+     */
+    @Test
+    public void equalsTrue() {
+        final List<String> head = Arrays.asList("test head");
+        final String body = "test body";
+        Assert.assertEquals(new RqFake(head, body), new RqFake(head, body));
+    }
+}

--- a/src/test/java/org/takes/rq/RqFakeTest.java
+++ b/src/test/java/org/takes/rq/RqFakeTest.java
@@ -23,9 +23,8 @@
  */
 package org.takes.rq;
 
-import java.util.Arrays;
-import java.util.List;
-import org.junit.Assert;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 /**
@@ -37,12 +36,13 @@ import org.junit.Test;
 public final class RqFakeTest {
 
     /**
-     * Two RqFakes are equal if they contain the same head and body.
+     * Can conform to the Object.equals() contract.
      */
     @Test
-    public void equalsTrue() {
-        final List<String> head = Arrays.asList("test head");
-        final String body = "test body";
-        Assert.assertEquals(new RqFake(head, body), new RqFake(head, body));
+    public void conformsToEquality() {
+        EqualsVerifier.forClass(RqFake.class)
+            .suppress(Warning.TRANSIENT_FIELDS)
+            .withRedefinedSuperclass()
+            .verify();
     }
 }


### PR DESCRIPTION
#120: Two RqFake instances are equal if they contain the same head and
byte array body.