### PR TITLE
#573 Unstable Travis-CI Build

### DIFF
--- a/src/test/java/org/takes/http/BkTimeableTest.java
+++ b/src/test/java/org/takes/http/BkTimeableTest.java
@@ -23,6 +23,8 @@
  */
 package org.takes.http;
 
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -37,8 +39,6 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rs.RsText;
-import com.jcabi.http.request.JdkRequest;
-import com.jcabi.http.response.RestResponse;
 
 /**
  * Test case for {@link BkTimeable}.
@@ -101,21 +101,21 @@ public final class BkTimeableTest {
                             "--threads=1",
                             "--lifetime=4000",
                             "--max-latency=100"
-                            ).start(exit);
+                        ).start(exit);
                     } catch (final IOException ex) {
                         throw new IllegalStateException(ex);
                     }
                 }
             }
-            );
+        );
         thread.start();
         ready.await();
         final int port = Integer.parseInt(FileUtils.readFileToString(file));
         new JdkRequest(String.format("http://localhost:%d", port))
-        .fetch()
-        .as(RestResponse.class)
-        .assertStatus(HttpURLConnection.HTTP_OK)
-        .assertBody(Matchers.startsWith(response));
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.startsWith(response));
         try {
             thread.join();
         } catch (final InterruptedException ex) {

--- a/src/test/java/org/takes/http/BkTimeableTest.java
+++ b/src/test/java/org/takes/http/BkTimeableTest.java
@@ -23,8 +23,6 @@
  */
 package org.takes.http;
 
-import com.jcabi.http.request.JdkRequest;
-import com.jcabi.http.response.RestResponse;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -39,6 +37,8 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rs.RsText;
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
 
 /**
  * Test case for {@link BkTimeable}.
@@ -99,23 +99,23 @@ public final class BkTimeableTest {
                             take,
                             String.format("--port=%s", file.getAbsoluteFile()),
                             "--threads=1",
-                            "--lifetime=3000",
+                            "--lifetime=4000",
                             "--max-latency=100"
-                        ).start(exit);
+                            ).start(exit);
                     } catch (final IOException ex) {
                         throw new IllegalStateException(ex);
                     }
                 }
             }
-        );
+            );
         thread.start();
         ready.await();
         final int port = Integer.parseInt(FileUtils.readFileToString(file));
         new JdkRequest(String.format("http://localhost:%d", port))
-            .fetch()
-            .as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.startsWith(response));
+        .fetch()
+        .as(RestResponse.class)
+        .assertStatus(HttpURLConnection.HTTP_OK)
+        .assertBody(Matchers.startsWith(response));
         try {
             thread.join();
         } catch (final InterruptedException ex) {

--- a/src/test/java/org/takes/http/FtCLITest.java
+++ b/src/test/java/org/takes/http/FtCLITest.java
@@ -23,8 +23,6 @@
  */
 package org.takes.http;
 
-import com.jcabi.http.request.JdkRequest;
-import com.jcabi.http.response.RestResponse;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -36,6 +34,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
 
 /**
  * Test case for {@link FtCLI}.
@@ -79,22 +79,22 @@ public final class FtCLITest {
                             new TkFork(new FkRegex("/", "hello!")),
                             String.format("--port=%s", file.getAbsoluteFile()),
                             "--threads=1",
-                            "--lifetime=3000"
-                        ).start(exit);
+                            "--lifetime=4000"
+                            ).start(exit);
                     } catch (final IOException ex) {
                         throw new IllegalStateException(ex);
                     }
                 }
             }
-        );
+            );
         thread.start();
         ready.await();
         final int port = Integer.parseInt(FileUtils.readFileToString(file));
         new JdkRequest(String.format("http://localhost:%d", port))
-            .fetch()
-            .as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.startsWith("hello"));
+        .fetch()
+        .as(RestResponse.class)
+        .assertStatus(HttpURLConnection.HTTP_OK)
+        .assertBody(Matchers.startsWith("hello"));
         try {
             thread.join();
         } catch (final InterruptedException ex) {

--- a/src/test/java/org/takes/http/FtCLITest.java
+++ b/src/test/java/org/takes/http/FtCLITest.java
@@ -23,6 +23,8 @@
  */
 package org.takes.http;
 
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -34,8 +36,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
-import com.jcabi.http.request.JdkRequest;
-import com.jcabi.http.response.RestResponse;
 
 /**
  * Test case for {@link FtCLI}.
@@ -80,21 +80,21 @@ public final class FtCLITest {
                             String.format("--port=%s", file.getAbsoluteFile()),
                             "--threads=1",
                             "--lifetime=4000"
-                            ).start(exit);
+                        ).start(exit);
                     } catch (final IOException ex) {
                         throw new IllegalStateException(ex);
                     }
                 }
             }
-            );
+        );
         thread.start();
         ready.await();
         final int port = Integer.parseInt(FileUtils.readFileToString(file));
         new JdkRequest(String.format("http://localhost:%d", port))
-        .fetch()
-        .as(RestResponse.class)
-        .assertStatus(HttpURLConnection.HTTP_OK)
-        .assertBody(Matchers.startsWith("hello"));
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.startsWith("hello"));
         try {
             thread.join();
         } catch (final InterruptedException ex) {


### PR DESCRIPTION
Bug #573 Unstable Travis-CI Build. 

After increase the amount of lifetime of the ServerSocket, the unstable builds in travis doesn't occur anymore.

**List of changes**
- BkTimeableTest: Increased the lifetime of the ServerSocket to 4000ms;
- FtCLITest: Increased the lifetime of the ServerSocket to 4000ms.