### PR TITLE
#450 - RsXSLT.InClasspath resolve() method was not using "base" parameter.

### DIFF
--- a/src/main/java/org/takes/rs/RsXSLT.java
+++ b/src/main/java/org/takes/rs/RsXSLT.java
@@ -236,8 +236,14 @@ public final class RsXSLT extends RsWrap {
         @Override
         public Source resolve(final String href, final String base)
             throws TransformerException {
+            final URI uri;
+            if (base == null) {
+                uri = URI.create(href);
+            } else {
+                uri = URI.create(base).resolve(href);
+            }
             final InputStream input = this.getClass().getResourceAsStream(
-                URI.create(href).getPath()
+                uri.getPath()
             );
             if (input == null) {
                 throw new TransformerException(

--- a/src/test/java/org/takes/rs/RsXSLTTest.java
+++ b/src/test/java/org/takes/rs/RsXSLTTest.java
@@ -201,6 +201,21 @@ public final class RsXSLTTest {
             ).print(),
             Matchers.endsWith("Hello, Dan!")
         );
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsXSLT(
+                    new RsText(
+                        Joiner.on(' ').join(
+                            "<?xml-stylesheet  ",
+                            " href='/org/takes/rs/includes.xsl'",
+                            "  type='text/xsl' ?>",
+                            "<p><name>Miranda</name></p>"
+                        )
+                    )
+                )
+            ).print(),
+            Matchers.endsWith("Hello, Miranda!")
+        );
     }
 
 }

--- a/src/test/resources/org/takes/rs/inclass/imported.xsl
+++ b/src/test/resources/org/takes/rs/inclass/imported.xsl
@@ -1,0 +1,6 @@
+<stylesheet xmlns='http://www.w3.org/1999/XSL/Transform' version='2.0' >
+    <output method='text'/>
+    <template name="exclamation">
+        <text>!</text>
+    </template>
+</stylesheet>

--- a/src/test/resources/org/takes/rs/included.xsl
+++ b/src/test/resources/org/takes/rs/included.xsl
@@ -1,0 +1,7 @@
+<stylesheet xmlns='http://www.w3.org/1999/XSL/Transform' version='2.0' >
+    <import href="inclass/imported.xsl"/>
+    <output method='text'/>
+    <template name="hello">
+        <text>Hello</text>
+    </template>
+</stylesheet>

--- a/src/test/resources/org/takes/rs/includes.xsl
+++ b/src/test/resources/org/takes/rs/includes.xsl
@@ -1,0 +1,10 @@
+<stylesheet xmlns='http://www.w3.org/1999/XSL/Transform' version='2.0' >
+    <include href="/org/takes/rs/included.xsl"/>
+    <output method='text'/>
+    <template match='/'>
+        <call-template name="hello"/>
+        <text>, </text>
+        <value-of select='/p/name'/>
+        <call-template name="exclamation"/>
+    </template>
+</stylesheet>


### PR DESCRIPTION
Fix for issue #450 - base parameter in RsXSLT.InClasspath.resolve(String, String) is unused.

- RsXSLT.InClasspath.resolve() method updated to use URI.resolve() for "href" when "base" parameters is not null. When "base" is null URI on href is created.
- RsXSLTTest.resolvesInClasspath() test method updated to test also xsl:include and xsl:import with relative and absolute paths.
- Added 3 .xsl files in order to test InClasspath.resolve() calls also for xsl:include & xsl:import.