### PR TITLE
#548: Prevent getting URISyntaxException due to bad urls by automatically fixing them

### DIFF
--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -25,6 +25,7 @@ package org.takes.misc;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
@@ -76,7 +77,7 @@ public final class Href implements CharSequence {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public Href(final CharSequence txt) {
         this.params = new ConcurrentHashMap<String, List<String>>(0);
-        final URI link = URI.create(txt.toString());
+        final URI link = Href.createURI(txt.toString());
         final String query = link.getRawQuery();
         if (query == null) {
             this.uri = link;
@@ -280,4 +281,35 @@ public final class Href implements CharSequence {
         }
     }
 
+    /**
+     * Parses the specified content to create the corresponding {@code URI}
+     * instance. In case of an {@code URISyntaxException}, it will automatically
+     * encode the character that causes the issue then it will try again
+     * if it is possible otherwise an {@code IllegalArgumentException} will
+     * be thrown.
+     * @param txt The content to parse
+     * @return The {@code URI} corresponding to the specified content.
+     * @throws IllegalArgumentException in case the content could not be parsed
+     * @throws IllegalStateException in case an invalid character could not be
+     *  encoded properly.
+     */
+    private static URI createURI(final String txt) {
+        URI result;
+        try {
+            result = new URI(txt);
+        } catch (final URISyntaxException ex) {
+            final int index = ex.getIndex();
+            if (index == -1) {
+                throw new IllegalArgumentException(ex.getMessage(), ex);
+            }
+            final StringBuilder value = new StringBuilder(txt);
+            value.replace(
+                index,
+                index + 1,
+                Href.encode(value.substring(index, index + 1))
+            );
+            result = Href.createURI(value.toString());
+        }
+        return result;
+    }
 }

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -100,4 +100,19 @@ public final class HrefTest {
             Matchers.equalTo(url)
         );
     }
+
+    /**
+     * Href can accept non properly encoded URL.
+     */
+    @Test
+    public void acceptsNonProperlyEncodedURL() {
+        final String url =
+            "http://www.netbout.com/[foo/bar]/read?file=%5B%5D%28%29.txt";
+        final String result =
+            "http://www.netbout.com/%5Bfoo/bar%5D/read?file=%5B%5D%28%29.txt";
+        MatcherAssert.assertThat(
+            new Href(url).toString(),
+            Matchers.equalTo(result)
+        );
+    }
 }

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -106,13 +106,10 @@ public final class HrefTest {
      */
     @Test
     public void acceptsNonProperlyEncodedURL() {
-        final String url =
-            "http://www.netbout.com/[foo/bar]/read?file=%5B%5D%28%29.txt";
-        final String result =
-            "http://www.netbout.com/%5Bfoo/bar%5D/read?file=%5B%5D%28%29.txt";
         MatcherAssert.assertThat(
-            new Href(url).toString(),
-            Matchers.equalTo(result)
+            // @checkstyle LineLength (2 lines)
+            new Href("http://www.netbout.com/[foo/bar]/read?file=%5B%5D%28%29.txt").toString(),
+            Matchers.equalTo("http://www.netbout.com/%5Bfoo/bar%5D/read?file=%5B%5D%28%29.txt")
         );
     }
 }


### PR DESCRIPTION
For #548 

The goal of this PR is to prevent getting URISyntaxException when we have to deal with not properly encoded url. It fixes that by encoding all the invalid characters until we get a parseable URI.