### PR TITLE
Refactor HmRsHeader matcher to accept any header and value matchers

### DIFF
--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -24,55 +24,58 @@
 package org.takes.facets.hamcrest;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.List;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.takes.Response;
-import org.takes.misc.EntryImpl;
 
 /**
  * Response Header Matcher.
  *
  * <p>This "matcher" tests given response header.
- * <p>The header name(s) should be provided in lowercase.
  * <p>The class is immutable and thread-safe.
  *
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
+ * @author I. Sokolov (happy.neko@gmail.com)
  * @version $Id$
  * @since 0.23.3
  */
 public final class HmRsHeader extends TypeSafeMatcher<Response> {
 
     /**
-     * Expected response header matcher.
+     * Header matcher.
      */
-    private final transient HeaderMatcher matcher;
+    private final transient Matcher<String> headerm;
+
+    /**
+     * Value matcher.
+     */
+    private final transient Matcher<Iterable<String>> valuem;
 
     /**
      * Ctor.
-     * @param mtchr Matcher
+     * @param hdrm Header matcher
+     * @param vlm Value matcher
      */
-    public HmRsHeader(
-        final Matcher<? extends Map.Entry<String, String>> mtchr) {
+    public HmRsHeader(final Matcher<String> hdrm,
+        final Matcher<Iterable<String>> vlm) {
         super();
-        this.matcher = new EntryHeaderMatcher(mtchr);
+        this.headerm = hdrm;
+        this.valuem = vlm;
     }
 
     /**
      * Ctor.
      * @param header Header name
-     * @param mtchr Matcher
+     * @param vlm Value matcher
      */
     public HmRsHeader(final String header,
-        final Matcher<? extends Iterable<String>> mtchr) {
-        super();
-        this.matcher = new IterableHeaderMatcher(header, mtchr);
+        final Matcher<Iterable<String>> vlm) {
+        this(Matchers.equalToIgnoringCase(header), vlm);
     }
 
     /**
@@ -81,12 +84,18 @@ public final class HmRsHeader extends TypeSafeMatcher<Response> {
      * @param value Header value
      */
     public HmRsHeader(final String header, final String value) {
-        this(new EntryMatcher<String, String>(header, value));
+        this(
+            Matchers.equalToIgnoringCase(header),
+            Matchers.hasItems(value)
+        );
     }
 
     @Override
     public void describeTo(final Description description) {
-        this.matcher.describeTo(description);
+        description.appendText("headers: ")
+            .appendDescriptionOf(this.headerm)
+            .appendText(" -> values: ")
+            .appendDescriptionOf(this.valuem);
     }
 
     @Override
@@ -96,7 +105,14 @@ public final class HmRsHeader extends TypeSafeMatcher<Response> {
             if (headers.hasNext()) {
                 headers.next();
             }
-            return this.matcher.matches(headers);
+            final List<String> values = new ArrayList<String>(0);
+            while (headers.hasNext()) {
+                final String[] parts = HmRsHeader.split(headers.next());
+                if (this.headerm.matches(parts[0].trim())) {
+                    values.add(parts[1].trim());
+                }
+            }
+            return this.valuem.matches(values);
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }
@@ -110,117 +126,5 @@ public final class HmRsHeader extends TypeSafeMatcher<Response> {
      */
     private static String[] split(final String header) {
         return header.split(":", 2);
-    }
-
-    /**
-     * Header matcher.
-     */
-    private interface HeaderMatcher {
-
-        /**
-         * Performs the matching.
-         *
-         * @param headers Headers to check
-         * @return True if positive match
-         */
-        boolean matches(final Iterator<String> headers);
-
-        /**
-         * Generates a description of the matcher.
-         *
-         * @param description The description to be built or appended to
-         */
-        void describeTo(final Description description);
-    }
-
-    /**
-     * Header matcher for {@code Matcher<? extends Map.Entry<String, String>>}.
-     */
-    private static class EntryHeaderMatcher implements HeaderMatcher {
-
-        /**
-         * Matcher.
-         */
-        private final transient
-            Matcher<? extends Map.Entry<String, String>> matcher;
-
-        /**
-         * Ctor.
-         * @param mtchr Matcher
-         */
-        public EntryHeaderMatcher(
-            final Matcher<? extends Entry<String, String>> mtchr) {
-            this.matcher = mtchr;
-        }
-
-        @Override
-        @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-        public boolean matches(final Iterator<String> headers) {
-            boolean result = false;
-            while (headers.hasNext()) {
-                final String[] parts = HmRsHeader.split(headers.next());
-                final Map.Entry<String, String> entry =
-                    new EntryImpl<String, String>(
-                        parts[0].trim().toLowerCase(Locale.ENGLISH),
-                        parts[1].trim()
-                    );
-                if (this.matcher.matches(entry)) {
-                    result = true;
-                    break;
-                }
-            }
-            return result;
-        }
-
-        @Override
-        public void describeTo(final Description description) {
-            this.matcher.describeTo(description);
-        }
-    }
-
-    /**
-     * Header matcher for {@code Matcher<? extends Iterable<String>>}.
-     */
-    private static class IterableHeaderMatcher implements HeaderMatcher {
-
-        /**
-         * Header.
-         */
-        private final transient String header;
-
-        /**
-         * Matcher.
-         */
-        private final transient Matcher<? extends Iterable<String>> matcher;
-
-        /**
-         * Ctor.
-         * @param hdr Header
-         * @param mtchr Matcher
-         */
-        public IterableHeaderMatcher(final String hdr,
-            final Matcher<? extends Iterable<String>> mtchr) {
-            this.header = hdr;
-            this.matcher = mtchr;
-        }
-
-        @Override
-        public boolean matches(final Iterator<String> headers) {
-            final Collection<String> hdrs = new LinkedList<String>();
-            while (headers.hasNext()) {
-                final String[] parts = HmRsHeader.split(headers.next());
-                final String lower = parts[0].trim()
-                    .toLowerCase(Locale.ENGLISH);
-                if (lower.equals(this.header)) {
-                    hdrs.add(parts[1].trim());
-                }
-            }
-            return this.matcher.matches(hdrs);
-        }
-
-        @Override
-        public void describeTo(final Description description) {
-            this.matcher.describeTo(description);
-        }
     }
 }

--- a/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
@@ -27,7 +27,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.rs.RsEmpty;
-import org.takes.rs.RsWithBody;
 import org.takes.rs.RsWithHeader;
 import org.takes.rs.RsWithHeaders;
 
@@ -40,52 +39,14 @@ import org.takes.rs.RsWithHeaders;
 public final class HmRsHeaderTest {
 
     /**
-     * HmRsHeader can test header available.
-     * @throws Exception If some problem inside
-     */
-    @Test
-    public void testsHeaderAvailable() throws Exception {
-        MatcherAssert.assertThat(
-            new RsWithHeader(
-                new RsWithBody("<html>Hello</html>"),
-                "content-encoding: gzip"
-            ),
-            new HmRsHeader(
-                new EntryMatcher<String, String>(
-                    "content-encoding", "gzip"
-                )
-            )
-        );
-    }
-
-    /**
-     * HmRsHeader can test header not available.
-     * @throws Exception If some problem inside
-     */
-    @Test
-    public void testsHeaderNotAvailable() throws Exception {
-        MatcherAssert.assertThat(
-            new RsWithBody("<html></html>"),
-            new HmRsHeader(
-                Matchers.not(
-                    new EntryMatcher<String, String>(
-                        "cache-control",
-                        "no-cache, no-store"
-                    )
-                )
-            )
-        );
-    }
-
-    /**
      * HmRsHeader can test header name and value available.
      * @throws Exception If some problem inside
      */
     @Test
     public void testsHeaderNameAndValueAvailable() throws Exception {
         MatcherAssert.assertThat(
-            new RsWithHeader("header1: value1"),
-            new HmRsHeader("header1", "value1")
+            new RsWithHeader("heAdEr1: value1"),
+            new HmRsHeader("HEAder1", "value1")
         );
     }
 
@@ -110,9 +71,9 @@ public final class HmRsHeaderTest {
         MatcherAssert.assertThat(
             new RsWithHeaders(
                 new RsEmpty(),
-                "header3: value31", "header3: value32"
+                "header3: value31", "HEADER3: value32"
             ),
-            new HmRsHeader("header3", Matchers.<String>iterableWithSize(2))
+            new HmRsHeader("Header3", Matchers.<String>iterableWithSize(2))
         );
     }
 

--- a/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsHeaderTest.java
@@ -28,6 +28,7 @@ import org.hamcrest.Matchers;
 import org.hamcrest.StringDescription;
 import org.junit.Test;
 import org.takes.rs.RsEmpty;
+import org.takes.rs.RsWithBody;
 import org.takes.rs.RsWithHeader;
 import org.takes.rs.RsWithHeaders;
 


### PR DESCRIPTION
Fix for #480. 

* Refactor `HmRsHeader` matcher to accept any header and value matchers.
* Make `IsEqualIgnoringCase` default header matcher when selecting headers by `String`.