### PR TITLE
#626: Improve the way to identify the boundary

### DIFF
--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -62,7 +62,7 @@ import org.takes.misc.VerboseIterable;
  * @version $Id$
  * @since 0.9
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 public interface RqMultipart extends Request {
 
     /**
@@ -317,13 +317,15 @@ public interface RqMultipart extends Request {
                     final byte data = this.buffer.get();
                     if (data == boundary[match]) {
                         ++match;
-                        if (match == boundary.length) {
-                            cont = false;
-                            break;
-                        }
+                    } else if (data == boundary[0]) {
+                        match = 1;
                     } else {
                         match = 0;
                         btarget.limit(this.buffer.position() - offset);
+                    }
+                    if (match == boundary.length) {
+                        cont = false;
+                        break;
                     }
                 }
                 target.write(btarget);

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -508,7 +508,7 @@ public final class RqMultipartTest {
 
     /**
      * RqMultipart.Base can identify the boundary even if the last content to
-     * read before the pattern pattern is an empty line.
+     * read before the pattern is an empty line.
      * @throws IOException If some problem inside
      */
     @Test


### PR DESCRIPTION
Fix for #626 

The goal of the PR is to improve the way to identify the boundary pattern especially when we have an empty line before the pattern. If the pattern cannot be found, we get unexpected behavior such as IOException of type "Too many open files in system" because the loop is endless so it creates and opens new files again and again.