### PR TITLE
#597 replaces String.split by Pattern final static field.

### DIFF
--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -50,7 +50,7 @@ import org.takes.rs.RsWithHeader;
  * <p>The class is immutable and thread-safe.
  *
  * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
+ * @version $Id$
  * @since 0.20
  */
 @EqualsAndHashCode(of = { "entry", "realm" })
@@ -62,7 +62,7 @@ public final class PsBasic implements Pass {
     private static final String AUTH_HEAD = "Basic";
 
     /**
-     * Split pattern.
+     * Pattern for basic authorization name.
      */
     private static final Pattern PATTERN = Pattern.compile(PsBasic.AUTH_HEAD);
 
@@ -93,8 +93,7 @@ public final class PsBasic implements Pass {
                 PATTERN.split(
                     new RqHeaders.Smart(
                         new RqHeaders.Base(request)
-                    )
-                        .single("authorization")
+                    ).single("authorization")
                 )[1]
             ), StandardCharsets.UTF_8
         ).trim();
@@ -130,7 +129,7 @@ public final class PsBasic implements Pass {
      * valid.
      *
      * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
+     * @version $Id$
      * @since 0.20
      */
     public interface Entry {
@@ -150,7 +149,7 @@ public final class PsBasic implements Pass {
      * <p>The class is immutable and thread-safe.
      *
      * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
+     * @version $Id$
      * @since 0.20
      *
      */
@@ -189,7 +188,7 @@ public final class PsBasic implements Pass {
      * Empty check.
      *
      * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
+     * @version $Id$
      * @since 0.20
      */
     public static final class Empty implements PsBasic.Entry {
@@ -204,7 +203,7 @@ public final class PsBasic implements Pass {
      * Default entry.
      *
      * @author Georgy Vlasov (wlasowegor@gmail.com)
-     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
+     * @version $Id$
      * @since 0.22
      */
     public static final class Default implements PsBasic.Entry {

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -59,12 +59,12 @@ public final class PsBasic implements Pass {
     /**
      * Authorization response HTTP head.
      */
-    private static final String AUTH_HEAD = "Basic";
+    private static final String AUTH = "Basic";
 
     /**
      * Pattern for basic authorization name.
      */
-    private static final Pattern PATTERN = Pattern.compile(PsBasic.AUTH_HEAD);
+    private static final Pattern AUTH_PATTERN = Pattern.compile(PsBasic.AUTH);
 
     /**
      * Entry to validate user information.
@@ -90,7 +90,7 @@ public final class PsBasic implements Pass {
     public Opt<Identity> enter(final Request request) throws IOException {
         final String decoded = new String(
             DatatypeConverter.parseBase64Binary(
-                PATTERN.split(
+                AUTH_PATTERN.split(
                     new RqHeaders.Smart(
                         new RqHeaders.Base(request)
                     ).single("authorization")

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -57,14 +57,9 @@ import org.takes.rs.RsWithHeader;
 public final class PsBasic implements Pass {
 
     /**
-     * Authorization response HTTP head.
-     */
-    private static final String AUTH = "Basic";
-
-    /**
      * Pattern for basic authorization name.
      */
-    private static final Pattern AUTH_PATTERN = Pattern.compile(PsBasic.AUTH);
+    private static final Pattern AUTH = Pattern.compile("Basic");
 
     /**
      * Entry to validate user information.
@@ -90,7 +85,7 @@ public final class PsBasic implements Pass {
     public Opt<Identity> enter(final Request request) throws IOException {
         final String decoded = new String(
             DatatypeConverter.parseBase64Binary(
-                AUTH_PATTERN.split(
+                AUTH.split(
                     new RqHeaders.Smart(
                         new RqHeaders.Base(request)
                     ).single("authorization")

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -50,7 +50,7 @@ import org.takes.rs.RsWithHeader;
  * <p>The class is immutable and thread-safe.
  *
  * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id$
+ * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
  * @since 0.20
  */
 @EqualsAndHashCode(of = { "entry", "realm" })
@@ -91,11 +91,11 @@ public final class PsBasic implements Pass {
         final String decoded = new String(
             DatatypeConverter.parseBase64Binary(
                 PATTERN.split(
-                        new RqHeaders.Smart(
-                                new RqHeaders.Base(request)
-                                )
+                    new RqHeaders.Smart(
+                        new RqHeaders.Base(request)
+                    )
                         .single("authorization")
-                        )[1]
+                )[1]
             ), StandardCharsets.UTF_8
         ).trim();
         final String user = decoded.split(":")[0];
@@ -130,7 +130,7 @@ public final class PsBasic implements Pass {
      * valid.
      *
      * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id$
+     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
      * @since 0.20
      */
     public interface Entry {
@@ -150,7 +150,7 @@ public final class PsBasic implements Pass {
      * <p>The class is immutable and thread-safe.
      *
      * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id$
+     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
      * @since 0.20
      *
      */
@@ -189,7 +189,7 @@ public final class PsBasic implements Pass {
      * Empty check.
      *
      * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id$
+     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
      * @since 0.20
      */
     public static final class Empty implements PsBasic.Entry {
@@ -204,7 +204,7 @@ public final class PsBasic implements Pass {
      * Default entry.
      *
      * @author Georgy Vlasov (wlasowegor@gmail.com)
-     * @version $Id$
+     * @version $Id: 5913e70e4877ecdd3f0cb85821dd8593f48a166a $
      * @since 0.22
      */
     public static final class Default implements PsBasic.Entry {

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
-
 import javax.xml.bind.DatatypeConverter;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
@@ -65,7 +64,7 @@ public final class PsBasic implements Pass {
     /**
      * Split pattern.
      */
-	private static final Pattern SPLIT_PATTERN = Pattern.compile(PsBasic.AUTH_HEAD);
+    private static final Pattern PATTERN = Pattern.compile(PsBasic.AUTH_HEAD);
 
     /**
      * Entry to validate user information.
@@ -91,10 +90,12 @@ public final class PsBasic implements Pass {
     public Opt<Identity> enter(final Request request) throws IOException {
         final String decoded = new String(
             DatatypeConverter.parseBase64Binary(
-                SPLIT_PATTERN.split(
+                PATTERN.split(
                         new RqHeaders.Smart(
-                                new RqHeaders.Base(request))
-                        .single("authorization"))[1]
+                                new RqHeaders.Base(request)
+                                )
+                        .single("authorization")
+                        )[1]
             ), StandardCharsets.UTF_8
         ).trim();
         final String user = decoded.split(":")[0];

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -32,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
+
 import javax.xml.bind.DatatypeConverter;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
@@ -59,6 +61,11 @@ public final class PsBasic implements Pass {
      * Authorization response HTTP head.
      */
     private static final String AUTH_HEAD = "Basic";
+    
+	/**
+	 * Split pattern.
+	 */
+	private static final Pattern splitPattern = Pattern.compile(PsBasic.AUTH_HEAD);
 
     /**
      * Entry to validate user information.
@@ -84,9 +91,7 @@ public final class PsBasic implements Pass {
     public Opt<Identity> enter(final Request request) throws IOException {
         final String decoded = new String(
             DatatypeConverter.parseBase64Binary(
-                new RqHeaders.Smart(
-                    new RqHeaders.Base(request)
-                ).single("authorization").split(PsBasic.AUTH_HEAD)[1]
+                splitPattern.split(new RqHeaders.Smart(new RqHeaders.Base(request)).single("authorization"))[1]
             ), StandardCharsets.UTF_8
         ).trim();
         final String user = decoded.split(":")[0];

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -61,11 +61,11 @@ public final class PsBasic implements Pass {
      * Authorization response HTTP head.
      */
     private static final String AUTH_HEAD = "Basic";
-    
-	/**
-	 * Split pattern.
-	 */
-	private static final Pattern splitPattern = Pattern.compile(PsBasic.AUTH_HEAD);
+
+    /**
+     * Split pattern.
+     */
+	private static final Pattern SPLIT_PATTERN = Pattern.compile(PsBasic.AUTH_HEAD);
 
     /**
      * Entry to validate user information.
@@ -91,7 +91,10 @@ public final class PsBasic implements Pass {
     public Opt<Identity> enter(final Request request) throws IOException {
         final String decoded = new String(
             DatatypeConverter.parseBase64Binary(
-                splitPattern.split(new RqHeaders.Smart(new RqHeaders.Base(request)).single("authorization"))[1]
+                SPLIT_PATTERN.split(
+                        new RqHeaders.Smart(
+                                new RqHeaders.Base(request))
+                        .single("authorization"))[1]
             ), StandardCharsets.UTF_8
         ).trim();
         final String user = decoded.split(":")[0];

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -42,7 +42,7 @@ import org.takes.tk.TkFixed;
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @version $Id$
+ * @version $Id: 0f621de76a6b6bcc446242289b2e8ae1b4a67fc4 $
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)
@@ -83,9 +83,9 @@ public final class FbStatus extends FbWrap {
                             res,
                             String.format(
                                 "%s: %s", SPLIT_PATTERN.split(
-                                     res.head().iterator().next(),
-                                     2
-                                     )[1], req.throwable().getLocalizedMessage()
+                                    res.head().iterator().next(),
+                                    2
+                                )[1], req.throwable().getLocalizedMessage()
                             )
                         ), "text/plain"
                     )

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -42,16 +42,16 @@ import org.takes.tk.TkFixed;
  *
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @version $Id: 0f621de76a6b6bcc446242289b2e8ae1b4a67fc4 $
+ * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)
 public final class FbStatus extends FbWrap {
 
     /**
-     * Split pattern.
+     * Whitespace pattern, used for splitting.
      */
-    private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s");
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
 
     /**
      * Ctor.
@@ -82,7 +82,7 @@ public final class FbStatus extends FbWrap {
                         new RsWithBody(
                             res,
                             String.format(
-                                "%s: %s", SPLIT_PATTERN.split(
+                                "%s: %s", WHITESPACE_PATTERN.split(
                                     res.head().iterator().next(),
                                     2
                                 )[1], req.throwable().getLocalizedMessage()

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -49,11 +49,11 @@ import org.takes.tk.TkFixed;
 @EqualsAndHashCode(callSuper = true)
 public final class FbStatus extends FbWrap {
 	
-	/**
-	 * Split pattern.
-	 */
-	private static final Pattern splitPattern = Pattern.compile("\\s");
-	
+    /**
+     * Split pattern.
+     */
+	private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s");
+
     /**
      * Ctor.
      * @param code HTTP status code
@@ -84,7 +84,7 @@ public final class FbStatus extends FbWrap {
                             res,
                             String.format(
                                 "%s: %s",
-                                splitPattern.split(res.head().iterator().next(), 2)[1],
+                                SPLIT_PATTERN.split(res.head().iterator().next(), 2)[1],
                                 req.throwable().getLocalizedMessage()
                             )
                         ),

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -24,6 +24,8 @@
 package org.takes.facets.fallback;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
+
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
 import org.takes.Take;
@@ -46,6 +48,12 @@ import org.takes.tk.TkFixed;
  */
 @EqualsAndHashCode(callSuper = true)
 public final class FbStatus extends FbWrap {
+	
+	/**
+	 * Split pattern.
+	 */
+	private static final Pattern splitPattern = Pattern.compile("\\s");
+	
     /**
      * Ctor.
      * @param code HTTP status code
@@ -76,7 +84,7 @@ public final class FbStatus extends FbWrap {
                             res,
                             String.format(
                                 "%s: %s",
-                                res.head().iterator().next().split("\\s", 2)[1],
+                                splitPattern.split(res.head().iterator().next(), 2)[1],
                                 req.throwable().getLocalizedMessage()
                             )
                         ),

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -25,7 +25,6 @@ package org.takes.facets.fallback;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
-
 import lombok.EqualsAndHashCode;
 import org.takes.Response;
 import org.takes.Take;
@@ -48,11 +47,11 @@ import org.takes.tk.TkFixed;
  */
 @EqualsAndHashCode(callSuper = true)
 public final class FbStatus extends FbWrap {
-	
+
     /**
      * Split pattern.
      */
-	private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s");
+    private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s");
 
     /**
      * Ctor.
@@ -83,12 +82,12 @@ public final class FbStatus extends FbWrap {
                         new RsWithBody(
                             res,
                             String.format(
-                                "%s: %s",
-                                SPLIT_PATTERN.split(res.head().iterator().next(), 2)[1],
-                                req.throwable().getLocalizedMessage()
+                                "%s: %s", SPLIT_PATTERN.split(
+                                     res.head().iterator().next(),
+                                     2
+                                     )[1], req.throwable().getLocalizedMessage()
                             )
-                        ),
-                        "text/plain"
+                        ), "text/plain"
                     )
                 );
             }

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -51,7 +51,7 @@ public final class FbStatus extends FbWrap {
     /**
      * Whitespace pattern, used for splitting.
      */
-    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
+    private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s");
 
     /**
      * Ctor.
@@ -82,7 +82,7 @@ public final class FbStatus extends FbWrap {
                         new RsWithBody(
                             res,
                             String.format(
-                                "%s: %s", WHITESPACE_PATTERN.split(
+                                "%s: %s", SPLIT_PATTERN.split(
                                     res.head().iterator().next(),
                                     2
                                 )[1], req.throwable().getLocalizedMessage()

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -51,7 +51,7 @@ public final class FbStatus extends FbWrap {
     /**
      * Whitespace pattern, used for splitting.
      */
-    private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s");
+    private static final Pattern WHITESPACE = Pattern.compile("\\s");
 
     /**
      * Ctor.
@@ -82,7 +82,7 @@ public final class FbStatus extends FbWrap {
                         new RsWithBody(
                             res,
                             String.format(
-                                "%s: %s", SPLIT_PATTERN.split(
+                                "%s: %s", WHITESPACE.split(
                                     res.head().iterator().next(),
                                     2
                                 )[1], req.throwable().getLocalizedMessage()

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -61,9 +61,9 @@ import org.takes.rq.RqHeaders;
 public final class FkEncoding implements Fork {
 
     /**
-     * Realm.
+     * Accept-Encoding separator.
      */
-    private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s*,\\s*");
+    private static final Pattern ENCODING_SEP = Pattern.compile("\\s*,\\s*");
 
     /**
      * Encoding we can deliver (or empty string).
@@ -94,7 +94,7 @@ public final class FkEncoding implements Fork {
             resp = new Opt.Single<Response>(this.origin);
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
-                SPLIT_PATTERN.split(
+                ENCODING_SEP.split(
                     headers.next()
                         .trim()
                         .toLowerCase(Locale.ENGLISH)

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -61,15 +61,15 @@ import org.takes.rq.RqHeaders;
 @EqualsAndHashCode(of = { "encoding", "origin" })
 public final class FkEncoding implements Fork {
 
-	/**
-	 * Split pattern.
-	 */
-	private static final Pattern splitPattern = Pattern.compile("\\s*,\\s*");
-	
+    /**
+     * Split pattern.
+     */
+	private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s*,\\s*");
+
     /**
      * Encoding we can deliver (or empty string).
      */
-    private final transient String encoding;
+	private final transient String encoding;
 
     /**
      * Response to return.
@@ -95,7 +95,8 @@ public final class FkEncoding implements Fork {
             resp = new Opt.Single<Response>(this.origin);
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
-            	splitPattern.split(headers.next().trim().toLowerCase(Locale.ENGLISH))
+                    SPLIT_PATTERN.split(headers.next().trim()
+                            .toLowerCase(Locale.ENGLISH))
             );
             if (items.contains(this.encoding)) {
                 resp = new Opt.Single<Response>(this.origin);

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.regex.Pattern;
-
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
 import org.takes.Response;
@@ -62,14 +61,14 @@ import org.takes.rq.RqHeaders;
 public final class FkEncoding implements Fork {
 
     /**
-     * Split pattern.
+     * Realm.
      */
-	private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s*,\\s*");
+    private static final Pattern SPLIT_PATTERN = Pattern.compile("\\s*,\\s*");
 
     /**
      * Encoding we can deliver (or empty string).
      */
-	private final transient String encoding;
+    private final transient String encoding;
 
     /**
      * Response to return.
@@ -95,8 +94,11 @@ public final class FkEncoding implements Fork {
             resp = new Opt.Single<Response>(this.origin);
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
-                    SPLIT_PATTERN.split(headers.next().trim()
-                            .toLowerCase(Locale.ENGLISH))
+                    SPLIT_PATTERN.split(
+                            headers.next()
+                            .trim()
+                            .toLowerCase(Locale.ENGLISH)
+                            )
             );
             if (items.contains(this.encoding)) {
                 resp = new Opt.Single<Response>(this.origin);

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Locale;
+import java.util.regex.Pattern;
+
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
 import org.takes.Response;
@@ -59,6 +61,11 @@ import org.takes.rq.RqHeaders;
 @EqualsAndHashCode(of = { "encoding", "origin" })
 public final class FkEncoding implements Fork {
 
+	/**
+	 * Split pattern.
+	 */
+	private static final Pattern splitPattern = Pattern.compile("\\s*,\\s*");
+	
     /**
      * Encoding we can deliver (or empty string).
      */
@@ -88,9 +95,7 @@ public final class FkEncoding implements Fork {
             resp = new Opt.Single<Response>(this.origin);
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
-                headers.next().trim()
-                    .toLowerCase(Locale.ENGLISH)
-                    .split("\\s*,\\s*")
+            	splitPattern.split(headers.next().trim().toLowerCase(Locale.ENGLISH))
             );
             if (items.contains(this.encoding)) {
                 resp = new Opt.Single<Response>(this.origin);

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -53,7 +53,7 @@ import org.takes.rq.RqHeaders;
  *
  * <p>The class is immutable and thread-safe.
  * @author Yegor Bugayenko (yegor@teamed.io)
- * @version $Id$
+ * @version $Id: a38ce59de8810b15af2763d253fd5b2a7833976c $
  * @see org.takes.facets.fork.RsFork
  * @since 0.10
  */
@@ -94,11 +94,11 @@ public final class FkEncoding implements Fork {
             resp = new Opt.Single<Response>(this.origin);
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
-                    SPLIT_PATTERN.split(
-                            headers.next()
-                            .trim()
-                            .toLowerCase(Locale.ENGLISH)
-                            )
+                SPLIT_PATTERN.split(
+                    headers.next()
+                        .trim()
+                        .toLowerCase(Locale.ENGLISH)
+                )
             );
             if (items.contains(this.encoding)) {
                 resp = new Opt.Single<Response>(this.origin);

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -53,7 +53,7 @@ import org.takes.rq.RqHeaders;
  *
  * <p>The class is immutable and thread-safe.
  * @author Yegor Bugayenko (yegor@teamed.io)
- * @version $Id: a38ce59de8810b15af2763d253fd5b2a7833976c $
+ * @version $Id$
  * @see org.takes.facets.fork.RsFork
  * @since 0.10
  */


### PR DESCRIPTION
Bug #597. Replaces String.split(regexp), with regexp that is at least 2 character long, by private static final Pattern field.