### PR TITLE
#519 - persistent HTTP connection

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -55,6 +55,10 @@ import org.takes.rs.RsWithStatus;
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle IndentationCheck (500 lines)
+ * @todo #519:30min The logic of persistent connection should be moved to
+ *  separate implementation of Back. BkBasic should be refactored as well in
+ *  order to remove connection management (otherwise new Back implementation
+ *  cannot be used as decorator for BkBasic)
  */
 @EqualsAndHashCode(of = "take")
 public final class BkBasic implements Back {
@@ -104,6 +108,11 @@ public final class BkBasic implements Back {
                 }
             }
         } catch (final SocketTimeoutException exc) {
+            // @checkstyle MethodBodyCommentsCheck (4 lines)
+            // This exception is thrown on socket timeout, this is just
+            // indicator that no more request can be handled in this connection.
+            // No need to throw it upper and no need to do anything specific
+            // on this exception.
         } finally {
             input.close();
         }

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -77,15 +77,14 @@ public final class BkBasic implements Back {
         this.take = tks;
     }
 
-//      @todo #519:30min Need to support Keep-Alive header here and take
-//       into account specified timeout and max requests parameters.
-//       See http://tools.ietf.org/id/draft-thomson-hybi-http-timeout-01.html
-//       for details. Also need to remove input.available <= 0 condition
-//       - this is done in order to prevent failure of some tests,
-//       should be replaced with proper Keep-Alive header in tests
+    // @todo #519:30min Need to support Keep-Alive header here and take
+    //  into account specified timeout and max requests parameters.
+    //  See http://tools.ietf.org/id/draft-thomson-hybi-http-timeout-01.html
+    //  for details. Also need to remove input.available <= 0 condition
+    //  - this is done in order to prevent failure of some tests,
+    //  should be replaced with proper Keep-Alive header in tests
     @Override
-    @SuppressWarnings({
-        "PMD.EmptyCatchBlock",
+    @SuppressWarnings({"PMD.EmptyCatchBlock",
         "PMD.AvoidInstantiatingObjectsInLoops"})
     public void accept(final Socket socket) throws IOException {
         socket.setSoTimeout(BkBasic.TIMEOUT);

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -64,11 +64,6 @@ import org.takes.rs.RsWithStatus;
 public final class BkBasic implements Back {
 
     /**
-     * Default socket timeouts (milliseconds).
-     */
-    private static final int TIMEOUT = Tv.THOUSAND;
-
-    /**
      * Take.
      */
     private final transient Take take;
@@ -91,8 +86,10 @@ public final class BkBasic implements Back {
     @SuppressWarnings({"PMD.EmptyCatchBlock",
         "PMD.AvoidInstantiatingObjectsInLoops"})
     public void accept(final Socket socket) throws IOException {
-        socket.setSoTimeout(BkBasic.TIMEOUT);
+        socket.setSoTimeout(Tv.THOUSAND);
         final InputStream input = socket.getInputStream();
+        final OutputStream output = socket.getOutputStream();
+        final BufferedOutputStream buffered = new BufferedOutputStream(output);
         try {
             while (true) {
                 final Request request = new RqLive(input);
@@ -101,7 +98,7 @@ public final class BkBasic implements Back {
                         request,
                         socket
                     ),
-                    new BufferedOutputStream(socket.getOutputStream())
+                    buffered
                 );
                 if (input.available() <= 0) {
                     break;
@@ -115,6 +112,7 @@ public final class BkBasic implements Back {
             // on this exception.
         } finally {
             input.close();
+            output.close();
         }
     }
 

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -78,9 +78,11 @@ public final class BkBasic implements Back {
     }
 
 //      @todo #519:30min Need to support Keep-Alive header here and take
-//       into account specified timeout and max requests.
+//       into account specified timeout and max requests parameters.
 //       See http://tools.ietf.org/id/draft-thomson-hybi-http-timeout-01.html
-//       for details
+//       for details. Also need to remove input.available <= 0 condition
+//       - this is done in order to prevent failure of some tests,
+//       should be replaced with proper Keep-Alive header in tests
     @Override
     @SuppressWarnings({
         "PMD.EmptyCatchBlock",

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -39,10 +39,7 @@ import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
-import org.takes.rq.RqHeaders;
-import org.takes.rq.RqLengthAware;
 import org.takes.rq.RqLive;
-import org.takes.rq.RqPrint;
 import org.takes.rq.RqWithHeaders;
 import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
@@ -93,7 +90,7 @@ public final class BkBasic implements Back {
         final InputStream input = socket.getInputStream();
         try {
             while (true) {
-                final Request request = new RqLengthAware(new RqLive(input));
+                final Request request = new RqLive(input);
                 this.print(
                     BkBasic.addSocketHeaders(
                         request,
@@ -101,16 +98,7 @@ public final class BkBasic implements Back {
                     ),
                     new BufferedOutputStream(socket.getOutputStream())
                 );
-                if (new RqHeaders.Base(request)
-                        .header("Content-Length")
-                        .size() > 0) {
-                    new RqPrint(request).printBody();
-                    input.read();
-                    input.read();
-                    if (input.available() <= 0) {
-                        break;
-                    }
-                } else {
+                if (input.available() <= 0) {
                     break;
                 }
             }

--- a/src/main/java/org/takes/tk/TkText.java
+++ b/src/main/java/org/takes/tk/TkText.java
@@ -66,12 +66,11 @@ public final class TkText extends TkWrap {
         super(
             new Take() {
                 @Override
-                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public Response act(final Request req) {
                     try {
                         new RqPrint(req).printBody();
                     } catch (final IOException exc) {
-                        throw new RuntimeException(exc);
+                        throw new IllegalStateException(exc);
                     }
                     return new RsText(body);
                 }
@@ -87,12 +86,11 @@ public final class TkText extends TkWrap {
         super(
             new Take() {
                 @Override
-                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public Response act(final Request req) {
                     try {
                         new RqPrint(req).printBody();
                     } catch (final IOException exc) {
-                        throw new RuntimeException(exc);
+                        throw new IllegalStateException(exc);
                     }
                     return new RsText(body);
                 }

--- a/src/main/java/org/takes/tk/TkText.java
+++ b/src/main/java/org/takes/tk/TkText.java
@@ -23,6 +23,7 @@
  */
 package org.takes.tk;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import lombok.EqualsAndHashCode;
@@ -30,6 +31,7 @@ import lombok.ToString;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
+import org.takes.rq.RqPrint;
 import org.takes.rs.RsText;
 
 /**
@@ -64,7 +66,13 @@ public final class TkText extends TkWrap {
         super(
             new Take() {
                 @Override
+                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public Response act(final Request req) {
+                    try {
+                        new RqPrint(req).printBody();
+                    } catch (final IOException exc) {
+                        throw new RuntimeException(exc);
+                    }
                     return new RsText(body);
                 }
             }
@@ -79,7 +87,13 @@ public final class TkText extends TkWrap {
         super(
             new Take() {
                 @Override
+                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public Response act(final Request req) {
+                    try {
+                        new RqPrint(req).printBody();
+                    } catch (final IOException exc) {
+                        throw new RuntimeException(exc);
+                    }
                     return new RsText(body);
                 }
             }

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -60,10 +60,6 @@ import org.takes.tk.TkText;
  * @since 0.15.2
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
- * @todo #306:30min At the moment we don't support HTTP
- *  persistent connections. Would be great to implement
- *  this feature. BkBasic.accept should handle more
- *  than one HTTP request in one connection.
  * @todo #516:30min It will be nice to refactor tests with Socket usage and
  *  replace them to real statements. See usage of BkBasicTest.createMockSocket.
  * @todo #516:15min Move header names from BkBasic to public constants.
@@ -189,7 +185,6 @@ public final class BkBasicTest {
      *
      * @throws Exception If some problem inside
      */
-    @Ignore
     @Test
     public void handlesTwoRequestInOneConnection() throws Exception {
         final String text = "Hello Twice!";
@@ -244,7 +239,7 @@ public final class BkBasicTest {
         }
         MatcherAssert.assertThat(
             output.toString(),
-            RegexMatchers.containsPattern(text + ".*?" + text)
+            RegexMatchers.containsPattern("(?s)" + text + ".*?" + text)
         );
     }
 

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -143,12 +143,11 @@ public final class BkBasicTest {
         new BkBasic(
             new Take() {
                 @Override
-                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public Response act(final Request req) {
                     try {
                         new RqPrint(req).printBody();
                     } catch (final IOException exc) {
-                        throw new RuntimeException(exc);
+                        throw new IllegalStateException(exc);
                     }
                     ref.set(req);
                     return new RsEmpty();

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -48,6 +48,7 @@ import org.takes.Take;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
 import org.takes.rq.RqHeaders;
+import org.takes.rq.RqPrint;
 import org.takes.rq.RqSocket;
 import org.takes.rs.RsEmpty;
 import org.takes.tk.TkText;
@@ -142,7 +143,13 @@ public final class BkBasicTest {
         new BkBasic(
             new Take() {
                 @Override
+                @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
                 public Response act(final Request req) {
+                    try {
+                        new RqPrint(req).printBody();
+                    } catch (final IOException exc) {
+                        throw new RuntimeException(exc);
+                    }
                     ref.set(req);
                     return new RsEmpty();
                 }


### PR DESCRIPTION
#519 - added ability to process more than one request in same connection. Existing test `handlesTwoRequestInOneConnection` is now passing. In order to enable this processing I had to add body consumption in TkText (since it doesn't use request body at all preventing from handling next request)