### PR TITLE
Fix #354 - Incorrect setting the expiration date for a cookies

### DIFF
--- a/src/main/java/org/takes/facets/auth/PsCookie.java
+++ b/src/main/java/org/takes/facets/auth/PsCookie.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
@@ -116,6 +117,7 @@ public final class PsCookie implements Pass {
         } else {
             text = new String(this.codec.encode(idt));
         }
+        final long millis = System.currentTimeMillis();
         return new RsWithCookie(
             res, this.cookie, text,
             "Path=/",
@@ -124,8 +126,8 @@ public final class PsCookie implements Pass {
                 Locale.ENGLISH,
                 "Expires=%1$ta, %1$td %1$tb %1$tY %1$tT GMT",
                 new Date(
-                    System.currentTimeMillis()
-                        + TimeUnit.DAYS.toMillis(this.age)
+                    millis + TimeUnit.DAYS.toMillis(this.age)
+                        - TimeZone.getDefault().getOffset(millis)
                 )
             )
         );

--- a/src/main/java/org/takes/facets/auth/PsCookie.java
+++ b/src/main/java/org/takes/facets/auth/PsCookie.java
@@ -26,8 +26,6 @@ package org.takes.facets.auth;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.Locale;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
@@ -117,19 +115,16 @@ public final class PsCookie implements Pass {
         } else {
             text = new String(this.codec.encode(idt));
         }
-        final long millis = System.currentTimeMillis();
         return new RsWithCookie(
             res, this.cookie, text,
-            "Path=/",
-            "HttpOnly",
-            String.format(
-                Locale.ENGLISH,
-                "Expires=%1$ta, %1$td %1$tb %1$tY %1$tT GMT",
+            new Opt.Single<Date>(
                 new Date(
-                    millis + TimeUnit.DAYS.toMillis(this.age)
-                        - TimeZone.getDefault().getOffset(millis)
+                    System.currentTimeMillis()
+                        + TimeUnit.DAYS.toMillis(this.age)
                 )
-            )
+            ),
+            "Path=/",
+            "HttpOnly"
         );
     }
 }

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -27,13 +27,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Opt;
 import org.takes.misc.Sprintf;
 import org.takes.rs.RsWithCookie;
 import org.takes.rs.RsWrap;
@@ -166,7 +165,6 @@ public final class RsFlash extends RsWrap {
      */
     private static Response make(final String msg, final Level level,
         final String cookie) throws UnsupportedEncodingException {
-        final long millis = System.currentTimeMillis();
         return new RsWithCookie(
             cookie,
             new Sprintf(
@@ -174,15 +172,12 @@ public final class RsFlash extends RsWrap {
                 URLEncoder.encode(msg, Charset.defaultCharset().name()),
                 level.getName()
             ),
-            "Path=/",
-            String.format(
-                Locale.ENGLISH,
-                "Expires=%1$ta, %1$td %1$tb %1$tY %1$tT GMT",
+            new Opt.Single<Date>(
                 new Date(
-                    millis + TimeUnit.HOURS.toMillis(1L)
-                        - TimeZone.getDefault().getOffset(millis)
+                    System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1L)
                 )
-            )
+            ),
+            "Path=/"
         );
     }
 

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -28,6 +28,7 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import lombok.EqualsAndHashCode;
@@ -165,6 +166,7 @@ public final class RsFlash extends RsWrap {
      */
     private static Response make(final String msg, final Level level,
         final String cookie) throws UnsupportedEncodingException {
+        final long millis = System.currentTimeMillis();
         return new RsWithCookie(
             cookie,
             new Sprintf(
@@ -177,8 +179,8 @@ public final class RsFlash extends RsWrap {
                 Locale.ENGLISH,
                 "Expires=%1$ta, %1$td %1$tb %1$tY %1$tT GMT",
                 new Date(
-                    System.currentTimeMillis()
-                        + TimeUnit.HOURS.toMillis(1L)
+                    millis + TimeUnit.HOURS.toMillis(1L)
+                        - TimeZone.getDefault().getOffset(millis)
                 )
             )
         );

--- a/src/main/java/org/takes/facets/ret/RsReturn.java
+++ b/src/main/java/org/takes/facets/ret/RsReturn.java
@@ -28,6 +28,7 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import lombok.ToString;
 import org.takes.Response;
@@ -75,6 +76,9 @@ public final class RsReturn extends RsWrap {
                     new Date(
                         System.currentTimeMillis()
                             + TimeUnit.HOURS.toMillis(1L)
+                            - TimeZone.getDefault().getOffset(
+                                System.currentTimeMillis()
+                            )
                     )
                 )
             )

--- a/src/main/java/org/takes/facets/ret/RsReturn.java
+++ b/src/main/java/org/takes/facets/ret/RsReturn.java
@@ -27,11 +27,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Opt;
 import org.takes.rs.RsWithCookie;
 import org.takes.rs.RsWrap;
 
@@ -69,18 +68,12 @@ public final class RsReturn extends RsWrap {
                 res,
                 cookie,
                 URLEncoder.encode(loc, Charset.defaultCharset().name()),
-                "Path=/",
-                String.format(
-                    Locale.ENGLISH,
-                    "Expires=%1$ta, %1$td %1$tb %1$tY %1$tT GMT",
+                new Opt.Single<Date>(
                     new Date(
-                        System.currentTimeMillis()
-                            + TimeUnit.HOURS.toMillis(1L)
-                            - TimeZone.getDefault().getOffset(
-                                System.currentTimeMillis()
-                            )
+                        System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1L)
                     )
-                )
+                ),
+                "Path=/"
             )
         );
     }

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -25,11 +25,16 @@ package org.takes.rs;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Opt;
 
 /**
  * Response decorator, with an additional cookie.
@@ -90,6 +95,18 @@ public final class RsWithCookie extends RsWrap {
     );
 
     /**
+     * Pattern for the expires cookie attribute.
+     */
+    private static final SimpleDateFormat EXPIRES_FORMAT = new SimpleDateFormat(
+        "'Expires='EEE, dd MMM yyyy HH:mm:ss 'GMT'",
+        Locale.ENGLISH
+    );
+
+    static {
+        RsWithCookie.EXPIRES_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
+    }
+
+    /**
      * Ctor.
      * @param name Cookie name
      * @param value Value of it
@@ -97,7 +114,20 @@ public final class RsWithCookie extends RsWrap {
      */
     public RsWithCookie(final CharSequence name, final CharSequence value,
         final CharSequence... attrs) {
-        this(new RsEmpty(), name, value, attrs);
+        this(name, value, new Opt.Empty<Date>(), attrs);
+    }
+
+    /**
+     * Ctor.
+     * @param name Cookie name
+     * @param value Value of it
+     * @param expires Expires Cookie attribute value
+     * @param attrs Optional attributes, for example "Path=/"
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public RsWithCookie(final CharSequence name, final CharSequence value,
+        final Opt<Date> expires, final CharSequence... attrs) {
+        this(new RsEmpty(), name, value, expires, attrs);
     }
 
     /**
@@ -111,6 +141,22 @@ public final class RsWithCookie extends RsWrap {
     @SuppressWarnings("PMD.CallSuperInConstructor")
     public RsWithCookie(final Response res, final CharSequence name,
         final CharSequence value, final CharSequence... attrs) {
+        this(res, name, value, new Opt.Empty<Date>(), attrs);
+    }
+
+    /**
+     * Ctor.
+     * @param res Original response
+     * @param name Cookie name
+     * @param value Value of it
+     * @param expires Expires Cookie attribute value
+     * @param attrs Optional attributes, for example "Path=/"
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    @SuppressWarnings("PMD.CallSuperInConstructor")
+    public RsWithCookie(final Response res, final CharSequence name,
+        final CharSequence value, final Opt<Date> expires,
+        final CharSequence... attrs) {
         super(
             new Response() {
                 @Override
@@ -120,7 +166,7 @@ public final class RsWithCookie extends RsWrap {
                         RsWithCookie.SET_COOKIE,
                         RsWithCookie.make(
                             RsWithCookie.previousValue(res),
-                            name, value, attrs
+                            name, value, expires, attrs
                         )
                     ).head();
                 }
@@ -139,12 +185,14 @@ public final class RsWithCookie extends RsWrap {
      * @param previous Previous Cookie value.
      * @param name Cookie name
      * @param value Value of it
+     * @param expires Expires Cookie attribute value
      * @param attrs Optional attributes, for example "Path=/"
      * @return Text
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     private static String make(final String previous, final CharSequence name,
-        final CharSequence value, final CharSequence... attrs) {
+        final CharSequence value, final Opt<Date> expires,
+        final CharSequence... attrs) {
         final StringBuilder text = new StringBuilder();
         if (!previous.isEmpty()) {
             text.append(String.format("%s,", previous));
@@ -152,6 +200,10 @@ public final class RsWithCookie extends RsWrap {
         text.append(String.format("%s=%s;", name, value));
         for (final CharSequence attr : attrs) {
             text.append(attr).append(';');
+        }
+        if (expires.has()) {
+            text.append(RsWithCookie.EXPIRES_FORMAT.format(expires.get()))
+                .append(';');
         }
         return text.toString();
     }

--- a/src/main/java/org/takes/rs/RsWithCookie.java
+++ b/src/main/java/org/takes/rs/RsWithCookie.java
@@ -95,18 +95,6 @@ public final class RsWithCookie extends RsWrap {
     );
 
     /**
-     * Pattern for the expires cookie attribute.
-     */
-    private static final SimpleDateFormat EXPIRES_FORMAT = new SimpleDateFormat(
-        "'Expires='EEE, dd MMM yyyy HH:mm:ss 'GMT'",
-        Locale.ENGLISH
-    );
-
-    static {
-        RsWithCookie.EXPIRES_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
-    }
-
-    /**
      * Ctor.
      * @param name Cookie name
      * @param value Value of it
@@ -202,8 +190,12 @@ public final class RsWithCookie extends RsWrap {
             text.append(attr).append(';');
         }
         if (expires.has()) {
-            text.append(RsWithCookie.EXPIRES_FORMAT.format(expires.get()))
-                .append(';');
+            final SimpleDateFormat format = new SimpleDateFormat(
+                "'Expires='EEE, dd MMM yyyy HH:mm:ss z",
+                Locale.ENGLISH
+            );
+            format.setTimeZone(TimeZone.getTimeZone("GMT"));
+            text.append(format.format(expires.get())).append(';');
         }
         return text.toString();
     }

--- a/src/test/java/org/takes/facets/auth/PsCookieTest.java
+++ b/src/test/java/org/takes/facets/auth/PsCookieTest.java
@@ -45,11 +45,6 @@ import org.takes.rs.RsPrint;
 public final class PsCookieTest {
 
     /**
-     * Identity instance used in tests.
-     */
-    private static Identity identity = new Identity.Simple("urn:test:99");
-
-    /**
      * PsCookie can add a cookie.
      * @throws IOException If some problem inside
      */
@@ -59,7 +54,7 @@ public final class PsCookieTest {
             new RsPrint(
                 new PsCookie(
                     new CcPlain(), "foo", 1L
-                ).exit(new RsEmpty(), PsCookieTest.identity)
+                ).exit(new RsEmpty(), new Identity.Simple("urn:test:99"))
             ).print(),
             Matchers.containsString(
                 "Set-Cookie: foo=urn%3Atest%3A99;Path=/;HttpOnly;"
@@ -72,7 +67,7 @@ public final class PsCookieTest {
      * @throws IOException If there are some problems inside
      */
     @Test
-    public void createCookieWithExpiresInGMT() throws IOException {
+    public void createsCookieWithExpiresInGMT() throws IOException {
         final long age = 1L;
         final SimpleDateFormat format = new SimpleDateFormat(
             "'Expires='EEE, dd MMM yyyy HH:mm:ss z;",
@@ -83,7 +78,7 @@ public final class PsCookieTest {
             new RsPrint(
                 new PsCookie(
                     new CcPlain(), "bar", age
-                ).exit(new RsEmpty(), PsCookieTest.identity)
+                ).exit(new RsEmpty(), Identity.ANONYMOUS)
             ).print(),
             Matchers.containsString(
                 format.format(

--- a/src/test/java/org/takes/facets/auth/PsCookieTest.java
+++ b/src/test/java/org/takes/facets/auth/PsCookieTest.java
@@ -68,14 +68,14 @@ public final class PsCookieTest {
     }
 
     /**
-     * The expiration date for a cookie must be a GMT time.
+     * PsCookie can create cookie with expires attribute in GMT.
      * @throws IOException If there are some problems inside
      */
     @Test
-    public void cookieExpiresInGMT() throws IOException {
+    public void createCookieWithExpiresInGMT() throws IOException {
         final long age = 1L;
         final SimpleDateFormat format = new SimpleDateFormat(
-            "EEE, dd MMM yyyy HH:mm:ss z",
+            "'Expires='EEE, dd MMM yyyy HH:mm:ss z;",
             Locale.ENGLISH
         );
         format.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -86,12 +86,9 @@ public final class PsCookieTest {
                 ).exit(new RsEmpty(), PsCookieTest.identity)
             ).print(),
             Matchers.containsString(
-                String.format(
-                    "Expires=%s;",
-                    format.format(
-                        new Date(System.currentTimeMillis()
-                            + TimeUnit.DAYS.toMillis(age)
-                        )
+                format.format(
+                    new Date(System.currentTimeMillis()
+                        + TimeUnit.DAYS.toMillis(age)
                     )
                 )
             )

--- a/src/test/java/org/takes/facets/flash/RsFlashTest.java
+++ b/src/test/java/org/takes/facets/flash/RsFlashTest.java
@@ -74,9 +74,9 @@ public final class RsFlashTest {
      * @throws IOException If there are some problems inside
      */
     @Test
-    public void createCookieWithExpiresInGMT() throws IOException {
+    public void createsCookieWithExpiresInGMT() throws IOException {
         final SimpleDateFormat format = new SimpleDateFormat(
-            "EEE, dd MMM yyyy HH:mm:ss z",
+            "'Expires='EEE, dd MMM yyyy HH:mm:ss z;",
             Locale.ENGLISH
         );
         format.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -85,12 +85,9 @@ public final class RsFlashTest {
                 new RsFlash("they are watching you")
             ).print(),
             Matchers.containsString(
-                String.format(
-                    "Expires=%s;",
-                    format.format(
-                        new Date(System.currentTimeMillis()
-                            + TimeUnit.HOURS.toMillis(1L)
-                        )
+                format.format(
+                    new Date(System.currentTimeMillis()
+                        + TimeUnit.HOURS.toMillis(1L)
                     )
                 )
             )

--- a/src/test/java/org/takes/facets/flash/RsFlashTest.java
+++ b/src/test/java/org/takes/facets/flash/RsFlashTest.java
@@ -26,6 +26,11 @@ package org.takes.facets.flash;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -59,6 +64,34 @@ public final class RsFlashTest {
                         Charset.defaultCharset().name()
                     ),
                     Level.INFO.getName()
+                )
+            )
+        );
+    }
+
+    /**
+     * The expiration date for a cookie must be a GMT time.
+     * @throws IOException If there are some problems inside
+     */
+    @Test
+    public void cookieExpiresInGMT() throws IOException {
+        final SimpleDateFormat format = new SimpleDateFormat(
+            "EEE, dd MMM yyyy HH:mm:ss z",
+            Locale.ENGLISH
+        );
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsFlash("they are watching you")
+            ).print(),
+            Matchers.containsString(
+                String.format(
+                    "Expires=%s;",
+                    format.format(
+                        new Date(System.currentTimeMillis()
+                            + TimeUnit.HOURS.toMillis(1L)
+                        )
+                    )
                 )
             )
         );

--- a/src/test/java/org/takes/facets/flash/RsFlashTest.java
+++ b/src/test/java/org/takes/facets/flash/RsFlashTest.java
@@ -70,11 +70,11 @@ public final class RsFlashTest {
     }
 
     /**
-     * The expiration date for a cookie must be a GMT time.
+     * RsFlash can create cookie with expires attribute in GMT.
      * @throws IOException If there are some problems inside
      */
     @Test
-    public void cookieExpiresInGMT() throws IOException {
+    public void createCookieWithExpiresInGMT() throws IOException {
         final SimpleDateFormat format = new SimpleDateFormat(
             "EEE, dd MMM yyyy HH:mm:ss z",
             Locale.ENGLISH

--- a/src/test/java/org/takes/facets/ret/RsReturnTest.java
+++ b/src/test/java/org/takes/facets/ret/RsReturnTest.java
@@ -69,11 +69,11 @@ public final class RsReturnTest {
     }
 
     /**
-     * The expiration date for a cookie must be a GMT time.
+     * RsReturn can create cookie with expires attribute in GMT..
      * @throws IOException If there are some problems inside
      */
     @Test
-    public void cookieExpiresInGMT() throws IOException {
+    public void createCookieWithExpiresInGMT() throws IOException {
         final SimpleDateFormat format = new SimpleDateFormat(
             "EEE, dd MMM yyyy HH:mm:ss z",
             Locale.ENGLISH

--- a/src/test/java/org/takes/facets/ret/RsReturnTest.java
+++ b/src/test/java/org/takes/facets/ret/RsReturnTest.java
@@ -73,9 +73,9 @@ public final class RsReturnTest {
      * @throws IOException If there are some problems inside
      */
     @Test
-    public void createCookieWithExpiresInGMT() throws IOException {
+    public void createsCookieWithExpiresInGMT() throws IOException {
         final SimpleDateFormat format = new SimpleDateFormat(
-            "EEE, dd MMM yyyy HH:mm:ss z",
+            "'Expires='EEE, dd MMM yyyy HH:mm:ss z;",
             Locale.ENGLISH
         );
         format.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -84,12 +84,9 @@ public final class RsReturnTest {
                 new RsReturn(new RsEmpty(), "/return/where")
             ).print(),
             Matchers.containsString(
-                String.format(
-                    "Expires=%s;",
-                    format.format(
-                        new Date(System.currentTimeMillis()
-                            + TimeUnit.HOURS.toMillis(1L)
-                        )
+                format.format(
+                    new Date(System.currentTimeMillis()
+                        + TimeUnit.HOURS.toMillis(1L)
                     )
                 )
             )

--- a/src/test/java/org/takes/facets/ret/RsReturnTest.java
+++ b/src/test/java/org/takes/facets/ret/RsReturnTest.java
@@ -26,6 +26,11 @@ package org.takes.facets.ret;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -57,6 +62,34 @@ public final class RsReturnTest {
                     URLEncoder.encode(
                         destination,
                         Charset.defaultCharset().name()
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * The expiration date for a cookie must be a GMT time.
+     * @throws IOException If there are some problems inside
+     */
+    @Test
+    public void cookieExpiresInGMT() throws IOException {
+        final SimpleDateFormat format = new SimpleDateFormat(
+            "EEE, dd MMM yyyy HH:mm:ss z",
+            Locale.ENGLISH
+        );
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsReturn(new RsEmpty(), "/return/where")
+            ).print(),
+            Matchers.containsString(
+                String.format(
+                    "Expires=%s;",
+                    format.format(
+                        new Date(System.currentTimeMillis()
+                            + TimeUnit.HOURS.toMillis(1L)
+                        )
                     )
                 )
             )


### PR DESCRIPTION
Fix for #354 
- Updated PsCookie, RsFlash and RsReturn classes to substract timezone offset from expire date when creating the cookie;
- Added to PsCookieTest, RsFlashTest and RsReturnTest classes test methods for testing the correct expire value to be in GMT timezone.
