### PR TITLE
#453 - Connection reset if request body wasn't read from POST

### DIFF
--- a/src/main/java/org/takes/tk/TkReadAlways.java
+++ b/src/main/java/org/takes/tk/TkReadAlways.java
@@ -37,7 +37,7 @@ import org.takes.Take;
  *
  * @author Dan Baleanu (dan.baleanu@gmail.com)
  * @version $Id$
- * @since 1.0
+ * @since 0.30
  */
 @ToString(of = {"origin"})
 @EqualsAndHashCode(of = {"origin"})

--- a/src/main/java/org/takes/tk/TkReadAlways.java
+++ b/src/main/java/org/takes/tk/TkReadAlways.java
@@ -1,0 +1,69 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.tk;
+
+import java.io.IOException;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+
+/**
+ * A Take decorator which reads and ignores the request body.
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Dan Baleanu (dan.baleanu@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+@ToString(of = {"origin"})
+@EqualsAndHashCode(of = {"origin"})
+public final class TkReadAlways implements Take {
+
+    /**
+     * Original take.
+     */
+    private final transient Take origin;
+
+    /**
+     * Ctor.
+     * @param take Original take
+     */
+    public TkReadAlways(final Take take) {
+        this.origin = take;
+    }
+
+    @Override
+    public Response act(final Request req) throws IOException {
+        final Response res = this.origin.act(req);
+        for (int count = req.body().available(); count > 0;
+                count = req.body().available()) {
+            req.body().skip(count);
+        }
+        return res;
+    }
+
+}

--- a/src/test/java/org/takes/tk/TkReadAlwaysTest.java
+++ b/src/test/java/org/takes/tk/TkReadAlwaysTest.java
@@ -23,7 +23,6 @@
  */
 package org.takes.tk;
 
-import com.google.common.base.Joiner;
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
@@ -41,7 +40,7 @@ import org.takes.rs.RsText;
  * Test case for {@link TkReadAlways}.
  * @author Dan Baleanu (dan.baleanu@gmail.com)
  * @version $Id$
- * @since 1.0
+ * @since 0.30
  */
 public final class TkReadAlwaysTest {
 
@@ -51,10 +50,11 @@ public final class TkReadAlwaysTest {
      */
     @Test
     public void requestBodyIsIgnored() throws Exception {
+        final String expected = "response ok";
         final Take take = new Take() {
             @Override
             public Response act(final Request req) throws IOException {
-                return new RsText("response ok");
+                return new RsText(expected);
             }
         };
         new FtRemote(new TkReadAlways(take)).exec(
@@ -71,11 +71,7 @@ public final class TkReadAlwaysTest {
                         .fetch()
                         .as(RestResponse.class)
                         .assertStatus(HttpURLConnection.HTTP_OK)
-                        .assertBody(
-                            Matchers.equalTo(
-                                Joiner.on(" ").join("response", "ok")
-                            )
-                    );
+                        .assertBody(Matchers.equalTo(expected));
                 }
             }
         );

--- a/src/test/java/org/takes/tk/TkReadAlwaysTest.java
+++ b/src/test/java/org/takes/tk/TkReadAlwaysTest.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.tk;
+
+import com.google.common.base.Joiner;
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.http.FtRemote;
+import org.takes.rs.RsText;
+
+/**
+ * Test case for {@link TkReadAlways}.
+ * @author Dan Baleanu (dan.baleanu@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public final class TkReadAlwaysTest {
+
+    /**
+     * Send a request with body which is ignored.
+     * @throws Exception If there are problems
+     */
+    @Test
+    public void requestBodyIsIgnored() throws Exception {
+        final Take take = new Take() {
+            @Override
+            public Response act(final Request req) throws IOException {
+                return new RsText("response ok");
+            }
+        };
+        new FtRemote(new TkReadAlways(take)).exec(
+            new FtRemote.Script() {
+                @Override
+                public void exec(final URI home) throws IOException {
+                    new JdkRequest(home)
+                        .method("POST").header(
+                            "Content-Type", "application/x-www-form-urlencoded"
+                        ).body()
+                        .formParam("name", "Jeff Warraby")
+                        .formParam("age", "4")
+                        .back()
+                        .fetch()
+                        .as(RestResponse.class)
+                        .assertStatus(HttpURLConnection.HTTP_OK)
+                        .assertBody(
+                            Matchers.equalTo(
+                                Joiner.on(" ").join("response", "ok")
+                            )
+                    );
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
Fix for issue #453 
- Implemented TkReadAlways Take decorator as requested. After the origin take creates the response available body() content from request is skipped using InputStream.skip() method.
- Added TkReadAlwaysTest test for the implemented decorator.
