### PR TITLE
#594 RqMultipart.java - Removing the warning suppression (PMD.ConstructorOnlyInitializesOrCallOtherConstructors)

### DIFF
--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -283,7 +283,7 @@ public interface RqMultipart extends Request {
          */
         private void copy(final WritableByteChannel target,
             final byte[] boundary, final ReadableByteChannel body)
-                throws IOException {
+            throws IOException {
             int match = 0;
             boolean cont = true;
             while (cont) {

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -282,8 +282,8 @@ public interface RqMultipart extends Request {
          * @checkstyle ExecutableStatementCountCheck (2 lines)
          */
         private void copy(final WritableByteChannel target,
-            final byte[] boundary,
-            final ReadableByteChannel body) throws IOException {
+            final byte[] boundary, final ReadableByteChannel body)
+                throws IOException {
             int match = 0;
             boolean cont = true;
             while (cont) {


### PR DESCRIPTION
Issue #594 - Solving puzzle 558-afc1c081 in
src/main/java/org/takes/rq/RqMultipart.java:131-135

- The class was refactored according to this article: http://www.yegor256.com/2015/05/07/ctors-must-be-code-free.html
- Removes the warning suppression (PMD.ConstructorOnlyInitializesOrCallOtherConstructors)
- Create static methods (body(final Request req) and buffer(final Request req)) to the constructor contains only variables initialization and other constructor calls.