### PR TITLE
#290: Enhanced javadoc for the Response class

### DIFF
--- a/src/main/java/org/takes/Response.java
+++ b/src/main/java/org/takes/Response.java
@@ -42,6 +42,11 @@ import java.io.InputStream;
  *   ),
  *   "Content-Type", "text/html"
  * );</pre>
+ * 
+ * <p>The implementations of this interface may require that {@link #head()}
+ * method has to be invoked before reading from the {@code InputStream},
+ * but they must NOT require that the {@link InputStream} has to be read from
+ * before the {@link #head()} method invocation.
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *

--- a/src/main/java/org/takes/Response.java
+++ b/src/main/java/org/takes/Response.java
@@ -43,10 +43,10 @@ import java.io.InputStream;
  *   "Content-Type", "text/html"
  * );</pre>
  *
- * <p>The implementations of this interface may require that {@link Response#head()}
- * method has to be invoked before reading from the {@code InputStream},
- * but they must NOT require that the {@link InputStream} has to be read from
- * before the {@link Response#head()} method invocation.
+ * <p>The implementations of this interface may require that
+ * {@link Response#head()} method has to be invoked before reading from the
+ * {@code InputStream}, but they must NOT require that the {@link InputStream}
+ * has to be read from before the {@link Response#head()} method invocation.
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *

--- a/src/main/java/org/takes/Response.java
+++ b/src/main/java/org/takes/Response.java
@@ -42,7 +42,7 @@ import java.io.InputStream;
  *   ),
  *   "Content-Type", "text/html"
  * );</pre>
- * 
+ *
  * <p>The implementations of this interface may require that {@link #head()}
  * method has to be invoked before reading from the {@code InputStream},
  * but they must NOT require that the {@link InputStream} has to be read from

--- a/src/main/java/org/takes/Response.java
+++ b/src/main/java/org/takes/Response.java
@@ -43,10 +43,10 @@ import java.io.InputStream;
  *   "Content-Type", "text/html"
  * );</pre>
  *
- * <p>The implementations of this interface may require that {@link #head()}
+ * <p>The implementations of this interface may require that {@link Response#head()}
  * method has to be invoked before reading from the {@code InputStream},
  * but they must NOT require that the {@link InputStream} has to be read from
- * before the {@link #head()} method invocation.
+ * before the {@link Response#head()} method invocation.
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *

--- a/src/main/java/org/takes/Response.java
+++ b/src/main/java/org/takes/Response.java
@@ -45,8 +45,9 @@ import java.io.InputStream;
  *
  * <p>The implementations of this interface may require that
  * {@link Response#head()} method has to be invoked before reading from the
- * {@code InputStream}, but they must NOT require that the {@link InputStream}
- * has to be read from before the {@link Response#head()} method invocation.
+ * {@code InputStream} obtained from the {@link Response#body()} method,
+ * but they must NOT require that the {@link InputStream} has to be read
+ * from before the {@link Response#head()} method invocation.
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -33,6 +33,11 @@ import org.takes.Response;
 /**
  * Response decorator, with body.
  *
+ * <p>This implementation of the {@link Response} interface requires that
+ * the {@link Response#head()} method has to be invoked before reading
+ * from the {@code InputStream} obtained from the {@link Response#body()}
+ * method.
+ *
  * <p>The class is immutable and thread-safe.
  *
  * @author Yegor Bugayenko (yegor@teamed.io)


### PR DESCRIPTION
#290: Enhanced javadoc for the Response class by describing the restrictions regarding the order of the head() and body() methods invocation.