### PR TITLE
#461 FkContentType should have a Take rather than a Response.

### DIFF
--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -30,6 +30,7 @@ import org.takes.Response;
 import org.takes.Take;
 import org.takes.misc.Opt;
 import org.takes.rq.RqHeaders;
+import org.takes.tk.TkFixed;
 
 /**
  * Fork by Content-type accepted by "Content-Type" HTTP header.
@@ -53,6 +54,15 @@ public final class FkContentType implements Fork {
      * Take to handle the request and dynamically return the response.
      */
     private final transient Take take;
+
+    /**
+     * Ctor.
+     * @param atype Accepted type
+     * @param response Response to return
+     */
+    public FkContentType(final String atype, final Response response) {
+        this(atype, new TkFixed(response));
+    }
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
 import org.takes.Response;
+import org.takes.Take;
 import org.takes.misc.Opt;
 import org.takes.rq.RqHeaders;
 
@@ -40,7 +41,7 @@ import org.takes.rq.RqHeaders;
  * @since 1.0
  * @see RsFork
  */
-@EqualsAndHashCode(of = { "type", "origin" })
+@EqualsAndHashCode(of = { "type", "take" })
 public final class FkContentType implements Fork {
 
     /**
@@ -49,25 +50,25 @@ public final class FkContentType implements Fork {
     private final transient MediaTypes type;
 
     /**
-     * Response to return.
+     * Take to handle the request and dynamically return the response.
      */
-    private final transient Response origin;
+    private final transient Take take;
 
     /**
      * Ctor.
      * @param atype Accepted type
-     * @param response Response to return
+     * @param take Take to handle the request dynamically.
      */
-    public FkContentType(final String atype, final Response response) {
+    public FkContentType(final String atype, final Take take) {
         this.type = new MediaTypes(atype);
-        this.origin = response;
+        this.take = take;
     }
 
     @Override
     public Opt<Response> route(final Request req) throws IOException {
         final Opt<Response> resp;
         if (FkContentType.getType(req).contains(this.type)) {
-            resp = new Opt.Single<Response>(this.origin);
+            resp = new Opt.Single<Response>(this.take.act(req));
         } else {
             resp = new Opt.Empty<Response>();
         }

--- a/src/main/java/org/takes/facets/fork/TkConsumes.java
+++ b/src/main/java/org/takes/facets/fork/TkConsumes.java
@@ -55,7 +55,7 @@ public final class TkConsumes extends TkWrap {
                 public Response act(final Request req) throws IOException {
                     return new RsFork(
                         req,
-                        new FkContentType(type, take.act(req))
+                        new FkContentType(type, take)
                     );
                 }
             }

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -65,14 +65,14 @@ public final class FkContentTypeTest {
             new FkContentType(
                 "text/xml",
                 FkContentTypeTest.createTakeWithEmptyResponse()
-                ).route(
-                    new RqWithHeader(
-                        new RqFake(),
-                        FkContentTypeTest.CONTENT_TYPE,
-                        "*/* "
-                    )
-                ).has(),
-                    Matchers.is(true)
+            ).route(
+                new RqWithHeader(
+                    new RqFake(),
+                    FkContentTypeTest.CONTENT_TYPE,
+                    "*/* "
+                )
+            ).has(),
+                Matchers.is(true)
         );
     }
 
@@ -86,14 +86,14 @@ public final class FkContentTypeTest {
             new FkContentType(
                 "application/json charset=utf-8",
                 FkContentTypeTest.createTakeWithEmptyResponse()
-                ).route(
+            ).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,
                     "images/*"
                 )
             ).has(),
-            Matchers.is(false)
+                Matchers.is(false)
         );
     }
 

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -146,7 +146,7 @@ public final class FkContentTypeTest {
             new FkContentType(
                 FkContentTypeTest.CTYPE,
                 FkContentTypeTest.createTakeWithEmptyResponse()
-                ).route(
+            ).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -29,6 +29,9 @@ import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithHeader;
 import org.takes.rs.RsEmpty;
@@ -59,14 +62,20 @@ public final class FkContentTypeTest {
     @Test
     public void matchesWithAnyTypes() throws IOException {
         MatcherAssert.assertThat(
-            new FkContentType("text/xml", new RsEmpty()).route(
-                new RqWithHeader(
-                    new RqFake(),
-                    FkContentTypeTest.CONTENT_TYPE,
-                    "*/* "
-                )
-            ).has(),
-            Matchers.is(true)
+            new FkContentType(
+                "text/xml", new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        return new RsEmpty();
+                    }
+                }).route(
+                    new RqWithHeader(
+                        new RqFake(),
+                        FkContentTypeTest.CONTENT_TYPE,
+                        "*/* "
+                    )
+                ).has(),
+                    Matchers.is(true)
         );
     }
 
@@ -78,8 +87,12 @@ public final class FkContentTypeTest {
     public void matchesDifferentTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                "application/json charset=utf-8", new RsEmpty()
-            ).route(
+                "application/json charset=utf-8", new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        return new RsEmpty();
+                    }
+                }).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,
@@ -98,8 +111,12 @@ public final class FkContentTypeTest {
     public void matchesIdenticalTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                FkContentTypeTest.CTYPE, new RsEmpty()
-            ).route(
+                FkContentTypeTest.CTYPE, new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        return new RsEmpty();
+                    }
+                }).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,
@@ -117,12 +134,17 @@ public final class FkContentTypeTest {
     @Test
     public void matchesEmptyType() throws IOException {
         MatcherAssert.assertThat(
-            new FkContentType("*/*", new RsEmpty()).route(
-                new RqWithHeader(
-                    new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
-                )
-            ).has(),
-            Matchers.is(true)
+            new FkContentType(
+                "*/*", new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        return new RsEmpty();
+                    }
+                }).route(
+                    new RqWithHeader(
+                        new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
+                    )
+                ).has(), Matchers.is(true)
         );
     }
 
@@ -134,8 +156,12 @@ public final class FkContentTypeTest {
     public void matchesDifferentEncodingsTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                FkContentTypeTest.CTYPE, new RsEmpty()
-            ).route(
+                FkContentTypeTest.CTYPE, new Take() {
+                    @Override
+                    public Response act(final Request req) throws IOException {
+                        return new RsEmpty();
+                    }
+                }).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -63,12 +63,9 @@ public final class FkContentTypeTest {
     public void matchesWithAnyTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                "text/xml", new Take() {
-                    @Override
-                    public Response act(final Request req) throws IOException {
-                        return new RsEmpty();
-                    }
-                }).route(
+                "text/xml",
+                FkContentTypeTest.createTakeWithEmptyResponse()
+                ).route(
                     new RqWithHeader(
                         new RqFake(),
                         FkContentTypeTest.CONTENT_TYPE,
@@ -87,12 +84,9 @@ public final class FkContentTypeTest {
     public void matchesDifferentTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                "application/json charset=utf-8", new Take() {
-                    @Override
-                    public Response act(final Request req) throws IOException {
-                        return new RsEmpty();
-                    }
-                }).route(
+                "application/json charset=utf-8",
+                FkContentTypeTest.createTakeWithEmptyResponse()
+                ).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,
@@ -111,12 +105,9 @@ public final class FkContentTypeTest {
     public void matchesIdenticalTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                FkContentTypeTest.CTYPE, new Take() {
-                    @Override
-                    public Response act(final Request req) throws IOException {
-                        return new RsEmpty();
-                    }
-                }).route(
+                FkContentTypeTest.CTYPE,
+                FkContentTypeTest.createTakeWithEmptyResponse()
+                ).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,
@@ -135,12 +126,9 @@ public final class FkContentTypeTest {
     public void matchesEmptyType() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                "*/*", new Take() {
-                    @Override
-                    public Response act(final Request req) throws IOException {
-                        return new RsEmpty();
-                    }
-                }).route(
+                "*/*",
+                FkContentTypeTest.createTakeWithEmptyResponse()
+                ).route(
                     new RqWithHeader(
                         new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
                     )
@@ -156,12 +144,9 @@ public final class FkContentTypeTest {
     public void matchesDifferentEncodingsTypes() throws IOException {
         MatcherAssert.assertThat(
             new FkContentType(
-                FkContentTypeTest.CTYPE, new Take() {
-                    @Override
-                    public Response act(final Request req) throws IOException {
-                        return new RsEmpty();
-                    }
-                }).route(
+                FkContentTypeTest.CTYPE,
+                FkContentTypeTest.createTakeWithEmptyResponse()
+                ).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,
@@ -181,5 +166,18 @@ public final class FkContentTypeTest {
         EqualsVerifier.forClass(FkContentType.class)
             .suppress(Warning.TRANSIENT_FIELDS)
             .verify();
+    }
+
+    /**
+     * Create a Take instance with empty response.
+     * @return Take
+     */
+    private static Take createTakeWithEmptyResponse() {
+        return new Take() {
+            @Override
+            public Response act(final Request req) throws IOException {
+                return new RsEmpty();
+            }
+        };
     }
 }

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -64,7 +64,7 @@ public final class FkContentTypeTest {
         MatcherAssert.assertThat(
             new FkContentType(
                 "text/xml",
-                FkContentTypeTest.createTakeWithEmptyResponse()
+                new RsEmpty()
             ).route(
                 new RqWithHeader(
                     new RqFake(),
@@ -85,7 +85,7 @@ public final class FkContentTypeTest {
         MatcherAssert.assertThat(
             new FkContentType(
                 "application/json charset=utf-8",
-                FkContentTypeTest.createTakeWithEmptyResponse()
+                FkContentTypeTest.emptyResponse()
             ).route(
                 new RqWithHeader(
                     new RqFake(),
@@ -106,7 +106,7 @@ public final class FkContentTypeTest {
         MatcherAssert.assertThat(
             new FkContentType(
                 FkContentTypeTest.CTYPE,
-                FkContentTypeTest.createTakeWithEmptyResponse()
+                FkContentTypeTest.emptyResponse()
             ).route(
                 new RqWithHeader(
                     new RqFake(),
@@ -127,7 +127,7 @@ public final class FkContentTypeTest {
         MatcherAssert.assertThat(
             new FkContentType(
                 "*/*",
-                FkContentTypeTest.createTakeWithEmptyResponse()
+                FkContentTypeTest.emptyResponse()
             ).route(
                 new RqWithHeader(
                     new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
@@ -145,7 +145,7 @@ public final class FkContentTypeTest {
         MatcherAssert.assertThat(
             new FkContentType(
                 FkContentTypeTest.CTYPE,
-                FkContentTypeTest.createTakeWithEmptyResponse()
+                FkContentTypeTest.emptyResponse()
             ).route(
                 new RqWithHeader(
                     new RqFake(),
@@ -172,7 +172,7 @@ public final class FkContentTypeTest {
      * Create a Take instance with empty response.
      * @return Take
      */
-    private static Take createTakeWithEmptyResponse() {
+    private static Take emptyResponse() {
         return new Take() {
             @Override
             public Response act(final Request req) throws IOException {

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -72,7 +72,7 @@ public final class FkContentTypeTest {
                     "*/* "
                 )
             ).has(),
-                Matchers.is(true)
+            Matchers.is(true)
         );
     }
 
@@ -93,7 +93,7 @@ public final class FkContentTypeTest {
                     "images/*"
                 )
             ).has(),
-                Matchers.is(false)
+            Matchers.is(false)
         );
     }
 
@@ -107,7 +107,7 @@ public final class FkContentTypeTest {
             new FkContentType(
                 FkContentTypeTest.CTYPE,
                 FkContentTypeTest.createTakeWithEmptyResponse()
-                ).route(
+            ).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -128,7 +128,7 @@ public final class FkContentTypeTest {
             new FkContentType(
                 "*/*",
                 FkContentTypeTest.createTakeWithEmptyResponse()
-                ).route(
+            ).route(
                     new RqWithHeader(
                         new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
                     )

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -62,10 +62,7 @@ public final class FkContentTypeTest {
     @Test
     public void matchesWithAnyTypes() throws IOException {
         MatcherAssert.assertThat(
-            new FkContentType(
-                "text/xml",
-                new RsEmpty()
-            ).route(
+            new FkContentType("text/xml", new RsEmpty()).route(
                 new RqWithHeader(
                     new RqFake(),
                     FkContentTypeTest.CONTENT_TYPE,

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -129,10 +129,10 @@ public final class FkContentTypeTest {
                 "*/*",
                 FkContentTypeTest.createTakeWithEmptyResponse()
             ).route(
-                    new RqWithHeader(
-                        new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
-                    )
-                ).has(), Matchers.is(true)
+                new RqWithHeader(
+                    new RqFake(), FkContentTypeTest.CONTENT_TYPE, ""
+                )
+            ).has(), Matchers.is(true)
         );
     }
 


### PR DESCRIPTION
Issue #461 - FkContentType is built with a Response. To handle more general use cases like Content-Type: text/html; charset=..., it should be built with a Take that will handle the request dynamically.