### PR TITLE
#674 Get rid of StandardCharsets.UTF_8.

### DIFF
--- a/src/main/java/org/takes/facets/fallback/FbLog4j.java
+++ b/src/main/java/org/takes/facets/fallback/FbLog4j.java
@@ -26,11 +26,11 @@ package org.takes.facets.fallback;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import org.apache.log4j.Logger;
 import org.takes.Response;
 import org.takes.misc.Opt;
+import org.takes.misc.Utf8PrintStream;
 import org.takes.rq.RqHref;
 import org.takes.rq.RqMethod;
 
@@ -67,8 +67,8 @@ public final class FbLog4j extends FbWrap {
     private static void log(final RqFallback req) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final Throwable error = req.throwable();
-        final PrintStream stream = new PrintStream(
-            baos, false, StandardCharsets.UTF_8.toString()
+        final PrintStream stream = new Utf8PrintStream(
+            baos, false
         );
         try {
             error.printStackTrace(stream);

--- a/src/main/java/org/takes/facets/fallback/FbSlf4j.java
+++ b/src/main/java/org/takes/facets/fallback/FbSlf4j.java
@@ -26,12 +26,12 @@ package org.takes.facets.fallback;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.takes.Response;
 import org.takes.misc.Opt;
+import org.takes.misc.Utf8PrintStream;
 import org.takes.rq.RqHref;
 import org.takes.rq.RqMethod;
 
@@ -76,8 +76,8 @@ public final class FbSlf4j extends FbWrap {
     private static void log(final RqFallback req) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final Throwable error = req.throwable();
-        final PrintStream stream = new PrintStream(
-            baos, false, StandardCharsets.UTF_8.toString()
+        final PrintStream stream = new Utf8PrintStream(
+            baos, false
         );
         try {
             error.printStackTrace(stream);

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -32,12 +32,12 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
+import org.takes.misc.Utf8PrintStream;
 import org.takes.rq.RqLive;
 import org.takes.rq.RqWithHeaders;
 import org.takes.rs.RsPrint;
@@ -129,8 +129,8 @@ public final class BkBasic implements Back {
     private static Response failure(final Throwable err, final int code)
         throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final PrintStream stream = new PrintStream(
-            baos, false, StandardCharsets.UTF_8.toString()
+        final PrintStream stream = new Utf8PrintStream(
+            baos, false
         );
         try {
             err.printStackTrace(stream);

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -27,18 +27,17 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.ServerSocket;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
+import org.takes.misc.Utf8InputStreamReader;
+import org.takes.misc.Utf8OutputStreamWriter;
 
 /**
  * Command line options.
@@ -98,8 +97,8 @@ final class Options {
         } else {
             final File file = new File(port);
             if (file.exists()) {
-                final Reader reader = new InputStreamReader(
-                    new FileInputStream(file), StandardCharsets.UTF_8
+                final Reader reader = new Utf8InputStreamReader(
+                    new FileInputStream(file)
                 );
                 try {
                     // @checkstyle MagicNumber (1 line)
@@ -113,8 +112,8 @@ final class Options {
                 }
             } else {
                 socket = new ServerSocket(0);
-                final Writer writer = new OutputStreamWriter(
-                    new FileOutputStream(file), StandardCharsets.UTF_8
+                final Writer writer = new Utf8OutputStreamWriter(
+                    new FileOutputStream(file)
                 );
                 try {
                     writer.append(Integer.toString(socket.getLocalPort()));

--- a/src/main/java/org/takes/misc/Utf8InputStreamReader.java
+++ b/src/main/java/org/takes/misc/Utf8InputStreamReader.java
@@ -42,10 +42,10 @@ public class Utf8InputStreamReader extends InputStreamReader {
 
     /**
      * Ctor.
-     * @param in InpputStream value
+     * @param inputStream InpputStream value
      */
-    public Utf8InputStreamReader(InputStream in) {
-        super(in, Charset.forName(Utf8InputStreamReader.ENCODING));
+    public Utf8InputStreamReader(final InputStream inputStream) {
+        super(inputStream, Charset.forName(Utf8InputStreamReader.ENCODING));
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8InputStreamReader.java
+++ b/src/main/java/org/takes/misc/Utf8InputStreamReader.java
@@ -25,7 +25,7 @@ package org.takes.misc;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * InputStreamReader that uses UTF-8 encoding for all operations.
@@ -36,16 +36,11 @@ import java.nio.charset.Charset;
 public class Utf8InputStreamReader extends InputStreamReader {
 
     /**
-     * UTF-8 encoding.
-     */
-    private static final String ENCODING = "UTF-8";
-
-    /**
      * Ctor.
      * @param input InpputStream value
      */
     public Utf8InputStreamReader(final InputStream input) {
-        super(input, Charset.forName(Utf8InputStreamReader.ENCODING));
+        super(input, StandardCharsets.UTF_8);
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8InputStreamReader.java
+++ b/src/main/java/org/takes/misc/Utf8InputStreamReader.java
@@ -42,10 +42,10 @@ public class Utf8InputStreamReader extends InputStreamReader {
 
     /**
      * Ctor.
-     * @param inputStream InpputStream value
+     * @param input InpputStream value
      */
-    public Utf8InputStreamReader(final InputStream inputStream) {
-        super(inputStream, Charset.forName(Utf8InputStreamReader.ENCODING));
+    public Utf8InputStreamReader(final InputStream input) {
+        super(input, Charset.forName(Utf8InputStreamReader.ENCODING));
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8InputStreamReader.java
+++ b/src/main/java/org/takes/misc/Utf8InputStreamReader.java
@@ -1,0 +1,51 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2016 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+/**
+ * InputStreamReader that uses UTF-8 encoding for all operations.
+ * @author Dali Freire (dalifreire@gmail.com)
+ * @version $Id$
+ * @since 0.33
+ */
+public class Utf8InputStreamReader extends InputStreamReader {
+
+    /**
+     * UTF-8 encoding.
+     */
+    private static final String ENCODING = "UTF-8";
+
+    /**
+     * Ctor.
+     * @param in InpputStream value
+     */
+    public Utf8InputStreamReader(InputStream in) {
+        super(in, Charset.forName(Utf8InputStreamReader.ENCODING));
+    }
+
+}

--- a/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
+++ b/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
@@ -44,8 +44,8 @@ public class Utf8OutputStreamWriter extends OutputStreamWriter {
      * Ctor.
      * @param out OutputStream value
      */
-    public Utf8OutputStreamWriter(OutputStream out) {
-        super(out, Charset.forName(Utf8OutputStreamWriter.ENCODING));
+    public Utf8OutputStreamWriter(final OutputStream outputStream) {
+        super(outputStream, Charset.forName(Utf8OutputStreamWriter.ENCODING));
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
+++ b/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
@@ -1,0 +1,51 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2016 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+/**
+ * OutputStreamWriter that uses UTF-8 encoding for all operations.
+ * @author Dali Freire (dalifreire@gmail.com)
+ * @version $Id$
+ * @since 0.33
+ */
+public class Utf8OutputStreamWriter extends OutputStreamWriter {
+
+    /**
+     * UTF-8 encoding.
+     */
+    private static final String ENCODING = "UTF-8";
+
+    /**
+     * Ctor.
+     * @param out OutputStream value
+     */
+    public Utf8OutputStreamWriter(OutputStream out) {
+        super(out, Charset.forName(Utf8OutputStreamWriter.ENCODING));
+    }
+
+}

--- a/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
+++ b/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
@@ -42,10 +42,10 @@ public class Utf8OutputStreamWriter extends OutputStreamWriter {
 
     /**
      * Ctor.
-     * @param out OutputStream value
+     * @param output OutputStream value
      */
-    public Utf8OutputStreamWriter(final OutputStream outputStream) {
-        super(outputStream, Charset.forName(Utf8OutputStreamWriter.ENCODING));
+    public Utf8OutputStreamWriter(final OutputStream output) {
+        super(output, Charset.forName(Utf8OutputStreamWriter.ENCODING));
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
+++ b/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
@@ -25,7 +25,7 @@ package org.takes.misc;
 
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * OutputStreamWriter that uses UTF-8 encoding for all operations.
@@ -36,16 +36,11 @@ import java.nio.charset.Charset;
 public class Utf8OutputStreamWriter extends OutputStreamWriter {
 
     /**
-     * UTF-8 encoding.
-     */
-    private static final String ENCODING = "UTF-8";
-
-    /**
      * Ctor.
      * @param output OutputStream value
      */
     public Utf8OutputStreamWriter(final OutputStream output) {
-        super(output, Charset.forName(Utf8OutputStreamWriter.ENCODING));
+        super(output, StandardCharsets.UTF_8);
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -26,6 +26,7 @@ package org.takes.misc;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * PrintStream that uses UTF-8 encoding for all operations.
@@ -36,11 +37,6 @@ import java.io.UnsupportedEncodingException;
 public class Utf8PrintStream extends PrintStream {
 
     /**
-     * UTF-8 encoding.
-     */
-    private static final String ENCODING = "UTF-8";
-
-    /**
      * Ctor.
      * @param output The output stream which values and objects will be printed
      * @param flush If true, the output buffer will be flushed
@@ -48,7 +44,7 @@ public class Utf8PrintStream extends PrintStream {
      */
     public Utf8PrintStream(final OutputStream output, final boolean flush)
         throws UnsupportedEncodingException {
-        super(output, flush, Utf8PrintStream.ENCODING);
+        super(output, flush, StandardCharsets.UTF_8.toString());
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -42,9 +42,9 @@ public class Utf8PrintStream extends PrintStream {
 
     /**
      * Ctor.
-     * @param output The output stream to which values and objects will be printed
+     * @param output The output stream which values and objects will be printed
      * @param flush If true, the output buffer will be flushed
-     * @throws UnsupportedEncodingException if fails 
+     * @throws UnsupportedEncodingException if fails
      */
     public Utf8PrintStream(final OutputStream output, final boolean flush)
         throws UnsupportedEncodingException {

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -42,13 +42,13 @@ public class Utf8PrintStream extends PrintStream {
 
     /**
      * Ctor.
-     * @param out The output stream to which values and objects will be printed
-     * @param autoFlush if true, the output buffer will be flushed
-     * @throws UnsupportedEncodingException
+     * @param output The output stream to which values and objects will be printed
+     * @param flush if true, the output buffer will be flushed
+     * @throws UnsupportedEncodingException if fails 
      */
-    public Utf8PrintStream(final OutputStream outputStream, final boolean autoFlush)
+    public Utf8PrintStream(final OutputStream output, final boolean flush)
         throws UnsupportedEncodingException {
-        super(outputStream, autoFlush, Utf8PrintStream.ENCODING);
+        super(output, flush, Utf8PrintStream.ENCODING);
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2016 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * PrintStream that uses UTF-8 encoding for all operations.
+ * @author Dali Freire (dalifreire@gmail.com)
+ * @version $Id$
+ * @since 0.33
+ */
+public class Utf8PrintStream extends PrintStream {
+
+    /**
+     * UTF-8 encoding.
+     */
+    private static final String ENCODING = "UTF-8";
+
+    /**
+     * Ctor.
+     * @param out The output stream to which values and objects will be printed
+     * @param autoFlush A boolean; if true, the output buffer will be flushed
+     * whenever a byte array is written, one of the <code>println</code>
+     * methods is invoked, or a newline character or byte (<code>'\n'</code>)
+     * is written
+     * @throws UnsupportedEncodingException
+     */
+    public Utf8PrintStream(OutputStream out, boolean autoFlush) 
+        throws UnsupportedEncodingException {
+        super(out, autoFlush, Utf8PrintStream.ENCODING);
+    }
+
+}

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -43,15 +43,12 @@ public class Utf8PrintStream extends PrintStream {
     /**
      * Ctor.
      * @param out The output stream to which values and objects will be printed
-     * @param autoFlush A boolean; if true, the output buffer will be flushed
-     * whenever a byte array is written, one of the <code>println</code>
-     * methods is invoked, or a newline character or byte (<code>'\n'</code>)
-     * is written
+     * @param autoFlush if true, the output buffer will be flushed
      * @throws UnsupportedEncodingException
      */
-    public Utf8PrintStream(OutputStream out, boolean autoFlush) 
+    public Utf8PrintStream(final OutputStream outputStream, final boolean autoFlush)
         throws UnsupportedEncodingException {
-        super(out, autoFlush, Utf8PrintStream.ENCODING);
+        super(outputStream, autoFlush, Utf8PrintStream.ENCODING);
     }
 
 }

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -43,7 +43,7 @@ public class Utf8PrintStream extends PrintStream {
     /**
      * Ctor.
      * @param output The output stream to which values and objects will be printed
-     * @param flush if true, the output buffer will be flushed
+     * @param flush If true, the output buffer will be flushed
      * @throws UnsupportedEncodingException if fails 
      */
     public Utf8PrintStream(final OutputStream output, final boolean flush)

--- a/src/main/java/org/takes/rq/RqPrint.java
+++ b/src/main/java/org/takes/rq/RqPrint.java
@@ -27,11 +27,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
+import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.misc.Utf8String;
 
 /**
@@ -93,9 +92,7 @@ public final class RqPrint extends RqWrap {
      */
     public void printHead(final OutputStream output) throws IOException {
         final String eol = "\r\n";
-        final Writer writer = new OutputStreamWriter(
-            output, StandardCharsets.UTF_8
-        );
+        final Writer writer = new Utf8OutputStreamWriter(output);
         for (final String line : this.head()) {
             writer.append(line);
             writer.append(eol);

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -26,7 +26,6 @@ package org.takes.rq.multipart;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import org.takes.Request;
 import org.takes.misc.Utf8String;
 import org.takes.rq.RqHeaders;

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.takes.Request;
+import org.takes.misc.Utf8String;
 import org.takes.rq.RqHeaders;
 import org.takes.rq.RqMultipart;
 import org.takes.rq.RqPrint;
@@ -154,7 +155,7 @@ public final class RqMtFake implements RqMultipart {
         @Override
         public InputStream body() {
             return new ByteArrayInputStream(
-                this.parts.getBytes(StandardCharsets.UTF_8)
+                new Utf8String(this.parts).bytes()
             );
         }
     }

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -27,13 +27,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.misc.Utf8String;
 
 /**
@@ -124,7 +123,7 @@ public final class RsPrint extends RsWrap {
     public void printHead(final OutputStream output) throws IOException {
         final String eol = "\r\n";
         final Writer writer =
-            new OutputStreamWriter(output, StandardCharsets.UTF_8);
+            new Utf8OutputStreamWriter(output);
         int pos = 0;
         for (final String line : this.head()) {
             if (pos == 0 && !RsPrint.FIRST.matcher(line).matches()) {

--- a/src/main/java/org/takes/rs/RsVelocity.java
+++ b/src/main/java/org/takes/rs/RsVelocity.java
@@ -27,11 +27,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +39,8 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.log.NullLogChute;
 import org.takes.Response;
+import org.takes.misc.Utf8InputStreamReader;
+import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.misc.Utf8String;
 
 /**
@@ -141,9 +140,7 @@ public final class RsVelocity extends RsWrap {
     private static InputStream render(final InputStream page,
         final Map<CharSequence, Object> params) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final Writer writer = new OutputStreamWriter(
-            baos, StandardCharsets.UTF_8
-        );
+        final Writer writer = new Utf8OutputStreamWriter(baos);
         final VelocityEngine engine = new VelocityEngine();
         engine.setProperty(
             RuntimeConstants.RUNTIME_LOG_LOGSYSTEM,
@@ -153,7 +150,7 @@ public final class RsVelocity extends RsWrap {
             new VelocityContext(params),
             writer,
             "",
-            new InputStreamReader(page, StandardCharsets.UTF_8)
+            new Utf8InputStreamReader(page)
         );
         writer.close();
         return new ByteArrayInputStream(baos.toByteArray());

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -27,10 +27,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Utf8String;
 
 /**
  * Response decorator, with body.
@@ -92,7 +92,7 @@ public final class RsWithBody extends RsWrap {
      * @param body Body
      */
     public RsWithBody(final Response res, final CharSequence body) {
-        this(res, body, StandardCharsets.UTF_8);
+        this(res, new Utf8String(body.toString()).bytes());
     }
 
     /**

--- a/src/main/java/org/takes/rs/RsXSLT.java
+++ b/src/main/java/org/takes/rs/RsXSLT.java
@@ -27,7 +27,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -153,14 +152,14 @@ public final class RsXSLT extends RsWrap {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final Source xsl = RsXSLT.stylesheet(
             factory, new StreamSource(
-                new InputStreamReader(
+                new Utf8InputStreamReader(
                     new ByteArrayInputStream(new Utf8String(input).bytes())
                 )
             )
         );
         RsXSLT.transformer(factory, xsl).transform(
             new StreamSource(
-                new InputStreamReader(
+                new Utf8InputStreamReader(
                     new ByteArrayInputStream(new Utf8String(input).bytes())
                 )
             ),

--- a/src/main/java/org/takes/rs/RsXSLT.java
+++ b/src/main/java/org/takes/rs/RsXSLT.java
@@ -28,9 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -42,6 +40,9 @@ import javax.xml.transform.stream.StreamSource;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Utf8InputStreamReader;
+import org.takes.misc.Utf8OutputStreamWriter;
+import org.takes.misc.Utf8String;
 
 /**
  * Response that converts XML into HTML using attached XSL stylesheet.
@@ -140,9 +141,6 @@ public final class RsXSLT extends RsWrap {
      * @param xml XML page to be transformed.
      * @return Resulting HTML page.
      * @throws TransformerException If fails
-     * @todo #664:30min continue removing usage StandardCharsets.UTF_8 from
-     *  takes code (remove usage not only from this class but also from other
-     *  parts of project). Please look at #664 for more details.
      */
     private static InputStream transform(final TransformerFactory factory,
         final InputStream xml) throws TransformerException {
@@ -156,21 +154,23 @@ public final class RsXSLT extends RsWrap {
         final Source xsl = RsXSLT.stylesheet(
             factory, new StreamSource(
                 new InputStreamReader(
-                    new ByteArrayInputStream(input), StandardCharsets.UTF_8
+                    new ByteArrayInputStream(new Utf8String(input).bytes())
                 )
             )
         );
         RsXSLT.transformer(factory, xsl).transform(
             new StreamSource(
                 new InputStreamReader(
-                    new ByteArrayInputStream(input), StandardCharsets.UTF_8
+                    new ByteArrayInputStream(new Utf8String(input).bytes())
                 )
             ),
             new StreamResult(
-                new OutputStreamWriter(baos, StandardCharsets.UTF_8)
+                new Utf8OutputStreamWriter(baos)
             )
         );
-        return new ByteArrayInputStream(baos.toByteArray());
+        return new ByteArrayInputStream(
+            new Utf8String(baos.toByteArray()).bytes()
+        );
     }
 
     /**
@@ -264,7 +264,7 @@ public final class RsXSLT extends RsWrap {
                 );
             }
             return new StreamSource(
-                new InputStreamReader(input, StandardCharsets.UTF_8)
+                new Utf8InputStreamReader(input)
             );
         }
     }

--- a/src/main/java/org/takes/rs/xe/RsXembly.java
+++ b/src/main/java/org/takes/rs/xe/RsXembly.java
@@ -27,9 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -43,6 +41,7 @@ import javax.xml.transform.stream.StreamResult;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
+import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.rs.RsEmpty;
 import org.takes.rs.RsWithStatus;
 import org.takes.rs.RsWithType;
@@ -150,7 +149,7 @@ public final class RsXembly extends RsWrap {
             TransformerFactory.newInstance().newTransformer().transform(
                 new DOMSource(node),
                 new StreamResult(
-                    new OutputStreamWriter(baos, StandardCharsets.UTF_8)
+                    new Utf8OutputStreamWriter(baos)
                 )
             );
         } catch (final TransformerException ex) {

--- a/src/test/java/org/takes/rq/multipart/RqTempTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqTempTest.java
@@ -25,12 +25,12 @@ package org.takes.rq.multipart;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.Request;
+import org.takes.misc.Utf8String;
 
 /**
  * Test case for {@link RqTemp}.
@@ -52,7 +52,7 @@ public final class RqTempTest {
         );
         Files.write(
             file.toPath(),
-            "Temp file deletion test".getBytes(StandardCharsets.UTF_8)
+            new Utf8String("Temp file deletion test").bytes()
         );
         final Request request = new RqTemp(file);
         try {


### PR DESCRIPTION
Issue #674. Puzzle 664-ddd2c9b3 in src/main/java/org/takes/rs/RsXSLT.java:143-145. Removes usage of StandardCharsets.UTF_8 from takes code (remove usage not only from this class but also from other parts of project). This PR do the following changes:

- Create new classes Utf8InputStreamReader, Utf8OutputStreamWriter, Utf8PrintStream and and replaced StandardCharsets.UTF_8 usage in all takes code.