### PR TITLE
Refactor String.replaceAll() to Matcher.replaceAll()

### DIFF
--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -24,6 +24,7 @@
 package org.takes.facets.fork;
 
 import java.util.Locale;
+import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -40,6 +41,11 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode(of = { "high", "low" })
 final class MediaType implements Comparable<MediaType> {
+
+    /**
+     * Media type priority clean pattern.
+     */
+    private static final Pattern CLEANER = Pattern.compile("[^0-9\\.]");
 
     /**
      * Priority.
@@ -112,7 +118,7 @@ final class MediaType implements Comparable<MediaType> {
         final String[] parts = MediaType.split(text);
         final Double priority;
         if (parts.length > 1) {
-            final String num = parts[1].replaceAll("[^0-9\\.]", "");
+            final String num = CLEANER.matcher(parts[1]).replaceAll("");
             if (num.isEmpty()) {
                 priority = 0.0d;
             } else {

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -43,9 +43,9 @@ import lombok.ToString;
 final class MediaType implements Comparable<MediaType> {
 
     /**
-     * Media type priority clean pattern.
+     * Pattern matching non-digit symbols.
      */
-    private static final Pattern CLEANER = Pattern.compile("[^0-9\\.]");
+    private static final Pattern NON_DIGITS = Pattern.compile("[^0-9\\.]");
 
     /**
      * Priority.
@@ -118,7 +118,8 @@ final class MediaType implements Comparable<MediaType> {
         final String[] parts = MediaType.split(text);
         final Double priority;
         if (parts.length > 1) {
-            final String num = CLEANER.matcher(parts[1]).replaceAll("");
+            final String num =
+                MediaType.NON_DIGITS.matcher(parts[1]).replaceAll("");
             if (num.isEmpty()) {
                 priority = 0.0d;
             } else {

--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 /**
  * HTTP URI/HREF.
@@ -52,6 +53,11 @@ import java.util.TreeMap;
         }
     )
 public final class Href implements CharSequence {
+
+    /**
+     * Trailer slash pattern.
+     */
+    private static final Pattern TRAILER = Pattern.compile("/$");
 
     /**
      * URI (without the query part).
@@ -195,9 +201,11 @@ public final class Href implements CharSequence {
     public Href path(final Object suffix) {
         return new Href(
             URI.create(
-                new StringBuilder(this.uri.toString().replaceAll("/$", ""))
-                    .append('/')
-                    .append(Href.encode(suffix.toString())).toString()
+                new StringBuilder(
+                    TRAILER.matcher(this.uri.toString()).replaceAll("")
+                )
+                .append('/')
+                .append(Href.encode(suffix.toString())).toString()
             ),
             this.params
         );

--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -55,9 +55,9 @@ import java.util.regex.Pattern;
 public final class Href implements CharSequence {
 
     /**
-     * Trailer slash pattern.
+     * Pattern matching trailing slash.
      */
-    private static final Pattern TRAILER = Pattern.compile("/$");
+    private static final Pattern TRAILING_SLASH = Pattern.compile("/$");
 
     /**
      * URI (without the query part).
@@ -202,7 +202,8 @@ public final class Href implements CharSequence {
         return new Href(
             URI.create(
                 new StringBuilder(
-                    TRAILER.matcher(this.uri.toString()).replaceAll("")
+                    Href.TRAILING_SLASH.matcher(this.uri.toString())
+                        .replaceAll("")
                 )
                 .append('/')
                 .append(Href.encode(suffix.toString())).toString()


### PR DESCRIPTION
Fix for #596.

* Refactor `String.replaceAll(`) to `Matcher.replaceAll()`.