### PR TITLE
#506 BkTimeableTest fails intermittently 

### DIFF
--- a/src/test/java/org/takes/facets/fork/FkHitRefreshTest.java
+++ b/src/test/java/org/takes/facets/fork/FkHitRefreshTest.java
@@ -40,14 +40,13 @@ import org.takes.tk.TkEmpty;
 /**
  * Test case for {@link FkHitRefresh}.
  * @author Yegor Bugayenko (yegor@teamed.io)
- * @version $Id: e60e0217ac71dbde8b13fc678e4770cbd2f9982c $
+ * @version $Id$
  * @since 0.9
  */
 public final class FkHitRefreshTest {
 
     /**
      * Temp directory.
-     * @checkstyle VisibilityModifierCheck (5 lines)
      */
     @Rule
     public final transient TemporaryFolder temp = new TemporaryFolder();
@@ -61,7 +60,7 @@ public final class FkHitRefreshTest {
     public void refreshesOnDemand() throws Exception {
         final Request req = new RqWithHeader(
             new RqFake(), "X-Takes-HitRefresh: yes"
-            );
+        );
         final AtomicBoolean done = new AtomicBoolean(false);
         final Fork fork = new FkHitRefresh(
             this.temp.getRoot(),
@@ -72,7 +71,7 @@ public final class FkHitRefreshTest {
                 }
             },
             new TkEmpty()
-            );
+        );
         TimeUnit.SECONDS.sleep(2L);
         FileUtils.touch(this.temp.newFile("hey.txt"));
         MatcherAssert.assertThat(
@@ -92,7 +91,7 @@ public final class FkHitRefreshTest {
         MatcherAssert.assertThat(
             new FkHitRefresh(
                 dir, "", new TkEmpty()
-                ).route(new RqFake()).has(),
+            ).route(new RqFake()).has(),
             Matchers.is(false)
         );
     }

--- a/src/test/java/org/takes/http/BkTimeableTest.java
+++ b/src/test/java/org/takes/http/BkTimeableTest.java
@@ -28,6 +28,7 @@ import com.jcabi.http.response.RestResponse;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
@@ -45,6 +46,7 @@ import org.takes.rs.RsText;
  * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
  * @version $Id$
  * @since 0.14.2
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.DoNotUseThreads")
 public final class BkTimeableTest {
@@ -63,6 +65,14 @@ public final class BkTimeableTest {
     @Test
     public void stopsLongRunningBack() throws Exception {
         final String response = "interrupted";
+        final CountDownLatch ready = new CountDownLatch(1);
+        final Exit exit = new Exit() {
+            @Override
+            public boolean ready() {
+                ready.countDown();
+                return false;
+            }
+        };
         final Take take = new Take() {
             @Override
             public Response act(final Request req) {
@@ -91,7 +101,7 @@ public final class BkTimeableTest {
                             "--threads=1",
                             "--lifetime=3000",
                             "--max-latency=100"
-                        ).start(Exit.NEVER);
+                        ).start(exit);
                     } catch (final IOException ex) {
                         throw new IllegalStateException(ex);
                     }
@@ -99,8 +109,7 @@ public final class BkTimeableTest {
             }
         );
         thread.start();
-        // @checkstyle MagicNumberCheck (1 line)
-        TimeUnit.MILLISECONDS.sleep(1500L);
+        ready.await();
         final int port = Integer.parseInt(FileUtils.readFileToString(file));
         new JdkRequest(String.format("http://localhost:%d", port))
             .fetch()

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -76,9 +76,7 @@ public final class RqMultipartTest {
      * Content disposition plus form data.
      */
     private static final String CONTENT = String.format(
-        "%s: %s",
-        RqMultipartTest.DISPOSITION,
-        "form-data; name=\"%s\""
+        "%s: %s", RqMultipartTest.DISPOSITION,"form-data; name=\"%s\""
     );
 
     /**
@@ -330,10 +328,7 @@ public final class RqMultipartTest {
         final String body =
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--zzz",
-                String.format(
-                    RqMultipartTest.CONTENT,
-                    part
-                ),
+                String.format(RqMultipartTest.CONTENT, part),
                 "",
                 StringUtils.repeat("X", length),
                 "--zzz--"
@@ -446,10 +441,7 @@ public final class RqMultipartTest {
                 "POST /post?u=3 HTTP/1.1",
                 "Host: example.com",
                 "Content-Type: multipart/form-data; boundary=zzz",
-                String.format(
-                    "Content-Length:%s",
-                    file.length()
-                )
+                String.format("Content-Length:%s",file.length())
             ),
             new TempInputStream(new FileInputStream(file), file)
         );

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -76,7 +76,7 @@ public final class RqMultipartTest {
      * Content disposition plus form data.
      */
     private static final String CONTENT = String.format(
-        "%s: %s", RqMultipartTest.DISPOSITION,"form-data; name=\"%s\""
+        "%s: %s", RqMultipartTest.DISPOSITION, "form-data; name=\"%s\""
     );
 
     /**
@@ -441,7 +441,7 @@ public final class RqMultipartTest {
                 "POST /post?u=3 HTTP/1.1",
                 "Host: example.com",
                 "Content-Type: multipart/form-data; boundary=zzz",
-                String.format("Content-Length:%s",file.length())
+                String.format("Content-Length:%s", file.length())
             ),
             new TempInputStream(new FileInputStream(file), file)
         );

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -378,8 +378,7 @@ public final class RqMultipartTest {
         final String body =
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--AaB0zz",
-                String.format(RqMultipartTest.CONTENT, part),
-                "",
+                String.format(RqMultipartTest.CONTENT, part), "",
                 "my picture", "--AaB0zz--"
             );
         new FtRemote(take).exec(

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -54,7 +54,7 @@ import org.takes.rs.RsText;
 /**
  * Test case for {@link RqMultipart.Base}.
  * @author Yegor Bugayenko (yegor@teamed.io)
- * @version $Id: 37f595f280dc032586806cdefa9afea1f279d9e0 $
+ * @version $Id$
  * @since 0.9
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
@@ -63,6 +63,7 @@ import org.takes.rs.RsText;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class RqMultipartTest {
+
     /**
      * T2 temporary part name.
      */
@@ -75,9 +76,9 @@ public final class RqMultipartTest {
      * Content disposition.
      */
     private static final String DISPOSITION = "Content-Disposition";
+    
     /**
      * Temp directory.
-     * @checkstyle VisibilityModifierCheck (5 lines)
      */
     @Rule
     public final transient TemporaryFolder temp = new TemporaryFolder();
@@ -115,12 +116,8 @@ public final class RqMultipartTest {
             );
         } finally {
             req.body().close();
-            reqbaseone.part("t-1")
-            .iterator()
-            .next().body().close();
-            reqbasetwo.part("t-1")
-            .iterator()
-            .next().body().close();
+            reqbaseone.part("t-1").iterator().next().body().close();
+            reqbasetwo.part("t-1").iterator().next().body().close();
         }
     }
 
@@ -233,19 +230,19 @@ public final class RqMultipartTest {
             MatcherAssert.assertThat(
                 new RqHeaders.Base(
                     multi.part("t4").iterator().next()
-                    ).header(RqMultipartTest.DISPOSITION),
+                ).header(RqMultipartTest.DISPOSITION),
                 Matchers.hasItem("form-data; name=\"t4\"")
             );
             MatcherAssert.assertThat(
                 new RqPrint(
                     new RqHeaders.Base(
                         multi.part("t4").iterator().next()
-                        )
-                    ).printBody(),
+                    )
+                ).printBody(),
                 Matchers.allOf(
                     Matchers.startsWith("40 N"),
                     Matchers.endsWith("CA 94085")
-                    )
+                )
             );
         } finally {
             multi.body().close();
@@ -316,7 +313,7 @@ public final class RqMultipartTest {
                 multi.names(),
                 Matchers.<Iterable<String>>equalTo(
                     new HashSet<String>(Arrays.asList("address", "data"))
-                    )
+                )
             );
         } finally {
             multi.body().close();
@@ -347,7 +344,7 @@ public final class RqMultipartTest {
             ),
             body
         );
-        final RqMultipart.Smart regsmart =  new RqMultipart.Smart(
+        final RqMultipart.Smart regsmart = new RqMultipart.Smart(
             new RqMultipart.Base(req)
         );
         try {
@@ -446,13 +443,13 @@ public final class RqMultipartTest {
                 String.format(
                     "Content-Length:%s",
                     tempfile.length()
-                    )
-                ),
+                )
+            ),
             new TempInputStream(new FileInputStream(tempfile), tempfile)
-            );
+        );
         final RqMultipart.Smart smartreq = new RqMultipart.Smart(
             new RqMultipart.Base(req)
-            );
+        );
         try {
             MatcherAssert.assertThat(
                 smartreq.single("test").body().available(),
@@ -510,7 +507,7 @@ public final class RqMultipartTest {
         );
         final InputStream stream = new RqMultipart.Smart(
             new RqMultipart.Base(req)
-            ).single("test1").body();
+        ).single("test1").body();
         try {
             MatcherAssert.assertThat(
                 stream.available(),
@@ -562,7 +559,7 @@ public final class RqMultipartTest {
                 new HmRqHeader(
                     "content-length",
                     "102"
-                    )
+                )
             );
         } finally {
             multipart.body().close();

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -484,10 +484,7 @@ public final class RqMultipartTest {
         final String head =
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--zzz1",
-                String.format(
-                    RqMultipartTest.CONTENT,
-                    part
-                ),
+                String.format(RqMultipartTest.CONTENT, part),
                 "",
                 ""
             );
@@ -553,10 +550,7 @@ public final class RqMultipartTest {
                 ),
                 Joiner.on("\r\n").join(
                     "--AaB01x",
-                    String.format(
-                        RqMultipartTest.CONTENT,
-                        part
-                    ),
+                    String.format(RqMultipartTest.CONTENT, part),
                     "",
                     "447 N Wolfe Rd, Sunnyvale, CA 94085",
                     "--AaB01x"

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -383,7 +383,7 @@ public final class RqMultipartTest {
         final String body =
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--AaB0zz",
-                String.format(RqMultipartTest.CONTENT,part),
+                String.format(RqMultipartTest.CONTENT, part),
                 "",
                 "my picture", "--AaB0zz--"
             );
@@ -428,7 +428,7 @@ public final class RqMultipartTest {
         bwr.write(
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--zzz",
-                String.format(RqMultipartTest.CONTENT,part),
+                String.format(RqMultipartTest.CONTENT, part),
                 "",
                 ""
             )

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -76,7 +76,7 @@ public final class RqMultipartTest {
      * Content disposition.
      */
     private static final String DISPOSITION = "Content-Disposition";
-    
+
     /**
      * Temp directory.
      */

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -383,10 +383,7 @@ public final class RqMultipartTest {
         final String body =
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--AaB0zz",
-                String.format(
-                    RqMultipartTest.CONTENT,
-                    part
-                ),
+                String.format(RqMultipartTest.CONTENT,part),
                 "",
                 "my picture", "--AaB0zz--"
             );
@@ -431,10 +428,7 @@ public final class RqMultipartTest {
         bwr.write(
             Joiner.on(RqMultipartTest.CRLF).join(
                 "--zzz",
-                String.format(
-                    RqMultipartTest.CONTENT,
-                    part
-                ),
+                String.format(RqMultipartTest.CONTENT,part),
                 "",
                 ""
             )

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -65,10 +65,6 @@ import org.takes.rs.RsText;
 public final class RqMultipartTest {
 
     /**
-     * T2 temporary part name.
-     */
-    private static final String PART_T2 = "t2";
-    /**
      * Carriage return constant.
      */
     private static final String CRLF = "\r\n";
@@ -107,17 +103,17 @@ public final class RqMultipartTest {
                 )
             )
         );
-        final RqMultipart.Base reqbaseone = new RqMultipart.Base(req);
-        final RqMultipart.Base reqbasetwo = new RqMultipart.Base(req);
+        final RqMultipart.Base one = new RqMultipart.Base(req);
+        final RqMultipart.Base two = new RqMultipart.Base(req);
         try {
             MatcherAssert.assertThat(
-                reqbaseone,
-                Matchers.equalTo(reqbasetwo)
+                one,
+                Matchers.equalTo(two)
             );
         } finally {
             req.body().close();
-            reqbaseone.part("t-1").iterator().next().body().close();
-            reqbasetwo.part("t-1").iterator().next().body().close();
+            one.part("t-1").iterator().next().body().close();
+            two.part("t-1").iterator().next().body().close();
         }
     }
 
@@ -245,7 +241,6 @@ public final class RqMultipartTest {
                 )
             );
         } finally {
-            multi.body().close();
             multi.part("t4").iterator().next().body().close();
         }
     }
@@ -532,6 +527,7 @@ public final class RqMultipartTest {
      */
     @Test
     public void producesPartsWithContentLength() throws IOException {
+        final String part = "t2";
         final RqMultipart.Base multipart = new RqMultipart.Base(
             new RqFake(
                 Arrays.asList(
@@ -542,9 +538,10 @@ public final class RqMultipartTest {
                 ),
                 Joiner.on("\r\n").join(
                     "--AaB01x",
-                    new StringBuilder()
-                    .append("Content-Disposition: form-data; name=\"")
-                    .append(RqMultipartTest.PART_T2).append("\""),
+                    String.format(
+                        "Content-Disposition: form-data; name=\"%s\"",
+                        part
+                    ),
                     "",
                     "447 N Wolfe Rd, Sunnyvale, CA 94085",
                     "--AaB01x"
@@ -553,7 +550,7 @@ public final class RqMultipartTest {
         );
         try {
             MatcherAssert.assertThat(
-                multipart.part(RqMultipartTest.PART_T2)
+                multipart.part(part)
                 .iterator()
                 .next(),
                 new HmRqHeader(
@@ -563,7 +560,7 @@ public final class RqMultipartTest {
             );
         } finally {
             multipart.body().close();
-            multipart.part(RqMultipartTest.PART_T2).iterator().next()
+            multipart.part(part).iterator().next()
                 .body().close();
         }
     }

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -564,7 +564,7 @@ public final class RqMultipartTest {
         } finally {
             multipart.body().close();
             multipart.part(RqMultipartTest.PART_T2).iterator().next()
-            .body().close();
+                .body().close();
         }
     }
 

--- a/src/test/java/org/takes/tk/TkFilesTest.java
+++ b/src/test/java/org/takes/tk/TkFilesTest.java
@@ -23,13 +23,13 @@
  */
 package org.takes.tk;
 
-import com.google.common.io.Files;
-import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.takes.HttpException;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
@@ -43,21 +43,27 @@ import org.takes.rs.RsPrint;
 public final class TkFilesTest {
 
     /**
+     * Temp directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @Rule
+    public final transient TemporaryFolder temp = new TemporaryFolder();
+
+    /**
      * TkFiles can dispatch by file name.
      * @throws IOException If some problem inside
      */
     @Test
     public void dispatchesByFileName() throws IOException {
-        final File dir = Files.createTempDir();
-        FileUtils.write(new File(dir, "a.txt"), "hello, world!");
+        FileUtils.write(this.temp.newFile("a.txt"), "hello, world!");
         MatcherAssert.assertThat(
             new RsPrint(
-                new TkFiles(dir).act(
+                new TkFiles(this.temp.getRoot()).act(
                     new RqFake(
                         "GET", "/a.txt?hash=a1b2c3", ""
+                        )
                     )
-                )
-            ).print(),
+                ).print(),
             Matchers.startsWith("HTTP/1.1 200 OK")
         );
     }
@@ -72,5 +78,4 @@ public final class TkFilesTest {
             new RqFake("PUT", "/something-else.txt", "")
         );
     }
-
 }

--- a/src/test/java/org/takes/tk/TkFilesTest.java
+++ b/src/test/java/org/takes/tk/TkFilesTest.java
@@ -44,7 +44,6 @@ public final class TkFilesTest {
 
     /**
      * Temp directory.
-     * @checkstyle VisibilityModifierCheck (5 lines)
      */
     @Rule
     public final transient TemporaryFolder temp = new TemporaryFolder();

--- a/src/test/java/org/takes/tk/TkFilesTest.java
+++ b/src/test/java/org/takes/tk/TkFilesTest.java
@@ -61,9 +61,9 @@ public final class TkFilesTest {
                 new TkFiles(this.temp.getRoot()).act(
                     new RqFake(
                         "GET", "/a.txt?hash=a1b2c3", ""
-                        )
                     )
-                ).print(),
+                )
+            ).print(),
             Matchers.startsWith("HTTP/1.1 200 OK")
         );
     }


### PR DESCRIPTION
The principal problem was in the RqMultipartTest because the requests are creating temporary files greater than 97mb, those files are now deleted after the junit test.

But, some files with 1KB stills remains in computer, I believe we need to fix the issue #576.

**- Refactoring notes**
 1) Some tests was creating files not using TemporaryFolder.
 2) RqMultipartTest was change to delete the temporary files after the execution of the junit. In order to that, I need the close the body part of the multipart request.

With these changes, after the execution of the all junits, the temporay files with 97mb are deleted after the junit ends, eliminating the instability of the builds. 

**This PR is related with issue #506**

**Code changes**

- RqMultipartTest - Lines 106 - 117
  Without that changes the code result in two more files created and not deleted after the junit test ends. So we need to close the body of this parts in order to delete them after we used them (#576).

- BkTimeableTest: add a Custom exit condition, to latch the current thread to continue the process of the junit.