### PR TITLE
#625 Removing RqGreedy from RqMultipartTest.

### DIFF
--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -558,14 +558,11 @@ public interface RqMultipart extends Request {
                         "Content-Type: multipart/form-data; boundary=%s",
                         RqMultipart.Fake.BOUNDARY
                     ),
-                    String.format(
-                        "Content-Length: %s",
-                        this.body.length()
-                    )
+                    String.format("Content-Length: %s", this.body.length())
                 ).head();
             }
             @Override
-            public InputStream body() throws IOException {
+            public InputStream body() {
                 return new ByteArrayInputStream(
                     this.body.getBytes(StandardCharsets.UTF_8)
                 );

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -493,21 +493,6 @@ public interface RqMultipart extends Request {
             return this.fake.body();
         }
         /**
-         * Fake body stream creator.
-         * @param parts Fake request body parts
-         * @return InputStream of given dispositions
-         * @throws IOException If fails
-         */
-        private static InputStream fakeStream(final Request... parts)
-            throws IOException {
-            return new ByteArrayInputStream(
-                RqMultipart.Fake.fakeBody(parts).toString().getBytes(
-                    StandardCharsets.UTF_8
-                )
-            );
-        }
-
-        /**
          * Fake body creator.
          * @param parts Fake request body parts
          * @return StringBuilder of given dispositions
@@ -553,15 +538,17 @@ public interface RqMultipart extends Request {
             /**
              * Holding multiple request body parts.
              */
-            private final Request[] parts;
+            private final String body;
             /**
              * The Constructor for the class.
              * @param rqst The Request object
              * @param list The sequence of dispositions
+             * @throws IOException if can't process requests
              */
-            FakeMultipartRequest(final Request rqst, final Request... list) {
+            FakeMultipartRequest(final Request rqst, final Request... list)
+                throws IOException {
                 this.req = rqst;
-                this.parts = list;
+                this.body = RqMultipart.Fake.fakeBody(list).toString();
             }
             @Override
             public Iterable<String> head() throws IOException {
@@ -573,13 +560,15 @@ public interface RqMultipart extends Request {
                     ),
                     String.format(
                         "Content-Length: %s",
-                        RqMultipart.Fake.fakeBody(this.parts).length()
+                        this.body.length()
                     )
                 ).head();
             }
             @Override
             public InputStream body() throws IOException {
-                return RqMultipart.Fake.fakeStream(this.parts);
+                return new ByteArrayInputStream(
+                    this.body.getBytes(StandardCharsets.UTF_8)
+                );
             }
         }
     }

--- a/src/test/java/org/takes/rq/RqMultipartTest.java
+++ b/src/test/java/org/takes/rq/RqMultipartTest.java
@@ -89,14 +89,6 @@ public final class RqMultipartTest {
     /**
      * RqMultipart.Base can satisfy equals contract.
      * @throws IOException if some problem inside
-     * @todo #620:30min This test is using RqGreedy in order to survive. If
-     *  you remove RqGreedy, the test will crash. I can't find out why
-     *  exactly it's happening. But the main problem is that somehow
-     *  inside RqMultipart.Fake we're reading body() of dispositions
-     *  twice or more times. That's why RqGreedy is required now. I order
-     *  to always return the same content. Let's find what exactly is the
-     *  problem and remove RqGreedy from this test and three other
-     *  test methods below.
      */
     @Test
     public void satisfiesEqualsContract() throws IOException {
@@ -104,24 +96,20 @@ public final class RqMultipartTest {
         final String part = "t-1";
         final Request req = new RqMultipart.Fake(
             new RqFake(),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(
-                        (long) body.getBytes().length
-                    ),
-                    RqMultipartTest.contentDispositionHeader(
-                        String.format("form-data; name=\"%s\"", part)
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(
+                    (long) body.getBytes().length
+                ),
+                RqMultipartTest.contentDispositionHeader(
+                    String.format("form-data; name=\"%s\"", part)
                 )
             ),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", ""),
-                    RqMultipartTest.contentLengthHeader(0L),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"data\"; filename=\"a.bin\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", ""),
+                RqMultipartTest.contentLengthHeader(0L),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"data\"; filename=\"a.bin\""
                 )
             )
         );
@@ -227,24 +215,20 @@ public final class RqMultipartTest {
         final String part = "t4";
         final RqMultipart multi = new RqMultipart.Fake(
             new RqFake(),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(
-                        (long) body.getBytes().length
-                    ),
-                    RqMultipartTest.contentDispositionHeader(
-                        String.format("form-data; name=\"%s\"", part)
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(
+                    (long) body.getBytes().length
+                ),
+                RqMultipartTest.contentDispositionHeader(
+                    String.format("form-data; name=\"%s\"", part)
                 )
             ),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", ""),
-                    RqMultipartTest.contentLengthHeader(0L),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"data\"; filename=\"a.bin\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", ""),
+                RqMultipartTest.contentLengthHeader(0L),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"data\"; filename=\"a.bin\""
                 )
             )
         );
@@ -281,24 +265,20 @@ public final class RqMultipartTest {
         final String body = "RqMultipartTest.closesAllParts";
         final RqMultipart request = new RqMultipart.Fake(
             new RqFake(),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(
-                        (long) body.getBytes().length
-                    ),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"name\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(
+                    (long) body.getBytes().length
+                ),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"name\""
                 )
             ),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(0L),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"content\"; filename=\"a.bin\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(0L),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"content\"; filename=\"a.bin\""
                 )
             )
         );
@@ -351,24 +331,20 @@ public final class RqMultipartTest {
         final String body = "RqMultipartTest.closesExplicitlyAllParts";
         final RqMultipart request = new RqMultipart.Fake(
             new RqFake(),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(
-                        (long) body.getBytes().length
-                    ),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"foo\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(
+                    (long) body.getBytes().length
+                ),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"foo\""
                 )
             ),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(0L),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"bar\"; filename=\"a.bin\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(0L),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"bar\"; filename=\"a.bin\""
                 )
             )
         );
@@ -395,24 +371,20 @@ public final class RqMultipartTest {
         final String body = "443 N Wolfe Rd, Sunnyvale, CA 94085";
         final RqMultipart multi = new RqMultipart.Fake(
             new RqFake(),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(
-                        (long) body.getBytes().length
-                    ),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"t5\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(
+                    (long) body.getBytes().length
+                ),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"t5\""
                 )
             ),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", ""),
-                    RqMultipartTest.contentLengthHeader(0L),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"data\"; filename=\"a.zip\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", ""),
+                RqMultipartTest.contentLengthHeader(0L),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"data\"; filename=\"a.zip\""
                 )
             )
         );
@@ -432,24 +404,20 @@ public final class RqMultipartTest {
         final String body = "441 N Wolfe Rd, Sunnyvale, CA 94085";
         final RqMultipart multi = new RqMultipart.Fake(
             new RqFake(),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", body),
-                    RqMultipartTest.contentLengthHeader(
-                        (long) body.getBytes().length
-                    ),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"address\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", body),
+                RqMultipartTest.contentLengthHeader(
+                    (long) body.getBytes().length
+                ),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"address\""
                 )
             ),
-            new RqGreedy(
-                new RqWithHeaders(
-                    new RqFake("", "", ""),
-                    RqMultipartTest.contentLengthHeader(0L),
-                    RqMultipartTest.contentDispositionHeader(
-                        "form-data; name=\"data\"; filename=\"a.bin\""
-                    )
+            new RqWithHeaders(
+                new RqFake("", "", ""),
+                RqMultipartTest.contentLengthHeader(0L),
+                RqMultipartTest.contentDispositionHeader(
+                    "form-data; name=\"data\"; filename=\"a.bin\""
                 )
             )
         );


### PR DESCRIPTION
Issue #625. Puzzle 620-91883c6a in src/test/java/org/takes/rq/RqMultipartTest.java:91-98. This test is using RqGreedy in order to survive. Let's remove RqGreedy from this test and three other test methods below. This PR do the following changes:

- Removes RqGreedy from RqMultipartTest.
- Refactoring 'RqMultipart.Fake.FakeMultipartRequest' to not read body() of dispositions several times. Rather that, the body is created only one time, at the constructor.