### PR TITLE
#635: Simplify TkProduces and TkConsumes by using TkFork instead of RsFork

### DIFF
--- a/src/main/java/org/takes/facets/fork/TkConsumes.java
+++ b/src/main/java/org/takes/facets/fork/TkConsumes.java
@@ -23,11 +23,8 @@
  */
 package org.takes.facets.fork;
 
-import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.takes.Request;
-import org.takes.Response;
 import org.takes.Take;
 import org.takes.tk.TkWrap;
 
@@ -49,17 +46,7 @@ public final class TkConsumes extends TkWrap {
      * @param type Content-Type
      */
     public TkConsumes(final Take take, final String type) {
-        super(
-            new Take() {
-                @Override
-                public Response act(final Request req) throws IOException {
-                    return new RsFork(
-                        req,
-                        new FkContentType(type, take)
-                    );
-                }
-            }
-        );
+        super(new TkFork(new FkContentType(type, take)));
     }
 
 }

--- a/src/main/java/org/takes/facets/fork/TkProduces.java
+++ b/src/main/java/org/takes/facets/fork/TkProduces.java
@@ -23,11 +23,8 @@
  */
 package org.takes.facets.fork;
 
-import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.takes.Request;
-import org.takes.Response;
 import org.takes.Take;
 import org.takes.tk.TkWrap;
 
@@ -50,17 +47,7 @@ public final class TkProduces extends TkWrap {
      * @param types Accept types
      */
     public TkProduces(final Take take, final String types) {
-        super(
-            new Take() {
-                @Override
-                public Response act(final Request req) throws IOException {
-                    return new RsFork(
-                        req,
-                        new FkTypes(types, take.act(req))
-                    );
-                }
-            }
-        );
+        super(new TkFork(new FkTypes(types, take)));
     }
 
 }

--- a/src/test/java/org/takes/facets/fork/FkTypesTest.java
+++ b/src/test/java/org/takes/facets/fork/FkTypesTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithHeader;
 import org.takes.rs.RsEmpty;
+import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkTypes}.
@@ -108,4 +109,17 @@ public final class FkTypesTest {
         );
     }
 
+    /**
+     * FkTypes can rely on a Take to provide the response.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void reliesOnTake() throws IOException {
+        MatcherAssert.assertThat(
+            new FkTypes("*/*,text/plain", new TkEmpty()).route(
+                new RqFake()
+            ).has(),
+            Matchers.is(true)
+        );
+    }
 }


### PR DESCRIPTION
Fix for #635 

The goal of this PR is to simplify TkProduces and TkConsumes by using TkFork instead of RsFork. For the need of this task, I added one new constructor in the class FkTypes in order to allow to provide a Take instead of a static Response. This way we can still provide a static response if we want but now we can provide a take for dynamic responses.