### PR TITLE
#667 Removes String#toLowerCase(Locale.ENGLISH)

### DIFF
--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -27,11 +27,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
 import org.takes.Response;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Opt;
 import org.takes.rq.RqHeaders;
 
@@ -81,7 +81,7 @@ public final class FkEncoding implements Fork {
      * @param response Response to return
      */
     public FkEncoding(final String enc, final Response response) {
-        this.encoding = enc.trim().toLowerCase(Locale.ENGLISH);
+        this.encoding = new EnglishLowerCase(enc.trim()).string();
         this.origin = response;
     }
 
@@ -95,9 +95,8 @@ public final class FkEncoding implements Fork {
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
                 ENCODING_SEP.split(
-                    headers.next()
-                        .trim()
-                        .toLowerCase(Locale.ENGLISH)
+                    new EnglishLowerCase(headers.next().trim())
+                        .string()
                 )
             );
             if (items.contains(this.encoding)) {

--- a/src/main/java/org/takes/facets/fork/FkHost.java
+++ b/src/main/java/org/takes/facets/fork/FkHost.java
@@ -24,11 +24,11 @@
 package org.takes.facets.fork;
 
 import java.io.IOException;
-import java.util.Locale;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Opt;
 import org.takes.rq.RqHeaders;
 
@@ -76,8 +76,8 @@ public final class FkHost extends FkWrap {
                     new RqHeaders.Base(req)
                 ).single("host");
                 final Opt<Response> rsp;
-                if (host.toLowerCase(Locale.ENGLISH)
-                    .equals(hst.toLowerCase(Locale.ENGLISH))) {
+                if (new EnglishLowerCase(host).string()
+                    .equals(new EnglishLowerCase(hst).string())) {
                     rsp = new Opt.Single<>(take.act(req));
                 } else {
                     rsp = new Opt.Empty<>();

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -24,11 +24,9 @@
 package org.takes.facets.fork;
 
 import java.util.regex.Pattern;
-
-import org.takes.misc.EnglishLowerCase;
-
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.takes.misc.EnglishLowerCase;
 
 /**
  * Media type.

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -23,8 +23,10 @@
  */
 package org.takes.facets.fork;
 
-import java.util.Locale;
 import java.util.regex.Pattern;
+
+import org.takes.misc.EnglishLowerCase;
+
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -162,9 +164,10 @@ final class MediaType implements Comparable<MediaType> {
      * @return String array with the sectors of the media type.
      */
     private static String[] sectors(final String text) {
-        return MediaType.split(text)[0].toLowerCase(Locale.ENGLISH).split(
-            "/", 2
-        );
+        return new EnglishLowerCase(MediaType.split(text)[0]).string()
+            .split(
+                "/", 2
+            );
     }
 
 }

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -132,8 +132,8 @@ final class MediaTypes {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private static SortedSet<MediaType> parse(final String text) {
         final SortedSet<MediaType> list = new TreeSet<MediaType>();
-        final String[] split = new EnglishLowerCase(text).string().split(",");
-        for (final String name : split) {
+        for (final String name
+            : new EnglishLowerCase(text).string().split(",")) {
             if (!name.isEmpty()) {
                 list.add(new MediaType(name));
             }

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -26,11 +26,9 @@ package org.takes.facets.fork;
 import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
-import org.takes.misc.EnglishLowerCase;
-
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.takes.misc.EnglishLowerCase;
 
 /**
  * Media types.

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -24,9 +24,11 @@
 package org.takes.facets.fork;
 
 import java.util.Collections;
-import java.util.Locale;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.takes.misc.EnglishLowerCase;
+
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -132,7 +134,8 @@ final class MediaTypes {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private static SortedSet<MediaType> parse(final String text) {
         final SortedSet<MediaType> list = new TreeSet<MediaType>();
-        for (final String name : text.toLowerCase(Locale.ENGLISH).split(",")) {
+        final String[] split = new EnglishLowerCase(text).string().split(",");
+        for (final String name : split) {
             if (!name.isEmpty()) {
                 list.add(new MediaType(name));
             }

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2016 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.util.Locale;
+
+/**
+ * English lower case string representation.
+ * @author Dali Freire (dalifreire@gmail.com)
+ * @version $Id$
+ * @since 0.33
+ */
+public final class EnglishLowerCase {
+
+    /**
+     * English locale.
+     */
+    private static final Locale ENGLISH = Locale.ENGLISH;
+
+    /**
+     * String value.
+     */
+    private final transient String value;
+
+    /**
+     * Ctor.
+     * @param string String value
+     */
+    public EnglishLowerCase(final String string) {
+        this.value = string.toLowerCase(ENGLISH);
+    }
+
+    /**
+     * Returns string value.
+     * @return String value
+     */
+    public String string() {
+        return this.value;
+    }
+
+}

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -51,7 +51,7 @@ public final class EnglishLowerCase {
      * @param string String value
      */
     public EnglishLowerCase(final String string) {
-        this.value = EnglishLowerCase.lowerCase(string);
+        this.value = string;
     }
 
     /**
@@ -59,16 +59,7 @@ public final class EnglishLowerCase {
      * @return String value
      */
     public String string() {
-        return this.value;
-    }
-
-    /**
-     * Returns the lower case string.
-     * @param string String value
-     * @return The english lower case string
-     */
-    private static String lowerCase(final String string) {
-        return string.toLowerCase(Locale.ENGLISH);
+        return this.value.toLowerCase(Locale.ENGLISH);
     }
 
 }

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -34,21 +34,24 @@ import java.util.Locale;
 public final class EnglishLowerCase {
 
     /**
-     * English locale.
-     */
-    private static final Locale ENGLISH = Locale.ENGLISH;
-
-    /**
      * String value.
      */
     private final transient String value;
 
     /**
      * Ctor.
+     * @param text Text value
+     */
+    public EnglishLowerCase(final CharSequence text) {
+        this(text.toString());
+    }
+
+    /**
+     * Ctor.
      * @param string String value
      */
     public EnglishLowerCase(final String string) {
-        this.value = string.toLowerCase(EnglishLowerCase.ENGLISH);
+        this.value = string.toLowerCase(Locale.ENGLISH);
     }
 
     /**

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -48,7 +48,7 @@ public final class EnglishLowerCase {
      * @param string String value
      */
     public EnglishLowerCase(final String string) {
-        this.value = string.toLowerCase(ENGLISH);
+        this.value = string.toLowerCase(EnglishLowerCase.ENGLISH);
     }
 
     /**

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -51,7 +51,7 @@ public final class EnglishLowerCase {
      * @param string String value
      */
     public EnglishLowerCase(final String string) {
-        this.value = string.toLowerCase(Locale.ENGLISH);
+        this.value = EnglishLowerCase.lowerCase(string);
     }
 
     /**
@@ -60,6 +60,15 @@ public final class EnglishLowerCase {
      */
     public String string() {
         return this.value;
+    }
+
+    /**
+     * Returns the lower case string.
+     * @param string String value
+     * @return The english lower case string
+     */
+    private static String lowerCase(final String string) {
+        return string.toLowerCase(Locale.ENGLISH);
     }
 
 }

--- a/src/main/java/org/takes/rq/RqCookies.java
+++ b/src/main/java/org/takes/rq/RqCookies.java
@@ -26,10 +26,10 @@ package org.takes.rq;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Sprintf;
 import org.takes.misc.VerboseIterable;
 
@@ -80,7 +80,7 @@ public interface RqCookies extends Request {
             throws IOException {
             final Map<String, String> map = this.map();
             final String value = map.get(
-                key.toString().toLowerCase(Locale.ENGLISH)
+                new EnglishLowerCase(key.toString()).string()
             );
             final Iterable<String> iter;
             if (value == null) {
@@ -123,7 +123,7 @@ public interface RqCookies extends Request {
                 for (final String pair : value.split(";")) {
                     final String[] parts = pair.split("=", 2);
                     final String key =
-                        parts[0].trim().toLowerCase(Locale.ENGLISH);
+                        new EnglishLowerCase(parts[0].trim()).string();
                     if (parts.length > 1 && !parts[1].isEmpty()) {
                         map.put(key, parts[1].trim());
                     } else {

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -36,12 +36,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.EqualsAndHashCode;
 import org.takes.HttpException;
 import org.takes.Request;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Sprintf;
 import org.takes.misc.Utf8String;
 import org.takes.misc.VerboseIterable;
@@ -111,7 +111,7 @@ public interface RqForm extends Request {
         public Iterable<String> param(final CharSequence key)
             throws IOException {
             final List<String> values =
-                this.map().get(key.toString().toLowerCase(Locale.ENGLISH));
+                this.map().get(new EnglishLowerCase(key.toString()).string());
             final Iterable<String> iter;
             if (values == null) {
                 iter = new VerboseIterable<>(
@@ -191,7 +191,7 @@ public interface RqForm extends Request {
                     );
                 }
                 final String key = RqForm.Base.decode(
-                    parts[0].trim().toLowerCase(Locale.ENGLISH)
+                    new EnglishLowerCase(parts[0].trim()).string()
                 );
                 if (!map.containsKey(key)) {
                     map.put(key, new LinkedList<String>());

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -65,8 +65,9 @@ import org.takes.misc.VerboseIterable;
  *     Forms in HTML</a>
  * @see org.takes.rq.RqGreedy
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #667 refactor this class and get rid the
- * ClassDataAbstractionCouplingCheck checkstyle supression.
+ * @todo #667 Reduce the data abstraction coupling of RqForm in order
+ *  to get rid of the checkstyle suppression of
+ *  ClassDataAbstractionCouplingCheck
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public interface RqForm extends Request {

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -65,8 +65,8 @@ import org.takes.misc.VerboseIterable;
  *     Forms in HTML</a>
  * @see org.takes.rq.RqGreedy
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #667:30min Reduce the data abstraction coupling of RqForm in order
- *  to get rid of the checkstyle suppression of
+ * @todo #667:30min Refacor this class to reduce the data abstraction
+ *  coupling in order to get rid of the checkstyle suppression of
  *  ClassDataAbstractionCouplingCheck
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -64,6 +64,7 @@ import org.takes.misc.VerboseIterable;
  * @see <a href="http://www.w3.org/TR/html401/interact/forms.html">
  *     Forms in HTML</a>
  * @see org.takes.rq.RqGreedy
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public interface RqForm extends Request {

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -65,6 +65,8 @@ import org.takes.misc.VerboseIterable;
  *     Forms in HTML</a>
  * @see org.takes.rq.RqGreedy
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @todo #667 refactor this class and get rid the
+ *     ClassDataAbstractionCouplingCheck checkstyle supression.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public interface RqForm extends Request {

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -66,7 +66,7 @@ import org.takes.misc.VerboseIterable;
  * @see org.takes.rq.RqGreedy
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @todo #667 refactor this class and get rid the
- *     ClassDataAbstractionCouplingCheck checkstyle supression.
+ * ClassDataAbstractionCouplingCheck checkstyle supression.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public interface RqForm extends Request {

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -65,7 +65,7 @@ import org.takes.misc.VerboseIterable;
  *     Forms in HTML</a>
  * @see org.takes.rq.RqGreedy
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #667 Reduce the data abstraction coupling of RqForm in order
+ * @todo #667:30min Reduce the data abstraction coupling of RqForm in order
  *  to get rid of the checkstyle suppression of
  *  ClassDataAbstractionCouplingCheck
  */

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -93,7 +93,7 @@ public interface RqHeaders extends Request {
         public List<String> header(final CharSequence key)
             throws IOException {
             final List<String> values = this.map().get(
-                new EnglishLowerCase(key.toString()).string()
+                new EnglishLowerCase(key).string()
             );
             final List<String> list;
             if (values == null) {

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -31,12 +31,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import org.takes.HttpException;
 import org.takes.Request;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.VerboseList;
 
 /**
@@ -93,7 +93,7 @@ public interface RqHeaders extends Request {
         public List<String> header(final CharSequence key)
             throws IOException {
             final List<String> values = this.map().get(
-                key.toString().toLowerCase(Locale.ENGLISH)
+                new EnglishLowerCase(key.toString()).string()
             );
             final List<String> list;
             if (values == null) {
@@ -150,7 +150,9 @@ public interface RqHeaders extends Request {
                         String.format("invalid HTTP header: \"%s\"", line)
                     );
                 }
-                final String key = parts[0].trim().toLowerCase(Locale.ENGLISH);
+                final String key = new EnglishLowerCase(
+                    parts[0].trim()
+                ).string();
                 if (!map.containsKey(key)) {
                     map.put(key, new LinkedList<String>());
                 }

--- a/src/main/java/org/takes/rq/RqWithoutHeader.java
+++ b/src/main/java/org/takes/rq/RqWithoutHeader.java
@@ -25,10 +25,10 @@ package org.takes.rq;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Locale;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
 import org.takes.misc.Condition;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Select;
 
 /**
@@ -55,14 +55,14 @@ public final class RqWithoutHeader extends RqWrap {
                 @Override
                 public Iterable<String> head() throws IOException {
                     final String prefix = String.format(
-                        "%s:", name.toString().toLowerCase(Locale.ENGLISH)
+                        "%s:", new EnglishLowerCase(name.toString()).string()
                     );
                     return new Select<String>(
                         req.head(),
                         new Condition<String>() {
                             @Override
                             public boolean fits(final String header) {
-                                return !header.toLowerCase(Locale.ENGLISH)
+                                return !new EnglishLowerCase(header).string()
                                     .startsWith(prefix);
                             }
                         }

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -40,12 +40,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.takes.HttpException;
 import org.takes.Request;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Sprintf;
 import org.takes.misc.VerboseIterable;
 import org.takes.rq.RqHeaders;
@@ -127,7 +127,7 @@ public final class RqMtBase implements RqMultipart {
     @Override
     public Iterable<Request> part(final CharSequence name) {
         final List<Request> values = this.map
-            .get(name.toString().toLowerCase(Locale.ENGLISH));
+            .get(new EnglishLowerCase(name.toString()).string());
         final Iterable<Request> iter;
         if (values == null) {
             iter = new VerboseIterable<>(
@@ -172,7 +172,7 @@ public final class RqMtBase implements RqMultipart {
     private Map<String, List<Request>> requests(
         final Request req) throws IOException {
         final String header = new RqHeaders.Smart(req).single("Content-Type");
-        if (!header.toLowerCase(Locale.ENGLISH)
+        if (!new EnglishLowerCase(header).string()
             .startsWith("multipart/form-data")) {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -70,6 +70,7 @@ import org.takes.rq.RqMultipart;
  * @see <a href="http://www.w3.org/TR/html401/interact/forms.html">
  *  Forms in HTML</a>
  * @see org.takes.rq.RqGreedy
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @lombok.EqualsAndHashCode(of = "origin")
 public final class RqMtBase implements RqMultipart {

--- a/src/main/java/org/takes/rs/RsWithoutHeader.java
+++ b/src/main/java/org/takes/rs/RsWithoutHeader.java
@@ -25,11 +25,11 @@ package org.takes.rs;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Locale;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
 import org.takes.misc.Condition;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Select;
 
 /**
@@ -57,14 +57,14 @@ public final class RsWithoutHeader extends RsWrap {
                 @Override
                 public Iterable<String> head() throws IOException {
                     final String prefix = String.format(
-                        "%s:", name.toString().toLowerCase(Locale.ENGLISH)
+                        "%s:", new EnglishLowerCase(name.toString()).string()
                     );
                     return new Select<String>(
                         res.head(),
                         new Condition<String>() {
                             @Override
                             public boolean fits(final String header) {
-                                return !header.toLowerCase(Locale.ENGLISH)
+                                return !new EnglishLowerCase(header).string()
                                     .startsWith(prefix);
                             }
                         }

--- a/src/main/java/org/takes/tk/TkProxy.java
+++ b/src/main/java/org/takes/tk/TkProxy.java
@@ -130,6 +130,7 @@ public final class TkProxy implements Take {
      * @return Request to be forwarded
      * @throws IOException If some problem inside
      */
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private com.jcabi.http.Request request(final Request req,
         final URI dest) throws IOException {
         final String method = new RqMethod.Base(req).method();

--- a/src/main/java/org/takes/tk/TkProxy.java
+++ b/src/main/java/org/takes/tk/TkProxy.java
@@ -30,11 +30,11 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.rq.RqHeaders;
 import org.takes.rq.RqLengthAware;
 import org.takes.rq.RqMethod;
@@ -136,7 +136,7 @@ public final class TkProxy implements Take {
         com.jcabi.http.Request proxied = new JdkRequest(dest).method(method);
         final RqHeaders headers = new RqHeaders.Base(req);
         for (final String name : headers.names()) {
-            if ("content-length".equals(name.toLowerCase(Locale.ENGLISH))) {
+            if ("content-length".equals(new EnglishLowerCase(name).string())) {
                 continue;
             }
             if (TkProxy.isHost(name)) {
@@ -202,6 +202,6 @@ public final class TkProxy implements Take {
      *  header name, {@code false} otherwise
      */
     private static boolean isHost(final String header) {
-        return "host".equals(header.toLowerCase(Locale.ENGLISH));
+        return "host".equals(new EnglishLowerCase(header).string());
     }
 }


### PR DESCRIPTION
Issue #667. There are too many places in the code base where we call toLowerCase(Locale.ENGLISH) from a String. This PR do the following changes:

- Create new class EnglishLowerCase and replaces String#toLowerCase(Locale.ENGLISH) usage in all takes code.
- A new puzlle was created in the class org.takes.rq.RqForm.