### PR TITLE
#623 PsGoogle throws NPE 

### DIFF
--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -195,7 +195,12 @@ public final class PsGoogle implements Pass {
         } else {
             props.put("picture", image.getString("url", "#"));
         }
-        props.put("name", json.getString("displayName", "unknown"));
+        if (json.containsKey("displayName")
+            && json.get("displayName") != null) {
+            props.put("name", json.getString("displayName"));
+        } else {
+            props.put("name", "unknown");
+        }
         return new Identity.Simple(
             String.format("urn:google:%s", json.getString("id")), props
         );

--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -148,11 +148,19 @@ public final class PsGoogle implements Pass {
             .path("me")
             .with("access_token", token)
             .toString();
-        return PsGoogle.parse(
-            new JdkRequest(uri).fetch()
-                .as(JsonResponse.class).json()
-                .readObject()
-        );
+        final JsonObject json = new JdkRequest(uri).fetch()
+            .as(JsonResponse.class).json()
+            .readObject();
+        if (json.containsKey("error")) {
+            throw new HttpException(
+                HttpURLConnection.HTTP_BAD_REQUEST,
+                String.format(
+                    "could not retrieve id from Google, possible cause: %s.",
+                    json.get("message")
+                )
+            );
+        }
+        return PsGoogle.parse(json);
     }
 
     /**

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -24,6 +24,7 @@
 package org.takes.facets.auth.social;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import javax.json.Json;
 import org.hamcrest.MatcherAssert;
@@ -52,7 +53,37 @@ import org.takes.rs.RsJSON;
  * @since 0.16.3
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class PsGoogleTest {
+
+    /**
+     * Code parameter.
+     */
+    private static final String CODE = "code";
+    /**
+     * Google token parameter.
+     */
+    private static final String GOOGLE_TOKEN = "GoogleToken";
+    /**
+     * Avatar google url.
+     */
+    private static final String AVATAR = "https://google.com/img/avatar.gif";
+    /**
+     * XPath access_token string.
+     */
+    private static final String ACCESS_TOKEN = "access_token";
+    /**
+     * Account url.
+     */
+    private static final String ACCOUNT = "http://localhost/account";
+    /**
+     * Key request parameter.
+     */
+    private static final String KEY = "key";
+    /**
+     * App request parameter.
+     */
+    private static final String APP = "app";
     /**
      * PsGoogle login.
      * @checkstyle MultipleStringLiteralsCheck (100 lines)
@@ -61,40 +92,7 @@ public final class PsGoogleTest {
     @Test
     public void logsIn() throws Exception {
         final Take take = new TkFork(
-            new FkRegex(
-                "/o/oauth2/token",
-                // @checkstyle AnonInnerLengthCheck (1 line)
-                new Take() {
-                    @Override
-                    public Response act(final Request req) throws IOException {
-                        MatcherAssert.assertThat(
-                            new RqPrint(req).printHead(),
-                            Matchers.containsString("POST /o/oauth2/token")
-                        );
-                        final Request greq = new RqGreedy(req);
-                        PsGoogleTest.assertParam(greq, "client_id", "app");
-                        PsGoogleTest.assertParam(
-                            greq,
-                            "redirect_uri",
-                            "http://localhost/account"
-                        );
-                        PsGoogleTest.assertParam(greq, "client_secret", "key");
-                        PsGoogleTest.assertParam(
-                            greq,
-                            "grant_type",
-                            "authorization_code"
-                        );
-                        PsGoogleTest.assertParam(greq, "code", "code");
-                        return new RsJSON(
-                            Json.createObjectBuilder()
-                                .add("access_token", "GoogleToken")
-                                .add("expires_in", 1)
-                                .add("token_type", "Bearer")
-                                .build()
-                        );
-                    }
-                }
-            ),
+            this.requestToken(),
             new FkRegex(
                 "/plus/v1/people/me",
                 // @checkstyle AnonInnerLengthCheck (1 line)
@@ -108,9 +106,10 @@ public final class PsGoogleTest {
                             )
                         );
                         MatcherAssert.assertThat(
-                            new RqHref.Base(req).href().param("access_token")
+                            new RqHref.Base(req).href()
+                                .param(PsGoogleTest.ACCESS_TOKEN)
                                 .iterator().next(),
-                            Matchers.containsString("GoogleToken")
+                            Matchers.containsString(PsGoogleTest.GOOGLE_TOKEN)
                         );
                         return new RsJSON(
                             Json.createObjectBuilder()
@@ -121,7 +120,7 @@ public final class PsGoogleTest {
                                     Json.createObjectBuilder()
                                         .add(
                                             "url",
-                                            "https://google.com/img/avatar.gif"
+                                            PsGoogleTest.AVATAR
                                         )
                                 )
                                 .build()
@@ -136,9 +135,9 @@ public final class PsGoogleTest {
                 @Override
                 public void exec(final URI home) throws IOException {
                     final Identity identity = new PsGoogle(
-                        "app",
-                        "key",
-                        "http://localhost/account",
+                        PsGoogleTest.APP,
+                        PsGoogleTest.KEY,
+                        PsGoogleTest.ACCOUNT,
                         home.toString(),
                         home.toString()
                     ).enter(new RqFake("GET", "?code=code")).get();
@@ -152,7 +151,182 @@ public final class PsGoogleTest {
                     );
                     MatcherAssert.assertThat(
                         identity.properties().get("picture"),
-                        Matchers.equalTo("https://google.com/img/avatar.gif")
+                        Matchers.equalTo(PsGoogleTest.AVATAR)
+                    );
+                }
+            }
+        );
+    }
+    /**
+     * PsGoogle login with fail due a bad response from google.
+     * @checkstyle MultipleStringLiteralsCheck (100 lines)
+     * @throws Exception If some problem inside
+     */
+    @Test(expected = IOException.class)
+    public void badGoogleResponse() throws Exception {
+        final Take take = new TkFork(
+            this.requestToken(),
+            new FkRegex(
+                "/plus/v1/people/me",
+                // @checkstyle AnonInnerLengthCheck (1 line)
+                new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        MatcherAssert.assertThat(
+                            new RqPrint(req).printHead(),
+                            Matchers.containsString(
+                                "GET /plus/v1/people/me"
+                            )
+                        );
+                        MatcherAssert.assertThat(
+                            new RqHref.Base(req).href()
+                                .param(PsGoogleTest.ACCESS_TOKEN)
+                                .iterator().next(),
+                            Matchers.containsString(PsGoogleTest.GOOGLE_TOKEN)
+                        );
+                        return createErrorJson();
+                    }
+                }
+            )
+        );
+        new FtRemote(take).exec(
+            // @checkstyle AnonInnerLengthCheck (100 lines)
+            new FtRemote.Script() {
+                @Override
+                public void exec(final URI home) throws IOException {
+                    new PsGoogle(
+                        PsGoogleTest.APP,
+                        PsGoogleTest.KEY,
+                        PsGoogleTest.ACCOUNT,
+                        home.toString(),
+                        home.toString()
+                    ).enter(new RqFake("GET", "?code=code")).get();
+                }
+            }
+        );
+    }
+    /**
+     * Test a google response without the displayName property.
+     * @checkstyle MultipleStringLiteralsCheck (100 lines)
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void noDisplayNameResponse() throws Exception {
+        final Take take = new TkFork(
+            this.requestToken(),
+            new FkRegex(
+                "/plus/v1/people/me",
+                // @checkstyle AnonInnerLengthCheck (1 line)
+                new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        MatcherAssert.assertThat(
+                            new RqPrint(req).printHead(),
+                            Matchers.containsString(
+                                "GET /plus/v1/people/me"
+                            )
+                        );
+                        MatcherAssert.assertThat(
+                            new RqHref.Base(req).href()
+                                .param(PsGoogleTest.ACCESS_TOKEN)
+                                .iterator().next(),
+                            Matchers.containsString(PsGoogleTest.GOOGLE_TOKEN)
+                        );
+                        return new RsJSON(
+                            Json.createObjectBuilder()
+                                .add("id", "1")
+                                .add(
+                                    "image",
+                                    Json.createObjectBuilder()
+                                        .add(
+                                            "url",
+                                            PsGoogleTest.AVATAR
+                                        )
+                                )
+                                .build()
+                        );
+                    }
+                }
+            )
+        );
+        new FtRemote(take).exec(
+            // @checkstyle AnonInnerLengthCheck (100 lines)
+            new FtRemote.Script() {
+                @Override
+                public void exec(final URI home) throws IOException {
+                    final Identity identity = new PsGoogle(
+                        PsGoogleTest.APP,
+                        PsGoogleTest.KEY,
+                        PsGoogleTest.ACCOUNT,
+                        home.toString(),
+                        home.toString()
+                    ).enter(new RqFake("GET", "?code=code")).get();
+                    MatcherAssert.assertThat(
+                        identity.urn(),
+                        Matchers.equalTo("urn:google:1")
+                    );
+                    MatcherAssert.assertThat(
+                        identity.properties().get("name"),
+                        Matchers.equalTo("unknown")
+                    );
+                    MatcherAssert.assertThat(
+                        identity.properties().get("picture"),
+                        Matchers.equalTo(PsGoogleTest.AVATAR)
+                    );
+                }
+            }
+        );
+    }
+    /**
+     * Build a token request fork.
+     * @return Returns the token request
+     */
+    private FkRegex requestToken() {
+        return new FkRegex(
+            "/o/oauth2/token",
+            // @checkstyle AnonInnerLengthCheck (1 line)
+            new Take() {
+                @Override
+                public Response act(final Request req) throws IOException {
+                    MatcherAssert.assertThat(
+                        new RqPrint(req).printHead(),
+                        Matchers.containsString("POST /o/oauth2/token")
+                    );
+                    final Request greq = new RqGreedy(req);
+                    PsGoogleTest.assertParam(
+                        greq,
+                        "client_id",
+                        PsGoogleTest.APP
+                    );
+                    PsGoogleTest.assertParam(
+                        greq,
+                        "redirect_uri",
+                        PsGoogleTest.ACCOUNT
+                    );
+                    PsGoogleTest.assertParam(
+                        greq,
+                        "client_secret",
+                        PsGoogleTest.KEY
+                    );
+                    PsGoogleTest.assertParam(
+                        greq,
+                        "grant_type",
+                        "authorization_code"
+                    );
+                    PsGoogleTest.assertParam(
+                        greq,
+                        PsGoogleTest.CODE,
+                        PsGoogleTest.CODE
+                    );
+                    return new RsJSON(
+                        Json.createObjectBuilder()
+                            .add(
+                                PsGoogleTest.ACCESS_TOKEN,
+                                PsGoogleTest.GOOGLE_TOKEN
+                             )
+                            .add("expires_in", 1)
+                            .add("token_type", "Bearer")
+                            .build()
                     );
                 }
             }
@@ -171,6 +345,37 @@ public final class PsGoogleTest {
         MatcherAssert.assertThat(
             new RqForm.Smart(new RqForm.Base(req)).single(param),
             Matchers.equalTo(value)
+        );
+    }
+    /**
+     * Construct a error response with google json syntax for errors.
+     * @return Json with error.
+     * @throws IOException If some problem inside
+     */
+    private static RsJSON createErrorJson() throws IOException {
+        final String message = "message";
+        return new RsJSON(
+            Json.createObjectBuilder()
+                .add(
+                    "error",
+                    Json.createObjectBuilder()
+                        .add(
+                            "errors",
+                            Json.createArrayBuilder()
+                                .add(
+                                    Json.createObjectBuilder()
+                                        .add("domain", "usageLimits")
+                                        .add("reason", "accessNotConfigured")
+                                        .add(
+                                            "extendedHelp",
+                                            "https://developers.google.com"
+                                        )
+                                )
+                            )
+                   )
+                  .add(PsGoogleTest.CODE, HttpURLConnection.HTTP_BAD_REQUEST)
+                  .add(message, "Access Not Configured.")
+                  .build()
         );
     }
 }


### PR DESCRIPTION
**List of changes**

- **PsGoogle**: Before try to use the json property **displayName**, the program certifies if the displayName is present in the json map, also verify if the **error** property is in the map.
- **PsGoogleTest**: Added 2 junit tests in order to test the missing of displayName property and the presence of error property in the google response.

PS: this correction is just to stop the NPE, we have to open another issue to investigate why the **displayName** is not present in the google response.