### PR TITLE
#576: Close all the parts on request's body close

### DIFF
--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -370,7 +370,7 @@ public interface RqMultipart extends Request {
         private class CloseMultipart extends FilterInputStream {
 
             /**
-             * Creates a {@code CloseParts} with the specified {@code input}.
+             * Creates a {@code CloseParts} with the specified input.
              * @param input The underlying input stream.
              */
             CloseMultipart(final InputStream input) {

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -26,6 +26,7 @@ package org.takes.rq;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
@@ -97,8 +98,8 @@ public interface RqMultipart extends Request {
      * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
      * @see RqGreedy
      */
-    @EqualsAndHashCode(callSuper = true)
-    final class Base extends RqWrap implements RqMultipart {
+    @EqualsAndHashCode(of = "origin")
+    final class Base implements RqMultipart {
         /**
          * Pattern to get boundary from header.
          */
@@ -124,13 +125,17 @@ public interface RqMultipart extends Request {
          */
         private final transient InputStream stream;
         /**
+         * Original request.
+         */
+        private final transient Request origin;
+        /**
          * Ctor.
          * @param req Original request
          * @throws IOException If fails
          * @checkstyle ExecutableStatementCountCheck (2 lines)
          */
         public Base(final Request req) throws IOException {
-            super(req);
+            this.origin = req;
             this.stream = new RqLengthAware(req).body();
             this.buffer = ByteBuffer.allocate(
                 // @checkstyle MagicNumberCheck (1 line)
@@ -166,6 +171,17 @@ public interface RqMultipart extends Request {
         public Iterable<String> names() {
             return this.map.keySet();
         }
+
+        @Override
+        public Iterable<String> head() throws IOException {
+            return this.origin.head();
+        }
+
+        @Override
+        public InputStream body() throws IOException {
+            return new CloseMultipart(this.origin.body());
+        }
+
         /**
          * Build a request for each part of the origin request.
          * @param req Origin request
@@ -231,10 +247,6 @@ public interface RqMultipart extends Request {
          * @param body Origin request body
          * @return Request
          * @throws IOException If fails
-         * @todo #254:30min in order to delete temporary files InputStream
-         *  instance on Request.body should be closed. In context of multipart
-         *  requests that means that body of all parts should be closed once
-         *  they are not needed anymore.
          */
         private Request make(final byte[] boundary,
             final ReadableByteChannel body) throws IOException {
@@ -350,6 +362,34 @@ public interface RqMultipart extends Request {
                 map.get(name).add(req);
             }
             return map;
+        }
+
+        /**
+         * Decorator allowing to close all the parts of the request.
+         */
+        private class CloseMultipart extends FilterInputStream {
+
+            /**
+             * Creates a {@code CloseParts} with the specified {@code input}.
+             * @param input The underlying input stream.
+             */
+            CloseMultipart(final InputStream input) {
+                super(input);
+            }
+
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    for (final List<Request> requests
+                        : RqMultipart.Base.this.map.values()) {
+                        for (final Request request : requests) {
+                            request.body().close();
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/org/takes/rq/TempInputStream.java
+++ b/src/main/java/org/takes/rq/TempInputStream.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -61,8 +62,14 @@ final class TempInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
-        this.origin.close();
-        Files.delete(Paths.get(this.file.getAbsolutePath()));
+        try {
+            this.origin.close();
+        } finally {
+            final Path path = Paths.get(this.file.getAbsolutePath());
+            if (Files.exists(path)) {
+                Files.delete(path);
+            }
+        }
     }
 
     @Override

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -274,10 +274,10 @@ public final class RqMultipartTest {
     /**
      * RqMultipart.Base can close all parts once the request body has been
      * closed.
-     * @throws IOException If some problem inside
+     * @throws Exception If some problem inside
      */
-    @Test(expected = IOException.class)
-    public void closesAllParts() throws IOException {
+    @Test
+    public void closesAllParts() throws Exception {
         RqMultipart.Base multi = null;
         try {
             final String body = "RqMultipartTest.closesAllParts";
@@ -322,20 +322,37 @@ public final class RqMultipartTest {
             );
         } catch (final IOException ex) {
             MatcherAssert.assertThat(
-                multi.part("content").iterator().next(),
-                Matchers.notNullValue()
+                ex.getMessage(),
+                Matchers.containsString("Closed")
             );
+        }
+        MatcherAssert.assertThat(
+            multi.part("content").iterator().next(),
+            Matchers.notNullValue()
+        );
+        try {
             multi.part("content").iterator().next().body().read();
+            Assert.fail(
+                "An IOException was expected since the Stream is closed"
+            );
+        } catch (final IOException ex) {
+            MatcherAssert.assertThat(
+                ex.getMessage(),
+                Matchers.containsString("Closed")
+            );
         }
     }
 
     /**
      * RqMultipart.Base can close all parts explicitly even if the request body
      * has been closed.
-     * @throws IOException If some problem inside
+     * <p>For backward compatibility reason we need to ensure that we don't get
+     * {@code IOException} when we close explicitly a part even after closing
+     * the input stream of the main request.
+     * @throws Exception If some problem inside
      */
     @Test
-    public void closesExplicitlyAllParts() throws IOException {
+    public void closesExplicitlyAllParts() throws Exception {
         final String body = "RqMultipartTest.closesExplicitlyAllParts";
         final RqMultipart request = new RqMultipart.Fake(
             new RqFake(),

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -278,39 +278,34 @@ public final class RqMultipartTest {
      */
     @Test
     public void closesAllParts() throws Exception {
-        RqMultipart.Base multi = null;
-        try {
-            final String body = "RqMultipartTest.closesAllParts";
-            final RqMultipart request = new RqMultipart.Fake(
-                new RqFake(),
-                new RqGreedy(
-                    new RqWithHeaders(
-                        new RqFake("", "", body),
-                        RqMultipartTest.contentLengthHeader(
-                            (long) body.getBytes().length
-                        ),
-                        RqMultipartTest.contentDispositionHeader(
-                            "form-data; name=\"name\""
-                        )
-                    )
-                ),
-                new RqGreedy(
-                    new RqWithHeaders(
-                        new RqFake("", "", body),
-                        RqMultipartTest.contentLengthHeader(0L),
-                        RqMultipartTest.contentDispositionHeader(
-                            "form-data; name=\"content\"; filename=\"a.bin\""
-                        )
+        final String body = "RqMultipartTest.closesAllParts";
+        final RqMultipart request = new RqMultipart.Fake(
+            new RqFake(),
+            new RqGreedy(
+                new RqWithHeaders(
+                    new RqFake("", "", body),
+                    RqMultipartTest.contentLengthHeader(
+                        (long) body.getBytes().length
+                    ),
+                    RqMultipartTest.contentDispositionHeader(
+                        "form-data; name=\"name\""
                     )
                 )
-            );
-            multi = new RqMultipart.Base(request);
-            multi.part("name").iterator().next().body().read();
-            multi.part("content").iterator().next().body().read();
-            multi.body().close();
-        } catch (final IOException ex) {
-            Assert.fail("An IOException was not expected");
-        }
+            ),
+            new RqGreedy(
+                new RqWithHeaders(
+                    new RqFake("", "", body),
+                    RqMultipartTest.contentLengthHeader(0L),
+                    RqMultipartTest.contentDispositionHeader(
+                        "form-data; name=\"content\"; filename=\"a.bin\""
+                    )
+                )
+            )
+        );
+        final RqMultipart.Base multi = new RqMultipart.Base(request);
+        multi.part("name").iterator().next().body().read();
+        multi.part("content").iterator().next().body().read();
+        multi.body().close();
         MatcherAssert.assertThat(
             multi.part("name").iterator().next(),
             Matchers.notNullValue()

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -268,6 +269,100 @@ public final class RqMultipartTest {
         } finally {
             multi.part(part).iterator().next().body().close();
         }
+    }
+
+    /**
+     * RqMultipart.Base can close all parts once the request body has been
+     * closed.
+     * @throws IOException If some problem inside
+     */
+    @Test(expected = IOException.class)
+    public void closesAllParts() throws IOException {
+        final String body = "RqMultipartTest.closesAllParts";
+        final RqMultipart request = new RqMultipart.Fake(
+            new RqFake(),
+            new RqGreedy(
+                new RqWithHeaders(
+                    new RqFake("", "", body),
+                    RqMultipartTest.contentLengthHeader(
+                        (long) body.getBytes().length
+                    ),
+                    RqMultipartTest.contentDispositionHeader(
+                        "form-data; name=\"name\""
+                    )
+                )
+            ),
+            new RqGreedy(
+                new RqWithHeaders(
+                    new RqFake("", "", body),
+                    RqMultipartTest.contentLengthHeader(0L),
+                    RqMultipartTest.contentDispositionHeader(
+                        "form-data; name=\"content\"; filename=\"a.bin\""
+                    )
+                )
+            )
+        );
+        final RqMultipart.Base multi = new RqMultipart.Base(request);
+        multi.body().close();
+        MatcherAssert.assertThat(
+            multi.part("name").iterator().next(),
+            Matchers.notNullValue()
+        );
+        try {
+            multi.part("name").iterator().next().body().read();
+            Assert.fail("An IOException was expected");
+        } catch (final IOException ex) {
+            MatcherAssert.assertThat(
+                multi.part("content").iterator().next(),
+                Matchers.notNullValue()
+            );
+            multi.part("content").iterator().next().body().read();
+        }
+    }
+
+    /**
+     * RqMultipart.Base can close all parts explicitly even if the request body
+     * has been closed.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void closesExplicitlyAllParts() throws IOException {
+        final String body = "RqMultipartTest.closesExplicitlyAllParts";
+        final RqMultipart request = new RqMultipart.Fake(
+            new RqFake(),
+            new RqGreedy(
+                new RqWithHeaders(
+                    new RqFake("", "", body),
+                    RqMultipartTest.contentLengthHeader(
+                        (long) body.getBytes().length
+                    ),
+                    RqMultipartTest.contentDispositionHeader(
+                        "form-data; name=\"foo\""
+                    )
+                )
+            ),
+            new RqGreedy(
+                new RqWithHeaders(
+                    new RqFake("", "", body),
+                    RqMultipartTest.contentLengthHeader(0L),
+                    RqMultipartTest.contentDispositionHeader(
+                        "form-data; name=\"bar\"; filename=\"a.bin\""
+                    )
+                )
+            )
+        );
+        final RqMultipart.Base multi = new RqMultipart.Base(request);
+        multi.body().close();
+        MatcherAssert.assertThat(
+            multi.part("foo").iterator().next(),
+            Matchers.notNullValue()
+        );
+        multi.part("foo").iterator().next().body().close();
+        MatcherAssert.assertThat(
+            multi.part("bar").iterator().next(),
+            Matchers.notNullValue()
+        );
+        multi.part("bar").iterator().next().body().close();
     }
 
     /**


### PR DESCRIPTION
Fix for https://github.com/yegor256/takes/issues/576

The goal of this PR is to close all the parts of the request in order to ensure that all the temporary files are properly deleted.