### PR TITLE
#524: Added the ability to specify the charset if needed

### DIFF
--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -52,7 +52,8 @@ import org.takes.Response;
 public final class RsWithBody extends RsWrap {
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithBody} with the specified body that will be
+     * encoded into UTF-8 by default.
      * @param body Body
      */
     public RsWithBody(final CharSequence body) {
@@ -60,7 +61,7 @@ public final class RsWithBody extends RsWrap {
     }
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithBody} with the specified body.
      * @param body Body
      */
     public RsWithBody(final byte[] body) {
@@ -68,7 +69,7 @@ public final class RsWithBody extends RsWrap {
     }
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithBody} with the specified body.
      * @param body Body
      */
     public RsWithBody(final InputStream body) {
@@ -76,7 +77,8 @@ public final class RsWithBody extends RsWrap {
     }
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithBody} with the content located at the specified
+     * url as body.
      * @param url URL with body
      */
     public RsWithBody(final URL url) {
@@ -84,7 +86,8 @@ public final class RsWithBody extends RsWrap {
     }
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithBody} with the specified response and body. The
+     * body will be encoded into UTF-8 by default.
      * @param res Original response
      * @param body Body
      */
@@ -93,7 +96,8 @@ public final class RsWithBody extends RsWrap {
     }
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithBody} with the specified response and body. The
+     * body will be encoded using the specified character set.
      * @param res Original response
      * @param body Body
      * @param charset The character set to use to serialize the body

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -88,7 +89,18 @@ public final class RsWithBody extends RsWrap {
      * @param body Body
      */
     public RsWithBody(final Response res, final CharSequence body) {
-        this(res, body.toString().getBytes(StandardCharsets.UTF_8));
+        this(res, body, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Ctor.
+     * @param res Original response
+     * @param body Body
+     * @param charset The character set to use to serialize the body
+     */
+    public RsWithBody(final Response res, final CharSequence body,
+        final Charset charset) {
+        this(res, body.toString().getBytes(charset));
     }
 
     /**

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -159,7 +159,7 @@ public final class RsWithType extends RsWrap {
         /**
          * Constructs a {@code HTML} that will add text/html as the content type
          * header to the response using the specified charset as charset
-         * parameter value if present..
+         * parameter value if present.
          * @param res Original response
          * @param charset The character set to add in the content type header if
          *  present.

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Opt;
 
 /**
  * Response decorator, with content type.
@@ -88,14 +89,28 @@ public final class RsWithType extends RsWrap {
      */
     private static Response make(final Response res, final CharSequence type,
         final Charset charset) {
-        final Response response;
+        final Opt<Charset> opt;
         if (charset == null) {
-            response = new RsWithHeader(
-                new RsWithoutHeader(res, RsWithType.HEADER),
-                RsWithType.HEADER,
-                type
-            );
+            opt = new Opt.Empty<>();
         } else {
+            opt = new Opt.Single<>(charset);
+        }
+        return RsWithType.make(res, type, opt);
+    }
+
+    /**
+     * Factory allowing to create {@code Response} with the corresponding
+     * content type and character set.
+     * @param res Original response
+     * @param type Content type
+     * @param charset The character set to add to the content type header. If
+     *  absent no character set will be added to the content type header
+     * @return Response
+     */
+    private static Response make(final Response res, final CharSequence type,
+        final Opt<Charset> charset) {
+        final Response response;
+        if (charset.has()) {
             response = new RsWithHeader(
                 new RsWithoutHeader(res, RsWithType.HEADER),
                 RsWithType.HEADER,
@@ -103,8 +118,14 @@ public final class RsWithType extends RsWrap {
                     "%s; %s=%s",
                     type,
                     RsWithType.CHARSET,
-                    charset.name()
+                    charset.get().name()
                 )
+            );
+        } else {
+            response = new RsWithHeader(
+                new RsWithoutHeader(res, RsWithType.HEADER),
+                RsWithType.HEADER,
+                type
             );
         }
         return response;

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -60,7 +60,7 @@ public final class RsWithType extends RsWrap {
      * @param type Content type
      */
     public RsWithType(final Response res, final CharSequence type) {
-        this(res, type, null);
+        this(res, type, new Opt.Empty<Charset>());
     }
 
     /**
@@ -75,27 +75,21 @@ public final class RsWithType extends RsWrap {
      */
     public RsWithType(final Response res, final CharSequence type,
         final Charset charset) {
-        super(RsWithType.make(res, type, charset));
+        this(res, type, new Opt.Single<Charset>(charset));
     }
 
     /**
-     * Factory allowing to create {@code Response} with the corresponding
-     * content type and character set.
+     * Constructs a {@code RsWithType} that will add the content type header to
+     * the response using the specified type as media type and the specified
+     * charset as charset parameter value if present.
      * @param res Original response
      * @param type Content type
-     * @param charset The character set to add to the content type header. If
-     *  {@code null} no character set will be added to the content type header
-     * @return Response
+     * @param charset The character set to add in the content type header if
+     *  present.
      */
-    private static Response make(final Response res, final CharSequence type,
-        final Charset charset) {
-        final Opt<Charset> opt;
-        if (charset == null) {
-            opt = new Opt.Empty<Charset>();
-        } else {
-            opt = new Opt.Single<Charset>(charset);
-        }
-        return RsWithType.make(res, type, opt);
+    private RsWithType(final Response res, final CharSequence type,
+        final Opt<Charset> charset) {
+        super(RsWithType.make(res, type, charset));
     }
 
     /**
@@ -148,7 +142,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public HTML(final Response res) {
-            this(res, null);
+            this(res, new Opt.Empty<Charset>());
         }
 
         /**
@@ -159,6 +153,18 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public HTML(final Response res, final Charset charset) {
+            this(res, new Opt.Single<Charset>(charset));
+        }
+
+        /**
+         * Constructs a {@code HTML} that will add text/html as the content type
+         * header to the response using the specified charset as charset
+         * parameter value if present..
+         * @param res Original response
+         * @param charset The character set to add in the content type header if
+         *  present.
+         */
+        private HTML(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "text/html", charset));
         }
 
@@ -181,7 +187,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public JSON(final Response res) {
-            this(res, null);
+            this(res, new Opt.Empty<Charset>());
         }
 
         /**
@@ -192,6 +198,18 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public JSON(final Response res, final Charset charset) {
+            this(res, new Opt.Single<Charset>(charset));
+        }
+
+        /**
+         * Constructs a {@code JSON} that will add application/json as the
+         * content type header to the response using the specified charset as
+         * charset parameter value if present.
+         * @param res Original response
+         * @param charset The character set to add in the content type header if
+         *  present.
+         */
+        private JSON(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "application/json", charset));
         }
 
@@ -214,7 +232,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public XML(final Response res) {
-            this(res, null);
+            this(res, new Opt.Empty<Charset>());
         }
 
         /**
@@ -225,6 +243,18 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public XML(final Response res, final Charset charset) {
+            this(res, new Opt.Single<Charset>(charset));
+        }
+
+        /**
+         * Constructs a {@code XML} that will add text/xml as the content type
+         * header to the response using the specified charset as
+         * charset parameter value if present.
+         * @param res Original response
+         * @param charset The character set to add in the content type header if
+         *  present.
+         */
+        private XML(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "text/xml", charset));
         }
 
@@ -247,7 +277,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public Text(final Response res) {
-            this(res, null);
+            this(res, new Opt.Empty<Charset>());
         }
 
         /**
@@ -258,6 +288,18 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public Text(final Response res, final Charset charset) {
+            this(res, new Opt.Single<Charset>(charset));
+        }
+
+        /**
+         * Constructs a {@code Text} that will add text/plain as the content
+         * type header to the response using the specified charset as
+         * charset parameter value if present.
+         * @param res Original response
+         * @param charset The character set to add in the content type header if
+         *  present.
+         */
+        private Text(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "text/plain", charset));
         }
 

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -91,9 +91,9 @@ public final class RsWithType extends RsWrap {
         final Charset charset) {
         final Opt<Charset> opt;
         if (charset == null) {
-            opt = new Opt.Empty<>();
+            opt = new Opt.Empty<Charset>();
         } else {
-            opt = new Opt.Single<>(charset);
+            opt = new Opt.Single<Charset>(charset);
         }
         return RsWithType.make(res, type, opt);
     }

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -237,8 +237,8 @@ public final class RsWithType extends RsWrap {
 
         /**
          * Constructs a {@code XML} that will add text/xml as the content type
-         * header to the response using the specified charset as
-         * charset parameter value.
+         * header to the response using the specified charset as charset
+         * parameter value.
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
@@ -248,8 +248,8 @@ public final class RsWithType extends RsWrap {
 
         /**
          * Constructs a {@code XML} that will add text/xml as the content type
-         * header to the response using the specified charset as
-         * charset parameter value if present.
+         * header to the response using the specified charset as charset
+         * parameter value if present.
          * @param res Original response
          * @param charset The character set to add in the content type header if
          *  present.
@@ -282,8 +282,8 @@ public final class RsWithType extends RsWrap {
 
         /**
          * Constructs a {@code Text} that will add text/plain as the content
-         * type header to the response using the specified charset as
-         * charset parameter value.
+         * type header to the response using the specified charset as charset
+         * parameter value.
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
@@ -293,8 +293,8 @@ public final class RsWithType extends RsWrap {
 
         /**
          * Constructs a {@code Text} that will add text/plain as the content
-         * type header to the response using the specified charset as
-         * charset parameter value if present.
+         * type header to the response using the specified charset as charset
+         * parameter value if present.
          * @param res Original response
          * @param charset The character set to add in the content type header if
          *  present.

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -52,36 +52,22 @@ public final class RsWithType extends RsWrap {
     private static final String CHARSET = "charset";
 
     /**
-     * Content type text/html.
-     */
-    private static final String TYPE_HTML = "text/html";
-
-    /**
-     * Content type text/xml.
-     */
-    private static final String TYPE_XML = "text/xml";
-
-    /**
-     * Content type text/plain.
-     */
-    private static final String TYPE_TEXT = "text/plain";
-
-    /**
-     * Content type application/json.
-     */
-    private static final String TYPE_JSON = "application/json";
-
-    /**
-     * Ctor.
+     * Constructs a {@code RsWithType} that will add the content type header to
+     * the response using the specified type as media type.
+     * <p>The resulting header is of type <code>Content-Type: media-type</code>.
      * @param res Original response
      * @param type Content type
      */
     public RsWithType(final Response res, final CharSequence type) {
-        super(RsWithType.make(res, type));
+        this(res, type, null);
     }
 
     /**
-     * Ctor.
+     * Constructs a {@code RsWithType} that will add the content type header to
+     * the response using the specified type as media type and the specified
+     * charset as charset parameter value.
+     * <p>The resulting header
+     * is of type <code>Content-Type: media-type; charset=charset-value</code>.
      * @param res Original response
      * @param type Content type
      * @param charset The character set to add in the content type header
@@ -92,33 +78,36 @@ public final class RsWithType extends RsWrap {
     }
 
     /**
-     * Ctor.
-     * @param res Original response
-     * @param type Content type
-     * @return Response
-     */
-    private static Response make(final Response res, final CharSequence type) {
-        return new RsWithHeader(
-            new RsWithoutHeader(res, RsWithType.HEADER),
-            RsWithType.HEADER, type
-        );
-    }
-
-    /**
      * Factory allowing to create {@code Response} with the corresponding
      * content type and character set.
      * @param res Original response
      * @param type Content type
-     * @param charset The character set to add in the content type header
+     * @param charset The character set to add to the content type header. If
+     *  {@code null} no character set will be added to the content type header
      * @return Response
      */
     private static Response make(final Response res, final CharSequence type,
         final Charset charset) {
-        return new RsWithHeader(
-            new RsWithoutHeader(res, RsWithType.HEADER),
-            RsWithType.HEADER,
-            String.format("%s; %s=%s", type, RsWithType.CHARSET, charset.name())
-        );
+        final Response response;
+        if (charset == null) {
+            response = new RsWithHeader(
+                new RsWithoutHeader(res, RsWithType.HEADER),
+                RsWithType.HEADER,
+                type
+            );
+        } else {
+            response = new RsWithHeader(
+                new RsWithoutHeader(res, RsWithType.HEADER),
+                RsWithType.HEADER,
+                String.format(
+                    "%s; %s=%s",
+                    type,
+                    RsWithType.CHARSET,
+                    charset.name()
+                )
+            );
+        }
+        return response;
     }
 
     /**
@@ -137,7 +126,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public HTML(final Response res) {
-            super(RsWithType.make(res, RsWithType.TYPE_HTML));
+            this(res, null);
         }
 
         /**
@@ -146,7 +135,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public HTML(final Response res, final Charset charset) {
-            super(RsWithType.make(res, RsWithType.TYPE_HTML, charset));
+            super(RsWithType.make(res, "text/html", charset));
         }
 
     }
@@ -167,7 +156,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public JSON(final Response res) {
-            super(RsWithType.make(res, RsWithType.TYPE_JSON));
+            this(res, null);
         }
 
         /**
@@ -176,7 +165,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public JSON(final Response res, final Charset charset) {
-            super(RsWithType.make(res, RsWithType.TYPE_JSON, charset));
+            super(RsWithType.make(res, "application/json", charset));
         }
 
     }
@@ -197,7 +186,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public XML(final Response res) {
-            super(RsWithType.make(res, RsWithType.TYPE_XML));
+            this(res, null);
         }
 
         /**
@@ -206,7 +195,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public XML(final Response res, final Charset charset) {
-            super(RsWithType.make(res, RsWithType.TYPE_XML, charset));
+            super(RsWithType.make(res, "text/xml", charset));
         }
 
     }
@@ -227,7 +216,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public Text(final Response res) {
-            super(RsWithType.make(res, RsWithType.TYPE_TEXT));
+            this(res, null);
         }
 
         /**
@@ -236,7 +225,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header
          */
         public Text(final Response res, final Charset charset) {
-            super(RsWithType.make(res, RsWithType.TYPE_TEXT, charset));
+            super(RsWithType.make(res, "text/plain", charset));
         }
 
     }

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -23,6 +23,7 @@
  */
 package org.takes.rs;
 
+import java.nio.charset.Charset;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
@@ -46,6 +47,31 @@ public final class RsWithType extends RsWrap {
     private static final String HEADER = "Content-Type";
 
     /**
+     * The name of the parameter allowing to define the character set.
+     */
+    private static final String CHARSET = "charset";
+
+    /**
+     * Content type text/html.
+     */
+    private static final String TYPE_HTML = "text/html";
+
+    /**
+     * Content type text/xml.
+     */
+    private static final String TYPE_XML = "text/xml";
+
+    /**
+     * Content type text/plain.
+     */
+    private static final String TYPE_TEXT = "text/plain";
+
+    /**
+     * Content type application/json.
+     */
+    private static final String TYPE_JSON = "application/json";
+
+    /**
      * Ctor.
      * @param res Original response
      * @param type Content type
@@ -58,12 +84,40 @@ public final class RsWithType extends RsWrap {
      * Ctor.
      * @param res Original response
      * @param type Content type
+     * @param charset The character set to add in the content type header
+     */
+    public RsWithType(final Response res, final CharSequence type,
+        final Charset charset) {
+        super(RsWithType.make(res, type, charset));
+    }
+
+    /**
+     * Ctor.
+     * @param res Original response
+     * @param type Content type
      * @return Response
      */
     private static Response make(final Response res, final CharSequence type) {
         return new RsWithHeader(
             new RsWithoutHeader(res, RsWithType.HEADER),
             RsWithType.HEADER, type
+        );
+    }
+
+    /**
+     * Factory allowing to create {@code Response} with the corresponding
+     * content type and character set.
+     * @param res Original response
+     * @param type Content type
+     * @param charset The character set to add in the content type header
+     * @return Response
+     */
+    private static Response make(final Response res, final CharSequence type,
+        final Charset charset) {
+        return new RsWithHeader(
+            new RsWithoutHeader(res, RsWithType.HEADER),
+            RsWithType.HEADER,
+            String.format("%s; %s=%s", type, RsWithType.CHARSET, charset.name())
         );
     }
 
@@ -83,7 +137,16 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public HTML(final Response res) {
-            super(RsWithType.make(res, "text/html"));
+            super(RsWithType.make(res, RsWithType.TYPE_HTML));
+        }
+
+        /**
+         * Ctor.
+         * @param res Original response
+         * @param charset The character set to add in the content type header
+         */
+        public HTML(final Response res, final Charset charset) {
+            super(RsWithType.make(res, RsWithType.TYPE_HTML, charset));
         }
 
     }
@@ -104,7 +167,16 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public JSON(final Response res) {
-            super(RsWithType.make(res, "application/json"));
+            super(RsWithType.make(res, RsWithType.TYPE_JSON));
+        }
+
+        /**
+         * Ctor.
+         * @param res Original response
+         * @param charset The character set to add in the content type header
+         */
+        public JSON(final Response res, final Charset charset) {
+            super(RsWithType.make(res, RsWithType.TYPE_JSON, charset));
         }
 
     }
@@ -125,7 +197,16 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public XML(final Response res) {
-            super(RsWithType.make(res, "text/xml"));
+            super(RsWithType.make(res, RsWithType.TYPE_XML));
+        }
+
+        /**
+         * Ctor.
+         * @param res Original response
+         * @param charset The character set to add in the content type header
+         */
+        public XML(final Response res, final Charset charset) {
+            super(RsWithType.make(res, RsWithType.TYPE_XML, charset));
         }
 
     }
@@ -146,7 +227,16 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          */
         public Text(final Response res) {
-            super(RsWithType.make(res, "text/plain"));
+            super(RsWithType.make(res, RsWithType.TYPE_TEXT));
+        }
+
+        /**
+         * Ctor.
+         * @param res Original response
+         * @param charset The character set to add in the content type header
+         */
+        public Text(final Response res, final Charset charset) {
+            super(RsWithType.make(res, RsWithType.TYPE_TEXT, charset));
         }
 
     }

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -54,7 +54,7 @@ public final class RsWithType extends RsWrap {
     /**
      * Constructs a {@code RsWithType} that will add the content type header to
      * the response using the specified type as media type.
-     * <p>The resulting header is of type <code>Content-Type: media-type</code>.
+     * <p>The resulting header is of type {@code Content-Type: media-type}.
      * @param res Original response
      * @param type Content type
      */
@@ -67,7 +67,7 @@ public final class RsWithType extends RsWrap {
      * the response using the specified type as media type and the specified
      * charset as charset parameter value.
      * <p>The resulting header
-     * is of type <code>Content-Type: media-type; charset=charset-value</code>.
+     * is of type {@code Content-Type: media-type; charset=charset-value}.
      * @param res Original response
      * @param type Content type
      * @param charset The character set to add in the content type header
@@ -122,7 +122,8 @@ public final class RsWithType extends RsWrap {
     public static final class HTML extends RsWrap {
 
         /**
-         * Ctor.
+         * Constructs a {@code HTML} that will add text/html as the content type
+         * header to the response.
          * @param res Original response
          */
         public HTML(final Response res) {
@@ -130,7 +131,9 @@ public final class RsWithType extends RsWrap {
         }
 
         /**
-         * Ctor.
+         * Constructs a {@code HTML} that will add text/html as the content type
+         * header to the response using the specified charset as charset
+         * parameter value.
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
@@ -152,7 +155,8 @@ public final class RsWithType extends RsWrap {
     public static final class JSON extends RsWrap {
 
         /**
-         * Ctor.
+         * Constructs a {@code JSON} that will add application/json as the
+         * content type header to the response.
          * @param res Original response
          */
         public JSON(final Response res) {
@@ -160,7 +164,9 @@ public final class RsWithType extends RsWrap {
         }
 
         /**
-         * Ctor.
+         * Constructs a {@code JSON} that will add application/json as the
+         * content type header to the response using the specified charset as
+         * charset parameter value.
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
@@ -182,7 +188,8 @@ public final class RsWithType extends RsWrap {
     public static final class XML extends RsWrap {
 
         /**
-         * Ctor.
+         * Constructs a {@code XML} that will add text/xml as the content type
+         * header to the response.
          * @param res Original response
          */
         public XML(final Response res) {
@@ -190,7 +197,9 @@ public final class RsWithType extends RsWrap {
         }
 
         /**
-         * Ctor.
+         * Constructs a {@code XML} that will add text/xml as the content type
+         * header to the response using the specified charset as
+         * charset parameter value.
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
@@ -212,7 +221,8 @@ public final class RsWithType extends RsWrap {
     public static final class Text extends RsWrap {
 
         /**
-         * Ctor.
+         * Constructs a {@code Text} that will add text/plain as the content
+         * type header to the response.
          * @param res Original response
          */
         public Text(final Response res) {
@@ -220,7 +230,9 @@ public final class RsWithType extends RsWrap {
         }
 
         /**
-         * Ctor.
+         * Constructs a {@code Text} that will add text/plain as the content
+         * type header to the response using the specified charset as
+         * charset parameter value.
          * @param res Original response
          * @param charset The character set to add in the content type header
          */

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -25,6 +25,7 @@ package org.takes.rs;
 
 import com.google.common.base.Joiner;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -59,6 +60,11 @@ public final class RsWithTypeTest {
     private static final String TYPE_TEXT = "text/plain";
 
     /**
+     * Content type application/json.
+     */
+    private static final String TYPE_JSON = "application/json";
+
+    /**
      * HTTP Status OK.
      */
     private static final String HTTP_OK = "HTTP/1.1 200 OK";
@@ -69,18 +75,21 @@ public final class RsWithTypeTest {
     private static final String CONTENT_TYPE = "Content-Type: %s";
 
     /**
+     * Content-Type format with charset.
+     */
+    private static final String CONTENT_TYPE_WITH_CHARSET =
+        "Content-Type: %s; charset=%s";
+
+    /**
      * RsWithType can replace an existing type.
-     * @throws java.lang.Exception If a problem occurs.
+     * @throws Exception If a problem occurs.
      */
     @Test
     public void replaceTypeToResponse() throws Exception {
         final String type = TYPE_TEXT;
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType(
-                    new RsWithType(new RsEmpty(), TYPE_XML),
-                    type
-                )
+                new RsWithType(new RsWithType(new RsEmpty(), TYPE_XML), type)
             ).print(),
             Matchers.equalTo(
                 Joiner.on(CRLF).join(
@@ -95,7 +104,7 @@ public final class RsWithTypeTest {
 
     /**
      * RsWithType does not replace response code.
-     * @throws java.lang.Exception If a problem occurs.
+     * @throws Exception If a problem occurs.
      */
     @Test
     public void doesNotReplaceResponseCode() throws Exception {
@@ -104,9 +113,7 @@ public final class RsWithTypeTest {
             new RsPrint(
                 new RsWithType(
                     new RsWithBody(
-                        new RsWithStatus(
-                            HttpURLConnection.HTTP_INTERNAL_ERROR
-                        ),
+                        new RsWithStatus(HttpURLConnection.HTTP_INTERNAL_ERROR),
                         body
                     ),
                     TYPE_HTML
@@ -126,17 +133,13 @@ public final class RsWithTypeTest {
 
     /**
      * RsWithType.HTML can replace an existing type with text/html.
-     * @throws java.lang.Exception If a problem occurs.
+     * @throws Exception If a problem occurs.
      */
     @Test
     public void replacesTypeWithHtml() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.HTML(
-                    new RsWithType(
-                        new RsEmpty(), TYPE_XML
-                    )
-                )
+                new RsWithType.HTML(new RsWithType(new RsEmpty(), TYPE_XML))
             ).print(),
             Matchers.equalTo(
                 Joiner.on(CRLF).join(
@@ -147,26 +150,62 @@ public final class RsWithTypeTest {
                 )
             )
         );
-    }
-
-    /**
-     * RsWithType.JSON can replace an existing type with application/json.
-     * @throws java.lang.Exception If a problem occurs.
-     */
-    @Test
-    public void replacesTypeWithJson() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.JSON(
-                    new RsWithType(
-                        new RsEmpty(), TYPE_XML
-                    )
+                new RsWithType.HTML(
+                    new RsWithType(new RsEmpty(), TYPE_XML),
+                    StandardCharsets.ISO_8859_1
                 )
             ).print(),
             Matchers.equalTo(
                 Joiner.on(CRLF).join(
                     HTTP_OK,
-                    String.format(CONTENT_TYPE, "application/json"),
+                    String.format(
+                        CONTENT_TYPE_WITH_CHARSET,
+                        TYPE_HTML,
+                        StandardCharsets.ISO_8859_1
+                    ),
+                    "",
+                    ""
+                )
+            )
+        );
+    }
+
+    /**
+     * RsWithType.JSON can replace an existing type with application/json.
+     * @throws Exception If a problem occurs.
+     */
+    @Test
+    public void replacesTypeWithJson() throws Exception {
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsWithType.JSON(new RsWithType(new RsEmpty(), TYPE_XML))
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(CONTENT_TYPE, TYPE_JSON),
+                    "",
+                    ""
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsWithType.JSON(
+                    new RsWithType(new RsEmpty(), TYPE_XML),
+                    StandardCharsets.ISO_8859_1
+                )
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(
+                        CONTENT_TYPE_WITH_CHARSET,
+                        TYPE_JSON,
+                        StandardCharsets.ISO_8859_1
+                    ),
                     "",
                     ""
                 )
@@ -176,17 +215,13 @@ public final class RsWithTypeTest {
 
     /**
      * RsWithType.XML can replace an existing type with text/xml.
-     * @throws java.lang.Exception If a problem occurs.
+     * @throws Exception If a problem occurs.
      */
     @Test
     public void replacesTypeWithXml() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.XML(
-                    new RsWithType(
-                        new RsEmpty(), TYPE_HTML
-                    )
-                )
+                new RsWithType.XML(new RsWithType(new RsEmpty(), TYPE_HTML))
             ).print(),
             Matchers.equalTo(
                 Joiner.on(CRLF).join(
@@ -197,22 +232,98 @@ public final class RsWithTypeTest {
                 )
             )
         );
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsWithType.XML(
+                    new RsWithType(new RsEmpty(), TYPE_HTML),
+                    StandardCharsets.ISO_8859_1
+                )
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(
+                        CONTENT_TYPE_WITH_CHARSET,
+                        TYPE_XML,
+                        StandardCharsets.ISO_8859_1
+                    ),
+                    "",
+                    ""
+                )
+            )
+        );
     }
 
     /**
      * RsWithType.Text can replace an existing type with text/plain.
-     * @throws java.lang.Exception If a problem occurs.
+     * @throws Exception If a problem occurs.
      */
     @Test
     public void replacesTypeWithText() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
+                new RsWithType.Text(new RsWithType(new RsEmpty(), TYPE_HTML))
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(CONTENT_TYPE, TYPE_TEXT),
+                    "",
+                    ""
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            new RsPrint(
                 new RsWithType.Text(
-                    new RsWithType(
-                        new RsEmpty(), TYPE_HTML
-                    )
+                    new RsWithType(new RsEmpty(), TYPE_HTML),
+                    StandardCharsets.ISO_8859_1
                 )
             ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(
+                        CONTENT_TYPE_WITH_CHARSET,
+                        TYPE_TEXT,
+                        StandardCharsets.ISO_8859_1
+                    ),
+                    "",
+                    ""
+                )
+            )
+        );
+    }
+
+    /**
+     * RsWithType can add the charset to the content type when it is explicitly
+     * specified and can still provide the content type without the charset
+     * when it is not explicitly specified.
+     * @throws Exception If a problem occurs.
+     */
+    @Test
+    public void addsCharsetToContentTypeIfNeeded() throws Exception {
+        MatcherAssert.assertThat(
+            new RsPrint(
+                new RsWithType(
+                    new RsEmpty(), TYPE_TEXT, StandardCharsets.ISO_8859_1
+                )
+            ).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(
+                        CONTENT_TYPE_WITH_CHARSET,
+                        TYPE_TEXT,
+                        StandardCharsets.ISO_8859_1
+                    ),
+                    "",
+                    ""
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            new RsPrint(new RsWithType(new RsEmpty(), TYPE_TEXT)).print(),
             Matchers.equalTo(
                 Joiner.on(CRLF).join(
                     HTTP_OK,

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -296,13 +296,31 @@ public final class RsWithTypeTest {
     }
 
     /**
-     * RsWithType can add the charset to the content type when it is explicitly
-     * specified and can still provide the content type without the charset
-     * when it is not explicitly specified.
+     * RsWithType can add properly the content type to the header.
      * @throws Exception If a problem occurs.
      */
     @Test
-    public void addsCharsetToContentTypeIfNeeded() throws Exception {
+    public void addsContentType() throws Exception {
+        MatcherAssert.assertThat(
+            new RsPrint(new RsWithType(new RsEmpty(), TYPE_TEXT)).print(),
+            Matchers.equalTo(
+                Joiner.on(CRLF).join(
+                    HTTP_OK,
+                    String.format(CONTENT_TYPE, TYPE_TEXT),
+                    "",
+                    ""
+                )
+            )
+        );
+    }
+
+    /**
+     * RsWithType can add the charset to the content type when it is explicitly
+     * specified.
+     * @throws Exception If a problem occurs.
+     */
+    @Test
+    public void addsCharsetToContentType() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
                 new RsWithType(
@@ -317,17 +335,6 @@ public final class RsWithTypeTest {
                         TYPE_TEXT,
                         StandardCharsets.ISO_8859_1
                     ),
-                    "",
-                    ""
-                )
-            )
-        );
-        MatcherAssert.assertThat(
-            new RsPrint(new RsWithType(new RsEmpty(), TYPE_TEXT)).print(),
-            Matchers.equalTo(
-                Joiner.on(CRLF).join(
-                    HTTP_OK,
-                    String.format(CONTENT_TYPE, TYPE_TEXT),
                     "",
                     ""
                 )


### PR DESCRIPTION
For #524 

The goal of this PR is to add the charset into the content type header by using the new constructor of RsWithType allowing to explicitly specify the charset.