### PR TITLE
Include Content-Length header from test requests

### DIFF
--- a/src/test/java/org/takes/rq/RqFormTest.java
+++ b/src/test/java/org/takes/rq/RqFormTest.java
@@ -43,14 +43,19 @@ public final class RqFormTest {
      */
     @Test
     public void parsesHttpBody() throws IOException {
+        final String body = "alpha=a+b+c&beta=%20Yes%20";
         final RqForm req = new RqForm.Base(
             new RqBuffered(
                 new RqFake(
                     Arrays.asList(
                         "GET /h?a=3",
-                        "Host: www.example.com"
+                        "Host: www.example.com",
+                        String.format(
+                            "Content-Length: %d",
+                            body.getBytes().length
+                        )
                     ),
-                    "alpha=a+b+c&beta=%20Yes%20"
+                    body
                 )
             )
         );

--- a/src/test/java/org/takes/rq/RqGreedyTest.java
+++ b/src/test/java/org/takes/rq/RqGreedyTest.java
@@ -45,16 +45,21 @@ public final class RqGreedyTest {
      */
     @Test
     public void makesRequestGreedy() throws IOException {
+        final String body = Joiner.on("\r\n").join(
+            "GET /test HTTP/1.1",
+            "Host: localhost",
+            "",
+            "... the body ..."
+        );
         final Request req = new RqGreedy(
-            new RqLive(
-                new ByteArrayInputStream(
-                    Joiner.on("\r\n").join(
-                        "GET /test HTTP/1.1",
-                        "Host: localhost",
-                        "",
-                        "... the body ..."
-                    ).getBytes()
-                )
+            new RqWithHeader(
+                new RqLive(
+                    new ByteArrayInputStream(
+                        body.getBytes()
+                    )
+                ),
+                "Content-Length",
+                String.valueOf(body.getBytes().length)
             )
         );
         MatcherAssert.assertThat(

--- a/src/test/java/org/takes/rq/RqLengthAwareTest.java
+++ b/src/test/java/org/takes/rq/RqLengthAwareTest.java
@@ -94,7 +94,8 @@ public final class RqLengthAwareTest {
             new RqFake(
                 Arrays.asList(
                     "GET /test1",
-                    "Host: b.example.com"
+                    "Host: b.example.com",
+                    contentLengthHeader(data.getBytes().length)
                 ),
                 data
             )
@@ -121,7 +122,8 @@ public final class RqLengthAwareTest {
                 Arrays.asList(
                     "GET /test2",
                     "Host: c.example.com",
-                    "Content-type: text/csv"
+                    "Content-type: text/csv",
+                    contentLengthHeader(data.getBytes().length)
                 ),
                 data
             )
@@ -147,7 +149,8 @@ public final class RqLengthAwareTest {
             new RqFake(
                 Arrays.asList(
                     "GET /test3",
-                    "Host: d.example.com"
+                    "Host: d.example.com",
+                    contentLengthHeader(data.getBytes().length)
                 ),
                 data
             )
@@ -165,5 +168,14 @@ public final class RqLengthAwareTest {
             stream.available(),
             Matchers.equalTo(data.length() - len)
         );
+    }
+
+    /**
+     * Format Content-Length header.
+     * @param length Body length
+     * @return Content-Length header
+     */
+    private static String contentLengthHeader(final long length) {
+        return String.format("Content-Length: %d", length);
     }
 }

--- a/src/test/java/org/takes/rq/RqWithBodyTest.java
+++ b/src/test/java/org/takes/rq/RqWithBodyTest.java
@@ -43,7 +43,16 @@ public final class RqWithBodyTest {
     public void returnsBody() throws Exception {
         final String body = "body";
         MatcherAssert.assertThat(
-            new RqPrint(new RqWithBody(new RqFake(), body)).printBody(),
+            new RqPrint(
+                new RqWithBody(
+                    new RqWithHeader(
+                        new RqFake(),
+                        "Content-Length",
+                        String.valueOf(body.getBytes().length)
+                    ),
+                    body
+                )
+            ).printBody(),
             Matchers.equalTo(body)
         );
     }


### PR DESCRIPTION
Fix for ticket #463. Include Content-Length header from test requests.