### PR TITLE
#463: add Content-Length header in RqFormTest

### DIFF
--- a/src/test/java/org/takes/rq/RqFormTest.java
+++ b/src/test/java/org/takes/rq/RqFormTest.java
@@ -38,6 +38,11 @@ import org.junit.Test;
 public final class RqFormTest {
 
     /**
+     * Content-Length header template.
+     */
+    private static final String HEADER = "Content-Length: %d";
+
+    /**
      * RqForm can parse body.
      * @throws IOException If some problem inside
      */
@@ -51,7 +56,7 @@ public final class RqFormTest {
                         "GET /h?a=3",
                         "Host: www.example.com",
                         String.format(
-                            "Content-Length: %d",
+                            HEADER,
                             body.getBytes().length
                         )
                     ),
@@ -103,12 +108,16 @@ public final class RqFormTest {
         final String value = "value";
         final String avalue = "a&b";
         final String aavalue = "againanothervalue";
+        final String body = "key=value&key=a%26b&anotherkey=againanothervalue";
         final RqForm req = new RqForm.Fake(
             new RqFake(
                 Arrays.asList(
                     "GET /form",
                     "Host: www.example5.com",
-                    "Content-Length: 49"
+                    String.format(
+                        HEADER,
+                        body.length()
+                    )
                 ),
                 ""
             ),

--- a/src/test/java/org/takes/rq/RqFormTest.java
+++ b/src/test/java/org/takes/rq/RqFormTest.java
@@ -23,6 +23,8 @@
  */
 package org.takes.rq;
 
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
 import java.io.IOException;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
@@ -108,7 +110,7 @@ public final class RqFormTest {
         final String value = "value";
         final String avalue = "a&b";
         final String aavalue = "againanothervalue";
-        final String body = "key=value&key=a%26b&anotherkey=againanothervalue";
+        final Escaper escaper = UrlEscapers.urlFormParameterEscaper();
         final RqForm req = new RqForm.Fake(
             new RqFake(
                 Arrays.asList(
@@ -116,7 +118,12 @@ public final class RqFormTest {
                     "Host: www.example5.com",
                     String.format(
                         HEADER,
-                        body.length()
+                        escaper.escape(key).length() + 1
+                            + escaper.escape(value).length() + 1
+                            + escaper.escape(key).length() + 1
+                            + escaper.escape(avalue).length() + 1
+                            + escaper.escape(akey).length() + 1
+                            + escaper.escape(aavalue).length()
                     )
                 ),
                 ""

--- a/src/test/java/org/takes/rq/RqFormTest.java
+++ b/src/test/java/org/takes/rq/RqFormTest.java
@@ -104,7 +104,14 @@ public final class RqFormTest {
         final String avalue = "a&b";
         final String aavalue = "againanothervalue";
         final RqForm req = new RqForm.Fake(
-            new RqFake(),
+            new RqFake(
+                Arrays.asList(
+                    "GET /form",
+                    "Host: www.example5.com",
+                    "Content-Length: 49"
+                ),
+                ""
+            ),
             key, value,
             key, avalue,
             akey, aavalue


### PR DESCRIPTION
Fix for #463.
Add Content-Length header to `RqFormTest.createsFormRequestWithParams()`.