### PR TITLE
533: Create explicitly a mock socket

### DIFF
--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -31,9 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
@@ -96,7 +94,7 @@ public final class BkBasicTest {
      */
     @Test
     public void handlesSocket() throws IOException {
-        final BkBasicTest.MkSocket socket = createMockSocket();
+        final MkSocket socket = BkBasicTest.createMockSocket();
         final ByteArrayOutputStream baos = socket.bufferedOutput();
         new BkBasic(new TkText("Hello world!")).accept(socket);
         MatcherAssert.assertThat(
@@ -367,38 +365,9 @@ public final class BkBasicTest {
      * @return Prepared Socket mock
      * @throws IOException If some problem inside
      */
-    private static BkBasicTest.MkSocket createMockSocket() throws IOException {
-        return new BkBasicTest.MkSocket();
-    }
-
-    /**
-     * Socket mock for reuse.
-     */
-    private static final class MkSocket extends Socket {
-
-        /**
-         * The address to provide for testing purpose.
-         */
-        private final transient InetAddress address;
-        /**
-         * The output stream of the socket.
-         */
-        private final transient ByteArrayOutputStream output;
-
-        /**
-         * Constructs a {@code MkSocket}.
-         * @throws IOException in case the call to
-         *  {@link InetAddress#getLocalHost()} fails.
-         */
-        private MkSocket() throws IOException {
-            super();
-            this.address = InetAddress.getLocalHost();
-            this.output = new ByteArrayOutputStream();
-        }
-
-        @Override
-        public InputStream getInputStream() {
-            return new ByteArrayInputStream(
+    private static MkSocket createMockSocket() throws IOException {
+        return new MkSocket(
+            new ByteArrayInputStream(
                 Joiner.on(BkBasicTest.CRLF).join(
                     "GET / HTTP/1.1",
                     "Host:localhost",
@@ -406,41 +375,7 @@ public final class BkBasicTest {
                     "",
                     "hi"
                 ).getBytes()
-            );
-        }
-
-        @Override
-        public OutputStream getOutputStream() {
-            return this.output;
-        }
-
-        @Override
-        public InetAddress getInetAddress() {
-            return this.address;
-        }
-
-        @Override
-        public InetAddress getLocalAddress() {
-            return this.address;
-        }
-
-        @Override
-        public int getPort() {
-            return 0;
-        }
-
-        @Override
-        public int getLocalPort() {
-            return 0;
-        }
-
-        /**
-         * Gives the output stream in {@link ByteArrayOutputStream} to be
-         * able to test it.
-         * @return The output in {@link ByteArrayOutputStream}.
-         */
-        private ByteArrayOutputStream bufferedOutput() {
-            return this.output;
-        }
+            )
+        );
     }
 }

--- a/src/test/java/org/takes/http/MkSocket.java
+++ b/src/test/java/org/takes/http/MkSocket.java
@@ -24,7 +24,6 @@
 package org.takes.http;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
@@ -57,12 +56,10 @@ public final class MkSocket  extends Socket {
     /**
      * Constructs a {@code MkSocket} with the specified input stream.
      * @param input The input stream of the socket.
-     * @throws IOException in case the call to
-     *  {@link InetAddress#getLocalHost()} fails.
      */
-    public MkSocket(final InputStream input) throws IOException {
+    public MkSocket(final InputStream input) {
         super();
-        this.address = InetAddress.getLocalHost();
+        this.address = InetAddress.getLoopbackAddress();
         this.output = new ByteArrayOutputStream();
         this.input = input;
     }

--- a/src/test/java/org/takes/http/MkSocket.java
+++ b/src/test/java/org/takes/http/MkSocket.java
@@ -1,0 +1,108 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+
+/**
+ * Socket mock for reuse.
+ *
+ * @author Nicolas Filotto (nicolas.filotto@gmail.com)
+ * @version $Id$
+ * @since 0.31
+ */
+public final class MkSocket  extends Socket {
+
+    /**
+     * The address to provide for testing purpose.
+     */
+    private final transient InetAddress address;
+
+    /**
+     * The output stream of the socket.
+     */
+    private final transient ByteArrayOutputStream output;
+
+    /**
+     * The input stream of the socket.
+     */
+    private final transient InputStream input;
+
+    /**
+     * Constructs a {@code MkSocket} with the specified input stream.
+     * @param input The input stream of the socket.
+     * @throws IOException in case the call to
+     *  {@link InetAddress#getLocalHost()} fails.
+     */
+    public MkSocket(final InputStream input) throws IOException {
+        super();
+        this.address = InetAddress.getLocalHost();
+        this.output = new ByteArrayOutputStream();
+        this.input = input;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return this.input;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return this.output;
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return this.address;
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return this.address;
+    }
+
+    @Override
+    public int getPort() {
+        return 0;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    /**
+     * Gives the output stream in {@link ByteArrayOutputStream} to be
+     * able to test it.
+     * @return The output in {@link ByteArrayOutputStream}.
+     */
+    public ByteArrayOutputStream bufferedOutput() {
+        return this.output;
+    }
+}

--- a/src/test/java/org/takes/http/MkSocket.java
+++ b/src/test/java/org/takes/http/MkSocket.java
@@ -35,7 +35,7 @@ import java.net.Socket;
  *
  * @author Nicolas Filotto (nicolas.filotto@gmail.com)
  * @version $Id$
- * @since 0.31
+ * @since 0.32
  */
 public final class MkSocket  extends Socket {
 


### PR DESCRIPTION
Fix for https://github.com/yegor256/takes/issues/533:

Followed the principale described [here](http://www.yegor256.com/2014/09/23/built-in-fake-objects.html) by replacing a mock created with Mockito with an explicit mock Socket called MkSocket.