### PR TITLE
286 tkgziptest compreses on demand does not work

### DIFF
--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -136,18 +136,33 @@ public final class RsWithBody extends RsWrap {
      * @param body Body
      */
     public RsWithBody(final Response res, final InputStream body) {
-        super(
-            new Response() {
-                @Override
-                public Iterable<String> head() throws IOException {
-                    return RsWithBody.append(res, body.available());
-                }
-                @Override
-                public InputStream body() {
-                    return body;
-                }
+        super(RsWithBody.make(res, body));
+    }
+
+    /**
+     * Makes a response asking InputStream available bytes without delay, since
+     * further this InputStream may happen to be closed already.
+     * @param res Original response
+     * @param body Body
+     * @return Response just made
+     */
+    private static Response make(final Response res, final InputStream body) {
+        final int length;
+        try {
+            length = body.available();
+        } catch (final IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+        return new Response() {
+            @Override
+            public Iterable<String> head() throws IOException {
+                return RsWithBody.append(res, length);
             }
-        );
+            @Override
+            public InputStream body() {
+                return body;
+            }
+        };
     }
 
     /**

--- a/src/test/java/org/takes/tk/TkGzipTest.java
+++ b/src/test/java/org/takes/tk/TkGzipTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;

--- a/src/test/java/org/takes/tk/TkGzipTest.java
+++ b/src/test/java/org/takes/tk/TkGzipTest.java
@@ -45,7 +45,6 @@ public final class TkGzipTest {
      * @throws IOException If some problem inside
      */
     @Test
-    @Ignore
     public void compressesOnDemandOnly() throws IOException {
         MatcherAssert.assertThat(
             new RsPrint(


### PR DESCRIPTION
Fixed #286 
Changed `RsWithBody` Response creation in a way that length value is obtained from `InputStream.available` without delay, since further caller of body method mat happen to close the stream. Enabled the test.