### PR TITLE
#655: Refactor the parse method to reduce the Cyclomatic Complexity

### DIFF
--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -108,7 +108,7 @@ public final class RqLive extends RqWrap {
      * @param input The input stream to read
      * @param baos Current read header
      * @param position Header line number
-     * @throws IOException If the next byte is not a Line Feed as expected.
+     * @throws IOException If the next byte is not a Line Feed as expected
      */
     private static void checkLineFeed(final InputStream input,
         final ByteArrayOutputStream baos, final Integer position)

--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -105,6 +105,8 @@ public final class RqLive extends RqWrap {
 
     /**
      * Checks whether or not the next byte to read is a Line Feed.
+     * <p><i>Please note that this method assumes that the previous byte read
+     * was a Carriage Return.</i>
      * @param input The input stream to read
      * @param baos Current read header
      * @param position Header line number


### PR DESCRIPTION
Fix for #655 

The goal of this PR is to reduce the Cyclomatic Complexity of the class RqLive by refactoring the parse method. 

Please note that I did not create a new class as expressed in the puzzle description because the class RqLive is already very simple as it only contains private static methods so creating a new class won't help in this case.