### PR TITLE
#575 implement close and skip method on CapinputStream

### DIFF
--- a/src/main/java/org/takes/rq/CapInputStream.java
+++ b/src/main/java/org/takes/rq/CapInputStream.java
@@ -99,4 +99,14 @@ final class CapInputStream extends InputStream {
         }
         return readed;
     }
+
+    @Override
+    public long skip(final long num) throws IOException {
+        return this.origin.skip(num);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.origin.close();
+    }
 }

--- a/src/main/java/org/takes/rq/CapInputStream.java
+++ b/src/main/java/org/takes/rq/CapInputStream.java
@@ -34,10 +34,6 @@ import java.io.InputStream;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.16
- * @todo #254:30min CapInputStream should delegate all standard InputStream
- *  calls to it's origin. It's very important in context of closing stream -
- *  right code should close the stream but default InputStream implementation
- *  just throws IOException
  */
 final class CapInputStream extends InputStream {
 

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -141,20 +141,12 @@ public interface RqMultipart extends Request {
         public Base(final Request req) throws IOException {
             super(req);
             final InputStream stream = new RqLengthAware(req).body();
-            try {
-                this.body = Channels.newChannel(stream);
-                try {
-                    this.buffer = ByteBuffer.allocate(
-                        // @checkstyle MagicNumberCheck (1 line)
-                        Math.min(8192, stream.available())
-                    );
-                    this.map = this.requests(req);
-                } finally {
-                    this.body.close();
-                }
-            } finally {
-                stream.close();
-            }
+            this.body = Channels.newChannel(stream);
+            this.buffer = ByteBuffer.allocate(
+                // @checkstyle MagicNumberCheck (1 line)
+                Math.min(8192, stream.available())
+            );
+            this.map = this.requests(req);
         }
         @Override
         public Iterable<Request> part(final CharSequence name) {

--- a/src/test/java/org/takes/rq/CapInputStreamTest.java
+++ b/src/test/java/org/takes/rq/CapInputStreamTest.java
@@ -25,9 +25,11 @@ package org.takes.rq;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Test case for {@link CapInputStream}.
@@ -52,6 +54,37 @@ public final class CapInputStreamTest {
             ).available(),
             Matchers.equalTo(length)
         );
+    }
+
+    /**
+     * CapInputStream can close a stream.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void closesStream() throws IOException {
+        final InputStream stream = Mockito.mock(InputStream.class);
+        final CapInputStream wrapper = new CapInputStream(
+            stream,
+            0L
+        );
+        wrapper.close();
+        Mockito.verify(stream, Mockito.times(1)).close();
+    }
+
+    /**
+     * CapInputStream can skip on a stream.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void skipsOnStream() throws IOException {
+        final long skip = 25L;
+        final InputStream stream = Mockito.mock(InputStream.class);
+        final CapInputStream wrapper = new CapInputStream(
+            stream,
+            50L
+        );
+        wrapper.skip(skip);
+        Mockito.verify(stream, Mockito.times(1)).skip(skip);
     }
 
 }

--- a/src/test/java/org/takes/rq/CapInputStreamTest.java
+++ b/src/test/java/org/takes/rq/CapInputStreamTest.java
@@ -58,31 +58,25 @@ public final class CapInputStreamTest {
 
     /**
      * CapInputStream can close a stream.
-     * @throws IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void closesStream() throws IOException {
+    public void closesStream() throws Exception {
         final InputStream stream = Mockito.mock(InputStream.class);
-        final CapInputStream wrapper = new CapInputStream(
-            stream,
-            0L
-        );
+        final CapInputStream wrapper = new CapInputStream(stream, 0L);
         wrapper.close();
         Mockito.verify(stream, Mockito.times(1)).close();
     }
 
     /**
      * CapInputStream can skip on a stream.
-     * @throws IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void skipsOnStream() throws IOException {
+    public void skipsOnStream() throws Exception {
         final long skip = 25L;
         final InputStream stream = Mockito.mock(InputStream.class);
-        final CapInputStream wrapper = new CapInputStream(
-            stream,
-            50L
-        );
+        final CapInputStream wrapper = new CapInputStream(stream, 50L);
         wrapper.skip(skip);
         Mockito.verify(stream, Mockito.times(1)).skip(skip);
     }


### PR DESCRIPTION
#575 is solved by this.

* Implemented `close` and `skip` on `CapInputStream`
* Added tests verifying that those actually delegate the `close` and `skip` to the stream the class wraps as requested by the Puzzle
**Caveat(?)**
* This entailed removing the finally call closing `stream` from `org.takes.rq.RqMultipart.Base#Base`! which is in line with the behavior tests like `org.takes.rq.RqMultipartTest#returnsCorrectPartLength` assume when they call the close on the `org.takes.rq.RqMultipart.Base#body` manually at the end of the test. The only reason this worked before was that closing on the `CapInputStream` did nothing but throw IOException` => no actual closing ever happened in `org.takes.rq.RqMultipart.Base`.
 * This likely explains #626 and #512 I think, since `CapInputStream` wraps all Request body streams here via `org.takes.rq.RqLengthAware#RqLengthAware`