### PR TITLE
#600 PsBasic.Default constructor must only set final variables and call other constructors

### DIFF
--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -54,6 +54,7 @@ import org.takes.rs.RsWithHeader;
  * @since 0.20
  */
 @EqualsAndHashCode(of = { "entry", "realm" })
+@SuppressWarnings("PMD.TooManyMethods")
 public final class PsBasic implements Pass {
 
     /**
@@ -146,7 +147,6 @@ public final class PsBasic implements Pass {
      * @author Endrigo Antonini (teamed@endrigo.com.br)
      * @version $Id$
      * @since 0.20
-     *
      */
     public static final class Fake implements PsBasic.Entry {
 
@@ -226,26 +226,9 @@ public final class PsBasic implements Pass {
          *  space characters as separators. Each of login, password and urn
          *  are URL-encoded substrings. For example,
          *  {@code "mike my%20password urn:jcabi-users:michael"}.
-         * @todo #558:30min Default ctor. According to new qulice version,
-         *  constructor must contain only variables initialization and
-         *  other constructor calls. Refactor code according to that rule
-         *  and remove `ConstructorOnlyInitializesOrCallOtherConstructors`
-         *  warning suppression.
          */
-        @SuppressWarnings
-            (
-                "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
-            )
         public Default(final String... users) {
-            this.usernames = new HashMap<String, String>(users.length);
-            for (final String user : users) {
-                final String unified = user.replace("%20", "+");
-                PsBasic.Default.validateUser(unified);
-                this.usernames.put(
-                    PsBasic.Default.key(unified),
-                    unified.substring(unified.lastIndexOf(' ') + 1)
-                );
-            }
+            this.usernames = Default.converted(users);
         }
 
         @Override
@@ -266,6 +249,28 @@ public final class PsBasic implements Pass {
                 identity = new Opt.Empty<Identity>();
             }
             return identity;
+        }
+
+        /**
+         * Converts Strings with user's login, password and URN to Map.
+         * @param users Strings with user's login, password and URN with
+         *  space characters as separators. Each of login, password and urn
+         *  are URL-encoded substrings. For example,
+         *  {@code "mike my%20password urn:jcabi-users:michael"}.
+         * @return Map from login/password pairs to URNs.
+         */
+        private static Map<String, String> converted(final String... users) {
+            final Map<String, String> result =
+                new HashMap<String, String>(users.length);
+            for (final String user : users) {
+                final String unified = user.replace("%20", "+");
+                PsBasic.Default.validateUser(unified);
+                result.put(
+                    PsBasic.Default.key(unified),
+                    unified.substring(unified.lastIndexOf(' ') + 1)
+                );
+            }
+            return result;
         }
 
         /**

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -36,6 +36,7 @@ import org.takes.rq.RqFake;
 import org.takes.rq.RqMethod;
 import org.takes.rq.RqWithHeaders;
 import org.takes.rs.RsPrint;
+import com.jcabi.aspects.Tv;
 
 /**
  * Test of {@link PsBasic}.
@@ -72,8 +73,7 @@ public final class PsBasicTest {
                     RqMethod.GET,
                     String.format(
                         PsBasicTest.VALID_CODE,
-                        // @checkstyle MagicNumberCheck (1 line)
-                        RandomStringUtils.randomAlphanumeric(10)
+                        RandomStringUtils.randomAlphanumeric(Tv.TEN)
                     )
                 ),
                 this.generateAuthenticateHead(user, "pass")
@@ -108,8 +108,7 @@ public final class PsBasicTest {
                     RqMethod.GET,
                     String.format(
                         PsBasicTest.VALID_CODE,
-                        // @checkstyle MagicNumberCheck (1 line)
-                        RandomStringUtils.randomAlphanumeric(10)
+                        RandomStringUtils.randomAlphanumeric(Tv.TEN)
                     )
                 ),
                 this.generateAuthenticateHead(user, password)
@@ -139,8 +138,7 @@ public final class PsBasicTest {
                         RqMethod.GET,
                         String.format(
                             "?invalid_code=%s",
-                            // @checkstyle MagicNumberCheck (1 line)
-                            RandomStringUtils.randomAlphanumeric(10)
+                            RandomStringUtils.randomAlphanumeric(Tv.TEN)
                         )
                     ),
                     this.generateAuthenticateHead("username", "wrong")
@@ -176,8 +174,7 @@ public final class PsBasicTest {
                     RqMethod.GET,
                     String.format(
                         "?multiple_code=%s",
-                        // @checkstyle MagicNumberCheck (1 line)
-                        RandomStringUtils.randomAlphanumeric(10)
+                        RandomStringUtils.randomAlphanumeric(Tv.TEN)
                     )
                 ),
                 this.generateAuthenticateHead(user, "changeit"),

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -42,6 +42,7 @@ import org.takes.rs.RsPrint;
  * @author Endrigo Antonini (teamed@endrigo.com.br)
  * @version $Id$
  * @since 0.20
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class PsBasicTest {
 
@@ -49,6 +50,11 @@ public final class PsBasicTest {
      * Basic Auth.
      */
     private static final String AUTH_BASIC = "Authorization: Basic %s";
+
+    /**
+     * Valid code parameter.
+     */
+    private static final String VALID_CODE = "?valid_code=%s";
 
     /**
      * PsBasic can handle connection with valid credential.
@@ -65,12 +71,47 @@ public final class PsBasicTest {
                 new RqFake(
                     RqMethod.GET,
                     String.format(
-                        "?valid_code=%s",
+                        PsBasicTest.VALID_CODE,
                         // @checkstyle MagicNumberCheck (1 line)
                         RandomStringUtils.randomAlphanumeric(10)
                     )
                 ),
                 this.generateAuthenticateHead(user, "pass")
+            )
+        );
+        MatcherAssert.assertThat(identity.has(), Matchers.is(true));
+        MatcherAssert.assertThat(
+            identity.get().urn(),
+            CoreMatchers.equalTo(this.generateIdentityUrn(user))
+        );
+    }
+
+    /**
+     * PsBasic can handle connection with valid credential when.
+     * @throws Exception if any error occurs
+     */
+    @Test
+    public void handleConnectionWithValidCredentialDefaultEntry()
+        throws Exception {
+        final String user = "johny";
+        final String password = "password2";
+        final Opt<Identity> identity = new PsBasic(
+            "RealmAA",
+            new PsBasic.Default(
+                "mike my%20password1 urn:basic:michael",
+                String.format("%s %s urn:basic:%s", user, password, user)
+            )
+        ).enter(
+            new RqWithHeaders(
+                new RqFake(
+                    RqMethod.GET,
+                    String.format(
+                        PsBasicTest.VALID_CODE,
+                        // @checkstyle MagicNumberCheck (1 line)
+                        RandomStringUtils.randomAlphanumeric(10)
+                    )
+                ),
+                this.generateAuthenticateHead(user, password)
             )
         );
         MatcherAssert.assertThat(identity.has(), Matchers.is(true));
@@ -192,6 +233,7 @@ public final class PsBasicTest {
     private String generateIdentityUrn(final String user) {
         return String.format("urn:basic:%s", user);
     }
+
     /**
      * Generate the string used on the request that store information about
      * authentication.

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -87,7 +87,8 @@ public final class PsBasicTest {
     }
 
     /**
-     * PsBasic can handle connection with valid credential when.
+     * PsBasic can handle connection with valid credential when Entry is
+     * a instance of Default.
      * @throws Exception if any error occurs
      */
     @Test

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -23,6 +23,7 @@
  */
 package org.takes.facets.auth;
 
+import com.jcabi.aspects.Tv;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.lang.RandomStringUtils;
 import org.hamcrest.CoreMatchers;
@@ -36,7 +37,6 @@ import org.takes.rq.RqFake;
 import org.takes.rq.RqMethod;
 import org.takes.rq.RqWithHeaders;
 import org.takes.rs.RsPrint;
-import com.jcabi.aspects.Tv;
 
 /**
  * Test of {@link PsBasic}.

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -114,13 +114,13 @@ public final class PsBasicTest {
                         RandomStringUtils.randomAlphanumeric(Tv.TEN)
                     )
                 ),
-                this.generateAuthenticateHead(user, password)
+                PsBasicTest.header(user, password)
             )
         );
         MatcherAssert.assertThat(identity.has(), Matchers.is(true));
         MatcherAssert.assertThat(
             identity.get().urn(),
-            CoreMatchers.equalTo(this.generateIdentityUrn(user))
+            CoreMatchers.equalTo(PsBasicTest.urn(user))
         );
     }
 


### PR DESCRIPTION
#600 I moved code from constructor to separate method. I added `@SuppressWarnings("PMD.TooManyMethods")` annotation to class.
Also I added test that uses PsBasic.Default to be sure that PsBasic.Default works fine.