### PR TITLE
#624 - Removing 'excludes' of FindBuging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,8 +319,8 @@
                                 <exclude>checkstyle:/src/site/resources/.*</exclude>
                                 <!--
                                 @todo #624:30min Continue fixing FindBugs violations started in #624.
-                                 #624 turned on the FindBugs, temporarily excluding some classes.
-                                 Remove all excludes of FindBugs below and fix the issues.
+                                #624 turned on the FindBugs, temporarily excluding some classes.
+                                Remove all excludes of FindBugs below and fix the issues.
                                 -->
                                 <exclude>findbugs:org.takes.facets.forward.TkForward$Safe</exclude>
                                 <exclude>findbugs:org.takes.rs.RsGzip</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -319,8 +319,8 @@
                                 <exclude>checkstyle:/src/site/resources/.*</exclude>
                                 <!--
                                 @todo #624:30min Continue fixing FindBugs violations started in #624.
-                                #624 turned on the FindBugs, temporarily excluding some classes.
-                                Remove all excludes of FindBugs below and fix the issues.
+                                 #624 turned on the FindBugs, temporarily excluding some classes.
+                                 Remove all excludes of FindBugs below and fix the issues.
                                 -->
                                 <exclude>findbugs:org.takes.facets.forward.TkForward$Safe</exclude>
                                 <exclude>findbugs:org.takes.rs.RsGzip</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -317,25 +317,6 @@
                         <configuration>
                             <excludes combine.children="append">
                                 <exclude>checkstyle:/src/site/resources/.*</exclude>
-                                <!--
-                                @todo #574:30min Continue fixing FindBugs violations started in #574.
-                                 #574 turned on the FindBugs, temporarily excluding some classes.
-                                 Remove all excludes of FindBugs below and fix the issues.
-                                -->
-                                <exclude>findbugs:org.takes.facets.forward.TkForward$Safe</exclude>
-                                <exclude>findbugs:org.takes.rs.RsGzip</exclude>
-                                <exclude>findbugs:org.takes.rq.RqForm$Base</exclude>
-                                <exclude>findbugs:org.takes.rs.RsPrettyJSON</exclude>
-                                <exclude>findbugs:org.takes.rs.RsPrettyXML</exclude>
-                                <exclude>findbugs:org.takes.tk.TkReadAlways</exclude>
-                                <exclude>findbugs:org.takes.HttpException</exclude>
-                                <exclude>findbugs:org.takes.facets.forward.RsForward</exclude>
-                                <exclude>findbugs:org.takes.facets.fork.FkRegex$2</exclude>
-                                <exclude>findbugs:org.takes.http.FtCLI$3</exclude>
-                                <exclude>findbugs:org.takes.http.MainRemote$1</exclude>
-                                <exclude>findbugs:org.takes.http.MainRemote</exclude>
-                                <exclude>findbugs:org.takes.rq.RqMultipart$Base</exclude>
-                                <exclude>findbugs:org.takes.http.Options</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                             <excludes combine.children="append">
                                 <exclude>checkstyle:/src/site/resources/.*</exclude>
                                 <!--
-                                @todo #624:30min Continue fixing FindBugs violations started in #624.
+                                @TODO #624:30min Continue fixing FindBugs violations started in #624.
                                  #624 turned on the FindBugs, temporarily excluding some classes.
                                  Remove all excludes of FindBugs below and fix the issues.
                                 -->

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,21 @@
                         <configuration>
                             <excludes combine.children="append">
                                 <exclude>checkstyle:/src/site/resources/.*</exclude>
+                                <!--
+                                @todo #624:30min Continue fixing FindBugs violations started in #624.
+                                 #624 turned on the FindBugs, temporarily excluding some classes.
+                                 Remove all excludes of FindBugs below and fix the issues.
+                                -->
+                                <exclude>findbugs:org.takes.facets.forward.TkForward$Safe</exclude>
+                                <exclude>findbugs:org.takes.rs.RsGzip</exclude>
+                                <exclude>findbugs:org.takes.rq.RqForm$Base</exclude>
+                                <exclude>findbugs:org.takes.rs.RsPrettyJSON</exclude>
+                                <exclude>findbugs:org.takes.rs.RsPrettyXML</exclude>
+                                <exclude>findbugs:org.takes.tk.TkReadAlways</exclude>
+                                <exclude>findbugs:org.takes.HttpException</exclude>
+                                <exclude>findbugs:org.takes.facets.forward.RsForward</exclude>
+                                <exclude>findbugs:org.takes.http.MainRemote</exclude>
+                                <exclude>findbugs:org.takes.http.Options</exclude>
                             </excludes>
                         </configuration>
                     </plugin>

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -188,26 +188,58 @@ public final class FkRegex implements Fork {
         if (matcher.matches()) {
             resp = new Opt.Single<Response>(
                 this.target.act(
-                    new RqRegex() {
-                        @Override
-                        public Matcher matcher() {
-                            return matcher;
-                        }
-                        @Override
-                        public Iterable<String> head() throws IOException {
-                            return req.head();
-                        }
-                        @Override
-                        public InputStream body() throws IOException {
-                            return req.body();
-                        }
-                    }
+                    new RqMatcher(matcher, req)
                 )
             );
         } else {
             resp = new Opt.Empty<Response>();
         }
         return resp;
+    }
+
+    /**
+     * Request with a matcher inside.
+     *
+     * @author Dali Freire (dalifreire@gmail.com)
+     * @version $Id$
+     * @since 0.32.5
+     */
+    private static final class RqMatcher implements RqRegex {
+
+        /**
+         * Matcher.
+         */
+        private final transient Matcher matcher;
+
+        /**
+         * Original request.
+         */
+        private final transient Request req;
+
+        /**
+         * Ctor.
+         * @param matcher Matcher
+         * @param req Request
+         */
+        RqMatcher(final Matcher matcher, final Request req) {
+            this.matcher = matcher;
+            this.req = req;
+        }
+
+        @Override
+        public Iterable<String> head() throws IOException {
+            return this.req.head();
+        }
+
+        @Override
+        public InputStream body() throws IOException {
+            return this.req.body();
+        }
+
+        @Override
+        public Matcher matcher() {
+            return this.matcher;
+        }
     }
 
 }

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -209,7 +209,7 @@ public final class FkRegex implements Fork {
         /**
          * Matcher.
          */
-        private final transient Matcher matcher;
+        private final transient Matcher mtr;
 
         /**
          * Original request.
@@ -219,11 +219,11 @@ public final class FkRegex implements Fork {
         /**
          * Ctor.
          * @param matcher Matcher
-         * @param req Request
+         * @param request Request
          */
-        RqMatcher(final Matcher matcher, final Request req) {
-            this.matcher = matcher;
-            this.req = req;
+        RqMatcher(final Matcher matcher, final Request request) {
+            this.mtr = matcher;
+            this.req = request;
         }
 
         @Override
@@ -238,7 +238,7 @@ public final class FkRegex implements Fork {
 
         @Override
         public Matcher matcher() {
-            return this.matcher;
+            return this.mtr;
         }
     }
 

--- a/src/main/java/org/takes/http/FtCLI.java
+++ b/src/main/java/org/takes/http/FtCLI.java
@@ -149,13 +149,43 @@ public final class FtCLI implements Front {
         final long max = this.options.lifetime();
         return new Exit.Or(
             exit,
-            new Exit() {
-                @Override
-                public boolean ready() {
-                    return System.currentTimeMillis() - start > max;
-                }
-            }
+            new Lifetime(start, max)
         );
     }
+
+    /**
+     * Lifetime exceeded exit.
+     *
+     * @author Dali Freire (dalifreire@gmail.com)
+     * @version $Id$
+     * @since 0.32.5
+     */
+    private static final class Lifetime implements Exit {
+
+        /**
+         * Start time.
+         */
+        private final transient long start;
+
+        /**
+         * Max lifetime.
+         */
+        private final transient long max;
+
+        /**
+         * Ctor.
+         * @param start Start time
+         * @param max Max lifetime
+         */
+        Lifetime(final long start, final long max) {
+            this.start = start;
+            this.max = max;
+        }
+
+        @Override
+        public boolean ready() {
+            return System.currentTimeMillis() - this.start > this.max;
+        }
+    };
 
 }

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -188,17 +188,15 @@ public final class MainRemote {
                     String.format(
                         "The %s method has been invoked at an illegal time.",
                         this.method.getName()
-                        ),
-                    ex
-                    );
+                    ), ex
+                );
             } catch (final IllegalAccessException ex) {
                 throw new IllegalStateException(
                     String.format(
                         "The visibility of the %s method do not allow access.",
                         this.method.getName()
-                        ),
-                    ex
-                    );
+                    ), ex
+                );
             }
         }
     }

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -92,20 +92,7 @@ public final class MainRemote {
         for (int idx = 0; idx < this.args.length; ++idx) {
             passed[idx + 1] = this.args[idx];
         }
-        final Thread thread = new Thread(
-            new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        method.invoke(null, (Object) passed);
-                    } catch (final InvocationTargetException ex) {
-                        throw new IllegalStateException(ex);
-                    } catch (final IllegalAccessException ex) {
-                        throw new IllegalStateException(ex);
-                    }
-                }
-            }
-        );
+        final Thread thread = new Thread(new MainMethod(method, passed));
         thread.start();
         try {
             script.exec(
@@ -163,4 +150,44 @@ public final class MainRemote {
         void exec(URI home) throws IOException;
     }
 
+    /**
+     * Runnable main method.
+     *
+     * @author Dali Freire (dalifreire@gmail.com)
+     * @version $Id$
+     * @since 0.32.5
+     */
+    private static final class MainMethod implements Runnable {
+
+        /**
+         * Method.
+         */
+        private final transient Method method;
+
+        /**
+         * Additional arguments.
+         */
+        private final transient String[] passed;
+
+        /**
+         * Ctor.
+         * @param method Main method
+         * @param passed Additional arguments to be passed to the main method
+         */
+        MainMethod(final Method method, final String[] passed) {
+            this.method = method;
+            this.passed = passed;
+        }
+
+        @Override
+        public void run() {
+            try {
+                this.method.invoke(null, (Object) this.passed);
+            } catch (final InvocationTargetException ex) {
+                throw new IllegalStateException(ex);
+            } catch (final IllegalAccessException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+    }
 }

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -174,9 +174,9 @@ public final class MainRemote {
          * @param method Main method
          * @param passed Additional arguments to be passed to the main method
          */
-        MainMethod(final Method method, final String[] passed) {
+        MainMethod(final Method method, final String... passed) {
             this.method = method;
-            this.passed = passed;
+            this.passed = Arrays.copyOf(passed, passed.length);
         }
 
         @Override

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -184,9 +184,21 @@ public final class MainRemote {
             try {
                 this.method.invoke(null, (Object) this.passed);
             } catch (final InvocationTargetException ex) {
-                throw new IllegalStateException(ex);
+                throw new IllegalStateException(
+                    String.format(
+                        "The %s method has been invoked at an illegal time.",
+                        this.method.getName()
+                        ),
+                    ex
+                    );
             } catch (final IllegalAccessException ex) {
-                throw new IllegalStateException(ex);
+                throw new IllegalStateException(
+                    String.format(
+                        "The visibility of the %s method do not allow access.",
+                        this.method.getName()
+                        ),
+                    ex
+                    );
             }
         }
     }

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -224,7 +224,7 @@ public interface RqMultipart extends Request {
                 );
             }
             final byte[] boundary = String.format(
-                "\r%n--%s", matcher.group(1)
+                "%s--%s", RqMultipart.Fake.CRLF, matcher.group(1)
             ).getBytes(StandardCharsets.UTF_8);
             this.buffer.flip();
             this.buffer.position(boundary.length - 2);

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -224,7 +224,7 @@ public interface RqMultipart extends Request {
                 );
             }
             final byte[] boundary = String.format(
-                "\r\n--%s", matcher.group(1)
+                "\r%n--%s", matcher.group(1)
             ).getBytes(StandardCharsets.UTF_8);
             this.buffer.flip();
             this.buffer.position(boundary.length - 2);


### PR DESCRIPTION
Issue #624 - Solving puzzle 574-2964594e in pom.xml.

Fixing and removing the following 'excludes' of FindBugs in the pom.xml file:
- findbugs:org.takes.facets.fork.FkRegex$2 `SIC_INNER_SHOULD_BE_STATIC_ANON`
- findbugs:org.takes.http.FtCLI$3	`SIC_INNER_SHOULD_BE_STATIC_ANON`	
- findbugs:org.takes.http.MainRemote$1 `SIC_INNER_SHOULD_BE_STATIC_ANON`
- findbugs:org.takes.rq.RqMultipart$Base `VA_FORMAT_STRING_USES_NEWLINE`

30 minutes to implement this task. It is not enough because the problem is much bigger and requires more work than the slotted time allows. A new puzzle was created so that can be resolved by other people.