### PR TITLE
Fix for #433 - TkFallback crashes when there is no fallback.

### DIFF
--- a/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
+++ b/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
@@ -104,4 +104,23 @@ public final class TkFallbackTest {
         );
     }
 
+    /**
+     * TkFallback can fall back.
+     * @throws IOException If some problem happens
+     */
+    @Test
+    public void fallsBackWithProperMessage() throws IOException {
+        try {
+            new TkFallback(
+                new TkFailure(),
+                new FbChain()
+              ).act(new RqFake());
+            MatcherAssert.assertThat("Must throw exception", false);
+        } catch (final IOException exception) {
+            MatcherAssert.assertThat(
+                exception.getMessage(),
+                Matchers.startsWith("There is no fallback available.")
+            );
+        }
+    }
 }

--- a/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
+++ b/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
@@ -105,7 +105,7 @@ public final class TkFallbackTest {
     }
 
     /**
-     * TkFallback can fall back.
+     * TkFallback can throw an IOException when no fallback is available.
      * @throws IOException If some problem happens
      */
     @Test
@@ -114,7 +114,7 @@ public final class TkFallbackTest {
             new TkFallback(
                 new TkFailure(),
                 new FbChain()
-              ).act(new RqFake());
+            ).act(new RqFake());
             MatcherAssert.assertThat("Must throw exception", false);
         } catch (final IOException exception) {
             MatcherAssert.assertThat(


### PR DESCRIPTION
Fix for #433:
- Updated TkFallback to check the Opt<Response> from the given fallback,
  and if empty throw a message with a proper message.
- Updated TkFallbackTest to run the snippet and check if the exception has
  the proper message.