### PR TITLE
#678 - Removes the SuppressWarnings PMD.BeanMembersShouldSerialize

### DIFF
--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -43,7 +43,7 @@ public class HttpException extends IOException {
     /**
      * Status code.
      */
-    private final Integer status;
+    private final int status;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -43,7 +43,7 @@ public class HttpException extends IOException {
     /**
      * Status code.
      */
-    private final int status;
+    private final transient int status;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -43,7 +43,7 @@ public class HttpException extends IOException {
     /**
      * Status code.
      */
-    private final int status;
+    private final Integer status;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -43,7 +43,7 @@ public class HttpException extends IOException {
     /**
      * Status code.
      */
-    private final transient int status;
+    private final int status;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -31,15 +31,8 @@ import java.io.IOException;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.13
- * @todo #660:30min Remove the SuppressWarnings PMD.BeanMembersShouldSerialize
- *  once the next release of Qulice will be available as it has been removed by
- *  https://github.com/teamed/qulice/issues/675
  */
-@SuppressWarnings(
-    {
-        "PMD.OnlyOneConstructorShouldDoInitialization",
-        "PMD.BeanMembersShouldSerialize"
-    })
+@SuppressWarnings("PMD.OnlyOneConstructorShouldDoInitialization")
 public class HttpException extends IOException {
 
     /**


### PR DESCRIPTION
Issue #678. 
The SuppressWarnings PMD.BeanMembersShouldSerialize was removed from the org.takes.HttpException class.