### PR TITLE
#684. Upper case => camel case. Add 3 suppress warnings and puzzle to remove them

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,42 +342,6 @@
                                 <exclude>checkstyle:/src/site/resources/.*</exclude>
                                 <!--
                                 @todo #678:30min After upgrade to qulice 0.16.4 we have to fix 
-                                 AbbreviationAsWordInNameCheck checkstyle warings in next classes. 
-                                 Fix issues and remove all excludes of PMD here.
-                                -->
-                                <exclude>checkstyle:/src/main/java/org/takes/facets/auth/codecs/CcAES.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/facets/auth/codecs/CcXOR.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/misc/Href.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/xe/XeSLA.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/RsJSON.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/RsPrettyJSON.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/RsWithType.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/RsXSLT.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/RsHTML.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/Body.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rs/RsPrettyXML.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/tk/TkHTML.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/tk/TkCORS.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/rq/ChunkedInputStream.java</exclude>
-                                <exclude>checkstyle:/src/main/java/org/takes/http/FtCLI.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/facets/auth/codecs/CcAESTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/facets/auth/codecs/CcXORTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/misc/HrefTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rs/xe/XeSLATest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rs/BodyTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rs/RsXSLTTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rs/RsJSONTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rs/RsPrettyJSONTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rs/RsPrettyXMLTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/tk/TkHTMLTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/tk/TkRedirectTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/tk/TkCORSTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/rq/RqMethodTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/http/FtBasicTest.java</exclude>
-                                <exclude>checkstyle:/src/test/java/org/takes/http/FtCLITest.java</exclude>
-                                <!--
-                                @todo #678:30min After upgrade to qulice 0.16.4 we have to fix 
                                  AvoidDuplicateLiterals PMD warings in next classes. Fix issues and  
                                  remove all excludes of PMD here.
                                 -->                                

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/App.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/App.java
@@ -31,8 +31,8 @@ import org.takes.Take;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
 import org.takes.http.Exit;
-import org.takes.http.FtCLI;
-import org.takes.tk.TkHTML;
+import org.takes.http.FtCli;
+import org.takes.tk.TkHtml;
 import org.takes.tk.TkRedirect;
 
 /**
@@ -64,7 +64,7 @@ public final class App implements Take {
      * @throws IOException If fails
      */
     public static void main(final String... args) throws IOException {
-        new FtCLI(
+        new FtCli(
             new App(new File(System.getProperty("user.dir"))),
             args
         ).start(Exit.NEVER);
@@ -76,7 +76,7 @@ public final class App implements Take {
             new FkRegex("/", new TkRedirect("/f")),
             new FkRegex(
                 "/about",
-                new TkHTML(App.class.getResource("about.html"))
+                new TkHtml(App.class.getResource("about.html"))
             ),
             new FkRegex("/robots.txt", ""),
             new FkRegex("/f(.*)", new TkDir(this.home))

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/RsPage.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/RsPage.java
@@ -26,7 +26,7 @@ package org.takes.it.fm;
 import java.io.IOException;
 import java.io.InputStream;
 import org.takes.Response;
-import org.takes.rs.RsXSLT;
+import org.takes.rs.RsXslt;
 import org.takes.rs.xe.RsXembly;
 import org.takes.rs.xe.XeAppend;
 import org.takes.rs.xe.XeMillis;
@@ -53,7 +53,7 @@ final class RsPage implements Response {
      * @param source Xembly source
      */
     RsPage(final String xsl, final XeSource source) {
-        this.origin = new RsXSLT(
+        this.origin = new RsXslt(
             new RsXembly(
                 new XeStylesheet(xsl),
                 new XeAppend(

--- a/src/main/java/org/takes/facets/auth/codecs/CcAes.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcAes.java
@@ -48,7 +48,7 @@ import org.takes.facets.auth.Identity;
  * @since 0.13.8
  */
 @EqualsAndHashCode(of = {"origin", "key", "spec"})
-public final class CcAES implements Codec {
+public final class CcAes implements Codec {
     /**
      * The block size constant.
      */
@@ -76,7 +76,7 @@ public final class CcAES implements Codec {
      * @param key The encryption key
      * @since 0.22
      */
-    public CcAES(final Codec codec, final String key) {
+    public CcAes(final Codec codec, final String key) {
         this(codec, key.getBytes(Charset.defaultCharset()));
     }
 
@@ -86,10 +86,10 @@ public final class CcAES implements Codec {
      * @param codec Original codec
      * @param key The encryption key
      */
-    public CcAES(final Codec codec, final byte[] key) {
+    public CcAes(final Codec codec, final byte[] key) {
         this.origin = codec;
         this.key = key.clone();
-        this.spec = CcAES.algorithmParameterSpec();
+        this.spec = CcAes.algorithmParameterSpec();
     }
 
     @Override
@@ -126,7 +126,7 @@ public final class CcAES implements Codec {
      */
     private static AlgorithmParameterSpec algorithmParameterSpec() {
         final SecureRandom random = new SecureRandom();
-        final byte[] bytes = new byte[CcAES.BLOCK];
+        final byte[] bytes = new byte[CcAes.BLOCK];
         random.nextBytes(bytes);
         return new IvParameterSpec(bytes);
     }
@@ -138,11 +138,11 @@ public final class CcAES implements Codec {
      * @return The verified encryption key
      */
     private static byte[] withCorrectBlockSize(final byte[] key) {
-        if (key.length != CcAES.BLOCK) {
+        if (key.length != CcAes.BLOCK) {
             throw new IllegalArgumentException(
                 String.format(
                     "the length of the AES key must be exactly %d bytes",
-                    CcAES.BLOCK
+                    CcAes.BLOCK
                 )
             );
         }
@@ -177,7 +177,7 @@ public final class CcAES implements Codec {
         throws IOException {
         try {
             final SecretKeySpec secret = new SecretKeySpec(
-                CcAES.withCorrectBlockSize(this.key), "AES"
+                CcAes.withCorrectBlockSize(this.key), "AES"
             );
             final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
             cipher.init(mode, secret, this.spec);

--- a/src/main/java/org/takes/facets/auth/codecs/CcXor.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcXor.java
@@ -39,7 +39,7 @@ import org.takes.misc.Utf8String;
  * @since 0.1
  */
 @EqualsAndHashCode(of = { "origin", "secret" })
-public final class CcXOR implements Codec {
+public final class CcXor implements Codec {
 
     /**
      * Original codec.
@@ -56,7 +56,7 @@ public final class CcXOR implements Codec {
      * @param codec Original codec
      * @param key Secret key for encoding
      */
-    public CcXOR(final Codec codec, final String key) {
+    public CcXor(final Codec codec, final String key) {
         this(codec, new Utf8String(key).bytes());
     }
 
@@ -65,7 +65,7 @@ public final class CcXOR implements Codec {
      * @param codec Original codec
      * @param key Secret key for encoding
      */
-    public CcXOR(final Codec codec, final byte[] key) {
+    public CcXor(final Codec codec, final byte[] key) {
         this.origin = codec;
         this.secret = Arrays.copyOf(key, key.length);
     }

--- a/src/main/java/org/takes/http/FtCli.java
+++ b/src/main/java/org/takes/http/FtCli.java
@@ -58,7 +58,7 @@ import org.takes.rq.RqWithHeader;
  * @since 0.1
  */
 @EqualsAndHashCode(of = { "take", "options" })
-public final class FtCLI implements Front {
+public final class FtCli implements Front {
 
     /**
      * Take.
@@ -75,7 +75,7 @@ public final class FtCLI implements Front {
      * @param tks Take
      * @param args Arguments
      */
-    public FtCLI(final Take tks, final String... args) {
+    public FtCli(final Take tks, final String... args) {
         this(tks, Arrays.asList(args));
     }
 
@@ -84,7 +84,7 @@ public final class FtCLI implements Front {
      * @param tks Take
      * @param args Arguments
      */
-    public FtCLI(final Take tks, final Iterable<String> args) {
+    public FtCli(final Take tks, final Iterable<String> args) {
         this.take = tks;
         this.options = new Options(args);
     }
@@ -96,7 +96,7 @@ public final class FtCLI implements Front {
             tks = new Take() {
                 @Override
                 public Response act(final Request request) throws IOException {
-                    return FtCLI.this.take.act(
+                    return FtCli.this.take.act(
                         new RqWithHeader(
                             request, "X-Takes-HitRefresh: yes"
                         )
@@ -125,7 +125,7 @@ public final class FtCLI implements Front {
                     @Override
                     public void run() {
                         try {
-                            front.start(FtCLI.this.exit(exit));
+                            front.start(FtCli.this.exit(exit));
                         } catch (final IOException ex) {
                             throw new IllegalStateException(ex);
                         }

--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -81,7 +81,7 @@ public final class Href implements CharSequence {
      * @param txt Text of the link
      */
     public Href(final CharSequence txt) {
-        this(Href.createURI(txt.toString()));
+        this(Href.createUri(txt.toString()));
     }
 
     /**
@@ -282,7 +282,7 @@ public final class Href implements CharSequence {
      * @throws IllegalStateException in case an invalid character could not be
      *  encoded properly.
      */
-    private static URI createURI(final String txt) {
+    private static URI createUri(final String txt) {
         URI result;
         try {
             result = new URI(txt);
@@ -297,7 +297,7 @@ public final class Href implements CharSequence {
                 index + 1,
                 Href.encode(value.substring(index, index + 1))
             );
-            result = Href.createURI(value.toString());
+            result = Href.createUri(value.toString());
         }
         return result;
     }

--- a/src/main/java/org/takes/rq/ChunkedInputStream.java
+++ b/src/main/java/org/takes/rq/ChunkedInputStream.java
@@ -120,7 +120,7 @@ final class ChunkedInputStream extends InputStream {
      * Read the CRLF terminator.
      * @throws IOException If an IO error occurs.
      */
-    private void readCRLF() throws IOException {
+    private void readCrlf() throws IOException {
         final int crsymbol = this.origin.read();
         final int lfsymbol = this.origin.read();
         if (crsymbol != '\r' || lfsymbol != '\n') {
@@ -142,7 +142,7 @@ final class ChunkedInputStream extends InputStream {
      */
     private void nextChunk() throws IOException {
         if (!this.bof) {
-            this.readCRLF();
+            this.readCrlf();
         }
         this.size = ChunkedInputStream.chunkSize(this.origin);
         this.bof = false;

--- a/src/main/java/org/takes/rs/Body.java
+++ b/src/main/java/org/takes/rs/Body.java
@@ -63,7 +63,7 @@ interface Body {
     /**
      * Content of a body based on an {@link java.net.URL}.
      */
-    final class URL implements Body {
+    final class Url implements Body {
 
         /**
          * The {@link java.net.URL} of the content.
@@ -74,7 +74,7 @@ interface Body {
          * Constructs an {@code URL} with the specified {@link java.net.URL}.
          * @param content The {@link java.net.URL} of the content.
          */
-        URL(final java.net.URL content) {
+        Url(final java.net.URL content) {
             this.url = content;
         }
 

--- a/src/main/java/org/takes/rs/RsHtml.java
+++ b/src/main/java/org/takes/rs/RsHtml.java
@@ -41,13 +41,13 @@ import org.takes.Response;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class RsHTML extends RsWrap {
+public final class RsHtml extends RsWrap {
 
     /**
      * Ctor.
      * @since 0.10
      */
-    public RsHTML() {
+    public RsHtml() {
         this("<html/>");
     }
 
@@ -55,7 +55,7 @@ public final class RsHTML extends RsWrap {
      * Ctor.
      * @param body HTML body
      */
-    public RsHTML(final CharSequence body) {
+    public RsHtml(final CharSequence body) {
         this(new RsEmpty(), body);
     }
 
@@ -63,7 +63,7 @@ public final class RsHTML extends RsWrap {
      * Ctor.
      * @param body HTML body
      */
-    public RsHTML(final byte[] body) {
+    public RsHtml(final byte[] body) {
         this(new RsEmpty(), body);
     }
 
@@ -72,7 +72,7 @@ public final class RsHTML extends RsWrap {
      * @param url URL with body
      * @since 0.10
      */
-    public RsHTML(final URL url) {
+    public RsHtml(final URL url) {
         this(new RsEmpty(), url);
     }
 
@@ -80,7 +80,7 @@ public final class RsHTML extends RsWrap {
      * Ctor.
      * @param body HTML body
      */
-    public RsHTML(final InputStream body) {
+    public RsHtml(final InputStream body) {
         this(new RsEmpty(), body);
     }
 
@@ -89,7 +89,7 @@ public final class RsHTML extends RsWrap {
      * @param res Original response
      * @param body HTML body
      */
-    public RsHTML(final Response res, final CharSequence body) {
+    public RsHtml(final Response res, final CharSequence body) {
         this(new RsWithBody(res, body));
     }
 
@@ -98,7 +98,7 @@ public final class RsHTML extends RsWrap {
      * @param res Original response
      * @param body HTML body
      */
-    public RsHTML(final Response res, final byte[] body) {
+    public RsHtml(final Response res, final byte[] body) {
         this(new RsWithBody(res, body));
     }
 
@@ -107,7 +107,7 @@ public final class RsHTML extends RsWrap {
      * @param res Original response
      * @param body HTML body
      */
-    public RsHTML(final Response res, final InputStream body) {
+    public RsHtml(final Response res, final InputStream body) {
         this(new RsWithBody(res, new Body.TempFile(new Body.Stream(body))));
     }
 
@@ -116,7 +116,7 @@ public final class RsHTML extends RsWrap {
      * @param res Original response
      * @param url URL with body
      */
-    public RsHTML(final Response res, final URL url) {
+    public RsHtml(final Response res, final URL url) {
         this(new RsWithBody(res, url));
     }
 
@@ -125,7 +125,7 @@ public final class RsHTML extends RsWrap {
      * @param res Original response
      * @since 0.10
      */
-    public RsHTML(final Response res) {
+    public RsHtml(final Response res) {
         super(
             new RsWithType(
                 new RsWithStatus(res, HttpURLConnection.HTTP_OK),

--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -49,6 +49,7 @@ import org.takes.Response;
  * @version $Id$
  * @since 1.0
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = "origin")
 @EqualsAndHashCode(of = "origin")
 public final class RsPrettyJson implements Response {

--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -51,7 +51,7 @@ import org.takes.Response;
  */
 @ToString(of = "origin")
 @EqualsAndHashCode(of = "origin")
-public final class RsPrettyJSON implements Response {
+public final class RsPrettyJson implements Response {
 
     /**
      * Original response.
@@ -67,7 +67,7 @@ public final class RsPrettyJSON implements Response {
      * Ctor.
      * @param res Original response
      */
-    public RsPrettyJSON(final Response res) {
+    public RsPrettyJson(final Response res) {
         this.transformed = new CopyOnWriteArrayList<Response>();
         this.origin = res;
     }
@@ -94,7 +94,7 @@ public final class RsPrettyJSON implements Response {
                 this.transformed.add(
                     new RsWithBody(
                         this.origin,
-                        RsPrettyJSON.transform(this.origin.body())
+                        RsPrettyJson.transform(this.origin.body())
                     )
                 );
             }

--- a/src/main/java/org/takes/rs/RsPrettyXml.java
+++ b/src/main/java/org/takes/rs/RsPrettyXml.java
@@ -55,6 +55,7 @@ import org.xml.sax.XMLReader;
  * @version $Id$
  * @since 1.0
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = "origin")
 @EqualsAndHashCode(of = "origin")
 public final class RsPrettyXml implements Response {

--- a/src/main/java/org/takes/rs/RsPrettyXml.java
+++ b/src/main/java/org/takes/rs/RsPrettyXml.java
@@ -57,7 +57,7 @@ import org.xml.sax.XMLReader;
  */
 @ToString(of = "origin")
 @EqualsAndHashCode(of = "origin")
-public final class RsPrettyXML implements Response {
+public final class RsPrettyXml implements Response {
 
     /**
      * Xerces feature to disable external DTD validation.
@@ -79,7 +79,7 @@ public final class RsPrettyXML implements Response {
      * Ctor.
      * @param res Original response
      */
-    public RsPrettyXML(final Response res) {
+    public RsPrettyXml(final Response res) {
         this.transformed = new CopyOnWriteArrayList<Response>();
         this.origin = res;
     }
@@ -106,7 +106,7 @@ public final class RsPrettyXML implements Response {
                 this.transformed.add(
                     new RsWithBody(
                         this.origin,
-                        RsPrettyXML.transform(this.origin.body())
+                        RsPrettyXml.transform(this.origin.body())
                     )
                 );
             }
@@ -128,16 +128,17 @@ public final class RsPrettyXML implements Response {
                 .newSAXParser().getXMLReader();
             source.setXMLReader(xmlreader);
             xmlreader.setFeature(
-                RsPrettyXML.LOAD_EXTERNAL_DTD, false
+                RsPrettyXml.LOAD_EXTERNAL_DTD, false
             );
+            final String yes = "yes";
             final Transformer transformer = TransformerFactory.newInstance()
                 .newTransformer();
             // @checkstyle MultipleStringLiteralsCheck (2 line)
             transformer.setOutputProperty(
-                OutputKeys.OMIT_XML_DECLARATION, "yes"
+                OutputKeys.OMIT_XML_DECLARATION, yes
             );
-            RsPrettyXML.prepareDocType(body, transformer);
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            RsPrettyXml.prepareDocType(body, transformer);
+            transformer.setOutputProperty(OutputKeys.INDENT, yes);
             transformer.transform(source, new StreamResult(result));
         } catch (final TransformerException ex) {
             throw new IOException(ex);
@@ -159,13 +160,14 @@ public final class RsPrettyXML implements Response {
     private static void prepareDocType(final InputStream body,
         final Transformer transformer) throws IOException {
         try {
-            final DocumentType doctype = RsPrettyXML.getDocType(body);
+            final String html = "html";
+            final DocumentType doctype = RsPrettyXml.getDocType(body);
             if (null != doctype) {
                 if (null == doctype.getSystemId()
                     && null == doctype.getPublicId()
                     // @checkstyle MultipleStringLiteralsCheck (3 line)
-                    && "html".equalsIgnoreCase(doctype.getName())) {
-                    transformer.setOutputProperty(OutputKeys.METHOD, "html");
+                    && html.equalsIgnoreCase(doctype.getName())) {
+                    transformer.setOutputProperty(OutputKeys.METHOD, html);
                     transformer.setOutputProperty(OutputKeys.VERSION, "5.0");
                     return;
                 }
@@ -199,7 +201,7 @@ public final class RsPrettyXML implements Response {
         final DocumentBuilderFactory factory =
             DocumentBuilderFactory.newInstance();
         try {
-            factory.setFeature(RsPrettyXML.LOAD_EXTERNAL_DTD, false);
+            factory.setFeature(RsPrettyXml.LOAD_EXTERNAL_DTD, false);
             final DocumentBuilder builder = factory.newDocumentBuilder();
             return builder.parse(body).getDoctype();
         } catch (final ParserConfigurationException ex) {

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -113,7 +113,7 @@ public final class RsWithBody extends RsWrap {
      * @param url URL with body
      */
     public RsWithBody(final Response res, final URL url) {
-        this(res, new Body.URL(url));
+        this(res, new Body.Url(url));
     }
 
     /**

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -134,14 +134,14 @@ public final class RsWithType extends RsWrap {
      * @version $Id$
      * @since 0.30
      */
-    public static final class HTML extends RsWrap {
+    public static final class Html extends RsWrap {
 
         /**
          * Constructs a {@code HTML} that will add text/html as the content type
          * header to the response.
          * @param res Original response
          */
-        public HTML(final Response res) {
+        public Html(final Response res) {
             this(res, new Opt.Empty<Charset>());
         }
 
@@ -152,7 +152,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
-        public HTML(final Response res, final Charset charset) {
+        public Html(final Response res, final Charset charset) {
             this(res, new Opt.Single<Charset>(charset));
         }
 
@@ -164,7 +164,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header if
          *  present.
          */
-        private HTML(final Response res, final Opt<Charset> charset) {
+        private Html(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "text/html", charset));
         }
 
@@ -179,14 +179,14 @@ public final class RsWithType extends RsWrap {
      * @version $Id$
      * @since 0.30
      */
-    public static final class JSON extends RsWrap {
+    public static final class Json extends RsWrap {
 
         /**
          * Constructs a {@code JSON} that will add application/json as the
          * content type header to the response.
          * @param res Original response
          */
-        public JSON(final Response res) {
+        public Json(final Response res) {
             this(res, new Opt.Empty<Charset>());
         }
 
@@ -197,7 +197,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
-        public JSON(final Response res, final Charset charset) {
+        public Json(final Response res, final Charset charset) {
             this(res, new Opt.Single<Charset>(charset));
         }
 
@@ -209,7 +209,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header if
          *  present.
          */
-        private JSON(final Response res, final Opt<Charset> charset) {
+        private Json(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "application/json", charset));
         }
 
@@ -224,14 +224,14 @@ public final class RsWithType extends RsWrap {
      * @version $Id$
      * @since 0.30
      */
-    public static final class XML extends RsWrap {
+    public static final class Xml extends RsWrap {
 
         /**
          * Constructs a {@code XML} that will add text/xml as the content type
          * header to the response.
          * @param res Original response
          */
-        public XML(final Response res) {
+        public Xml(final Response res) {
             this(res, new Opt.Empty<Charset>());
         }
 
@@ -242,7 +242,7 @@ public final class RsWithType extends RsWrap {
          * @param res Original response
          * @param charset The character set to add in the content type header
          */
-        public XML(final Response res, final Charset charset) {
+        public Xml(final Response res, final Charset charset) {
             this(res, new Opt.Single<Charset>(charset));
         }
 
@@ -254,7 +254,7 @@ public final class RsWithType extends RsWrap {
          * @param charset The character set to add in the content type header if
          *  present.
          */
-        private XML(final Response res, final Opt<Charset> charset) {
+        private Xml(final Response res, final Opt<Charset> charset) {
             super(RsWithType.make(res, "text/xml", charset));
         }
 

--- a/src/main/java/org/takes/rs/RsXslt.java
+++ b/src/main/java/org/takes/rs/RsXslt.java
@@ -54,7 +54,7 @@ import org.takes.misc.Utf8String;
  * &lt;page/&gt;
  * </pre>
  *
- * <p>{@link org.takes.rs.RsXSLT} will try to find that {@code /xsl/home.xsl}
+ * <p>{@link org.takes.rs.RsXslt} will try to find that {@code /xsl/home.xsl}
  * resource in classpath. If it's not found a runtime exception will thrown.
  *
  * <p>The best way to use this decorator is in combination with
@@ -86,14 +86,14 @@ import org.takes.misc.Utf8String;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class RsXSLT extends RsWrap {
+public final class RsXslt extends RsWrap {
 
     /**
      * Ctor.
      * @param rsp Original response
      */
-    public RsXSLT(final Response rsp) {
-        this(rsp, new RsXSLT.InClasspath());
+    public RsXslt(final Response rsp) {
+        this(rsp, new RsXslt.InClasspath());
     }
 
     /**
@@ -101,7 +101,7 @@ public final class RsXSLT extends RsWrap {
      * @param rsp Original response
      * @param resolver URI resolver
      */
-    public RsXSLT(final Response rsp, final URIResolver resolver) {
+    public RsXslt(final Response rsp, final URIResolver resolver) {
         super(
             new Response() {
                 @Override
@@ -110,7 +110,7 @@ public final class RsXSLT extends RsWrap {
                 }
                 @Override
                 public InputStream body() throws IOException {
-                    return RsXSLT.transform(rsp.body(), resolver);
+                    return RsXslt.transform(rsp.body(), resolver);
                 }
             }
         );
@@ -128,7 +128,7 @@ public final class RsXSLT extends RsWrap {
         try {
             final TransformerFactory factory = TransformerFactory.newInstance();
             factory.setURIResolver(resolver);
-            return RsXSLT.transform(factory, origin);
+            return RsXslt.transform(factory, origin);
         } catch (final TransformerException ex) {
             throw new IOException(ex);
         }
@@ -145,19 +145,19 @@ public final class RsXSLT extends RsWrap {
         final InputStream xml) throws TransformerException {
         final byte[] input;
         try {
-            input = RsXSLT.consume(xml);
+            input = RsXslt.consume(xml);
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final Source xsl = RsXSLT.stylesheet(
+        final Source xsl = RsXslt.stylesheet(
             factory, new StreamSource(
                 new Utf8InputStreamReader(
                     new ByteArrayInputStream(new Utf8String(input).bytes())
                 )
             )
         );
-        RsXSLT.transformer(factory, xsl).transform(
+        RsXslt.transformer(factory, xsl).transform(
             new StreamSource(
                 new Utf8InputStreamReader(
                     new ByteArrayInputStream(new Utf8String(input).bytes())

--- a/src/main/java/org/takes/rs/xe/XeSla.java
+++ b/src/main/java/org/takes/rs/xe/XeSla.java
@@ -55,12 +55,12 @@ import org.xembly.Directives;
  * @since 0.3
  */
 @EqualsAndHashCode(callSuper = true)
-public final class XeSLA extends XeWrap {
+public final class XeSla extends XeWrap {
 
     /**
      * Ctor.
      */
-    public XeSLA() {
+    public XeSla() {
         this("sla");
     }
 
@@ -68,7 +68,7 @@ public final class XeSLA extends XeWrap {
      * Ctor.
      * @param attr Attribute name
      */
-    public XeSLA(final CharSequence attr) {
+    public XeSla(final CharSequence attr) {
         super(
             new XeSource() {
                 @Override

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -54,7 +54,8 @@ import org.takes.rs.RsWithStatus;
  *
  * @todo #684:15min Remove PMD.AvoidDuplicateLiterals exclude here and in
  *  {@link RsPrettyJson}, {@link RsPrettyXml}. Note that this puzzle depends on
- *  https://github.com/teamed/qulice/issues/760.
+ *  https://github.com/teamed/qulice/issues/760. Also remove some of PMD
+ *  excludes that are mentioned in https://github.com/yegor256/takes/issues/686
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = { "origin", "allowed" })

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -34,7 +34,6 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqHeaders;
-import org.takes.rs.RsPrettyJson;
 import org.takes.rs.RsWithHeaders;
 import org.takes.rs.RsWithStatus;
 
@@ -51,7 +50,6 @@ import org.takes.rs.RsWithStatus;
  * @author Endrigo Antonini (teamed@endrigo.com.br)
  * @version $Id$
  * @since 0.20
- *
  * @todo #684:15min Remove PMD.AvoidDuplicateLiterals exclude here and in
  *  {@link RsPrettyJson}, {@link RsPrettyXml}. Note that this puzzle depends on
  *  https://github.com/teamed/qulice/issues/760. Also remove some of PMD

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -52,8 +52,8 @@ import org.takes.rs.RsWithStatus;
  * @since 0.20
  * @todo #684:15min Remove PMD.AvoidDuplicateLiterals exclude here and in
  *  {@link RsPrettyJson}, {@link RsPrettyXml}. Note that this puzzle depends on
- *  https://github.com/teamed/qulice/issues/760. Also remove some of PMD
- *  excludes that are mentioned in https://github.com/yegor256/takes/issues/686
+ *  https://github.com/teamed/qulice/issues/760. Note that this puzzle has
+ *  partially overlap with https://github.com/yegor256/takes/issues/686
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = { "origin", "allowed" })

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -34,6 +34,7 @@ import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqHeaders;
+import org.takes.rs.RsPrettyJson;
 import org.takes.rs.RsWithHeaders;
 import org.takes.rs.RsWithStatus;
 
@@ -50,7 +51,12 @@ import org.takes.rs.RsWithStatus;
  * @author Endrigo Antonini (teamed@endrigo.com.br)
  * @version $Id$
  * @since 0.20
+ *
+ * @todo #684:15min Remove PMD.AvoidDuplicateLiterals exclude here and in
+ *  {@link RsPrettyJson}, {@link RsPrettyXml}. Note that this puzzle depends on
+ *  https://github.com/teamed/qulice/issues/760.
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = { "origin", "allowed" })
 @EqualsAndHashCode(of = { "origin", "allowed" })
 public final class TkCors implements Take {

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -53,7 +53,7 @@ import org.takes.rs.RsWithStatus;
  */
 @ToString(of = { "origin", "allowed" })
 @EqualsAndHashCode(of = { "origin", "allowed" })
-public final class TkCORS implements Take {
+public final class TkCors implements Take {
 
     /**
      * Original take.
@@ -70,7 +70,7 @@ public final class TkCORS implements Take {
      * @param take Original
      * @param domains Allow domains
      */
-    public TkCORS(final Take take, final String... domains) {
+    public TkCors(final Take take, final String... domains) {
         this.origin = take;
         this.allowed = new HashSet<String>(Arrays.asList(domains));
     }

--- a/src/main/java/org/takes/tk/TkHtml.java
+++ b/src/main/java/org/takes/tk/TkHtml.java
@@ -21,20 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.takes.rs;
+package org.takes.tk;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import javax.json.Json;
-import javax.json.JsonStructure;
-import javax.json.JsonWriter;
+import java.io.InputStream;
+import java.net.URL;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.takes.Request;
 import org.takes.Response;
+import org.takes.Take;
+import org.takes.rs.RsHtml;
 
 /**
- * Response that converts Java object to JSON.
+ * HTML take.
+ *
+ * <p>This take returns an HTML response by wrapping the provided
+ * content into {@link org.takes.rs.RsHtml}.
  *
  * <p>The class is immutable and thread-safe.
  *
@@ -44,19 +46,18 @@ import org.takes.Response;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class RsJSON extends RsWrap {
+public final class TkHtml extends TkWrap {
 
     /**
      * Ctor.
-     * @param json JSON object
-     * @throws IOException If fails
+     * @param body Text
      */
-    public RsJSON(final JsonStructure json) throws IOException {
-        this(
-            new RsJSON.Source() {
+    public TkHtml(final String body) {
+        super(
+            new Take() {
                 @Override
-                public JsonStructure toJSON() {
-                    return json;
+                public Response act(final Request req) {
+                    return new RsHtml(body);
                 }
             }
         );
@@ -64,53 +65,47 @@ public final class RsJSON extends RsWrap {
 
     /**
      * Ctor.
-     * @param src Source
-     * @throws IOException If fails
+     * @param body Body with HTML
      */
-    public RsJSON(final RsJSON.Source src) throws IOException {
-        this(new RsWithBody(RsJSON.print(src)));
-    }
-
-    /**
-     * Ctor.
-     * @param res Resource
-     */
-    public RsJSON(final Response res) {
+    public TkHtml(final byte[] body) {
         super(
-            new RsWithType(
-                new RsWithStatus(res, HttpURLConnection.HTTP_OK),
-                "application/json"
-        )
+            new Take() {
+                @Override
+                public Response act(final Request req) {
+                    return new RsHtml(body);
+                }
+            }
         );
     }
 
     /**
-     * Print JSON.
-     * @param src Source
-     * @return JSON
-     * @throws IOException If fails
+     * Ctor.
+     * @param url URL with content
      */
-    private static byte[] print(final RsJSON.Source src) throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final JsonWriter writer = Json.createWriter(baos);
-        try {
-            writer.write(src.toJSON());
-        } finally {
-            writer.close();
-        }
-        return baos.toByteArray();
+    public TkHtml(final URL url) {
+        super(
+            new Take() {
+                @Override
+                public Response act(final Request req) {
+                    return new RsHtml(url);
+                }
+            }
+        );
     }
 
     /**
-     * Source with JSON.
+     * Ctor.
+     * @param body Content
      */
-    public interface Source {
-        /**
-         * Get JSON value.
-         * @return JSON
-         * @throws IOException If fails
-         */
-        JsonStructure toJSON() throws IOException;
+    public TkHtml(final InputStream body) {
+        super(
+            new Take() {
+                @Override
+                public Response act(final Request req) {
+                    return new RsHtml(body);
+                }
+            }
+        );
     }
 
 }

--- a/src/test/java/org/takes/facets/auth/codecs/CcXorTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcXorTest.java
@@ -21,51 +21,46 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package org.takes.facets.auth.codecs;
 
 import java.io.IOException;
-import javax.crypto.KeyGenerator;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.facets.auth.Identity;
 
 /**
- * Test case for {@link CcAES}.
- * @author Jason Wong (super132j@yahoo.com)
+ * Test case for {@link CcXor}.
+ * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
  * @version $Id$
- * @since 0.13.8
+ * @since 0.13.7
  */
-public final class CcAESTest {
+public final class CcXorTest {
 
     /**
-     * CcAES can encode and decode.
-     * @throws Exception any unexpected exception to throw
+     * CcXor can encode and decode.
+     * @throws IOException If some problem inside
      */
     @Test
-    public void encodesAndDecodes() throws Exception {
-        final int length = 128;
-        final KeyGenerator generator = KeyGenerator.getInstance("AES");
-        generator.init(length);
-        final byte[] key = generator.generateKey().getEncoded();
-        final String plain = "This is a test!!@@**";
-        final Codec codec = new CcAES(
+    public void encodesAndDecodes() throws IOException {
+        final String urn = "urn:domain:9";
+        final Codec codec = new CcXor(
             new Codec() {
                 @Override
-                public Identity decode(final byte[] bytes) throws IOException {
-                    return new Identity.Simple(new String(bytes));
-                }
-                @Override
-                public byte[] encode(final Identity identity)
-                    throws IOException {
+                public byte[] encode(final Identity identity) {
                     return identity.urn().getBytes();
                 }
+                @Override
+                public Identity decode(final byte[] bytes) {
+                    return new Identity.Simple(new String(bytes));
+                }
             },
-            key
+            "secret"
         );
         MatcherAssert.assertThat(
-            codec.decode(codec.encode(new Identity.Simple(plain))).urn(),
-            Matchers.equalTo(plain)
+            codec.decode(codec.encode(new Identity.Simple(urn))).urn(),
+            Matchers.equalTo(urn)
         );
     }
 }

--- a/src/test/java/org/takes/facets/auth/social/PsGithubTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGithubTest.java
@@ -43,7 +43,7 @@ import org.takes.rq.RqFake;
 import org.takes.rq.RqForm;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
-import org.takes.rs.RsJSON;
+import org.takes.rs.RsJson;
 import org.takes.rs.xe.RsXembly;
 import org.takes.rs.xe.XeDirectives;
 import org.xembly.Directives;
@@ -208,7 +208,7 @@ public final class PsGithubTest {
                     .iterator().next(),
                 Matchers.containsString(PsGithubTest.GIT_HUB_TOKEN)
             );
-            return new RsJSON(
+            return new RsJson(
                 Json.createObjectBuilder()
                     .add(PsGithubTest.LOGIN, PsGithubTest.OCTOCAT)
                     .add("id", 1)

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -42,7 +42,7 @@ import org.takes.rq.RqForm;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.RqPrint;
-import org.takes.rs.RsJSON;
+import org.takes.rs.RsJson;
 
 /**
  * Test case for {@link PsGoogle}.
@@ -111,7 +111,7 @@ public final class PsGoogleTest {
                                 .iterator().next(),
                             Matchers.containsString(PsGoogleTest.GOOGLE_TOKEN)
                         );
-                        return new RsJSON(
+                        return new RsJson(
                             Json.createObjectBuilder()
                                 .add("displayName", "octocat")
                                 .add("id", "1")
@@ -232,7 +232,7 @@ public final class PsGoogleTest {
                                 .iterator().next(),
                             Matchers.containsString(PsGoogleTest.GOOGLE_TOKEN)
                         );
-                        return new RsJSON(
+                        return new RsJson(
                             Json.createObjectBuilder()
                                 .add("id", "1")
                                 .add(
@@ -318,7 +318,7 @@ public final class PsGoogleTest {
                         PsGoogleTest.CODE,
                         PsGoogleTest.CODE
                     );
-                    return new RsJSON(
+                    return new RsJson(
                         Json.createObjectBuilder()
                             .add(
                                 PsGoogleTest.ACCESS_TOKEN,
@@ -352,9 +352,9 @@ public final class PsGoogleTest {
      * @return Json with error.
      * @throws IOException If some problem inside
      */
-    private static RsJSON createErrorJson() throws IOException {
+    private static RsJson createErrorJson() throws IOException {
         final String message = "message";
-        return new RsJSON(
+        return new RsJson(
             Json.createObjectBuilder()
                 .add(
                     "error",

--- a/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
@@ -44,7 +44,7 @@ import org.takes.misc.Href;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqHref;
 import org.takes.rq.RqPrint;
-import org.takes.rs.RsJSON;
+import org.takes.rs.RsJson;
 
 /**
  * Test case for {@link PsLinkedin}.
@@ -93,7 +93,7 @@ public final class PsLinkedinTest {
                             new RqHref.Base(req).href().toString(),
                             Matchers.endsWith("/uas/oauth2/accessToken")
                         );
-                        return new RsJSON(
+                        return new RsJson(
                             Json.createObjectBuilder()
                                 .add(
                                     "access_token",
@@ -108,7 +108,7 @@ public final class PsLinkedinTest {
                 new Take() {
                     @Override
                     public Response act(final Request req) throws IOException {
-                        return new RsJSON(
+                        return new RsJson(
                             Json.createObjectBuilder()
                                 .add("id", identifier)
                                 .add("firstName", "Frodo")

--- a/src/test/java/org/takes/facets/fork/TkConsumesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkConsumesTest.java
@@ -36,7 +36,7 @@ import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsEmpty;
-import org.takes.rs.RsJSON;
+import org.takes.rs.RsJson;
 import org.takes.rs.RsPrint;
 import org.takes.tk.TkFixed;
 
@@ -56,7 +56,7 @@ public final class TkConsumesTest {
     @Test
     public void acceptsCorrectContentTypeRequest() throws IOException {
         final Take consumes = new TkConsumes(
-            new TkFixed(new RsJSON(new RsEmpty())),
+            new TkFixed(new RsJson(new RsEmpty())),
             "application/json"
         );
         final Response response = consumes.act(
@@ -86,7 +86,7 @@ public final class TkConsumesTest {
     @Test(expected = HttpException.class)
     public void failsOnUnsupportedAcceptHeader() throws IOException {
         final Take consumes = new TkConsumes(
-            new TkFixed(new RsJSON(new RsEmpty())),
+            new TkFixed(new RsJson(new RsEmpty())),
             "application/json"
         );
         consumes.act(

--- a/src/test/java/org/takes/facets/fork/TkProducesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkProducesTest.java
@@ -34,7 +34,7 @@ import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsEmpty;
-import org.takes.rs.RsJSON;
+import org.takes.rs.RsJson;
 import org.takes.rs.RsPrint;
 import org.takes.tk.TkEmpty;
 import org.takes.tk.TkFixed;
@@ -76,7 +76,7 @@ public final class TkProducesTest {
     @Test
     public void producesCorrectContentTypeResponse() throws IOException {
         final Take produces = new TkProduces(
-            new TkFixed(new RsJSON(new RsEmpty())),
+            new TkFixed(new RsJson(new RsEmpty())),
             "text/json"
         );
         final Response response = produces.act(

--- a/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
@@ -30,7 +30,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.tk.TkEmpty;
-import org.takes.tk.TkHTML;
+import org.takes.tk.TkHtml;
 
 /**
  * Test case for {@link HmRsStatus}.
@@ -45,9 +45,9 @@ public final class HmRsStatusTest {
      * @throws IOException If some problem inside
      */
     @Test
-    public void testsStatusOK() throws IOException {
+    public void testsStatusOk() throws IOException {
         MatcherAssert.assertThat(
-            new TkHTML("<html></html>").act(new RqFake()),
+            new TkHtml("<html></html>").act(new RqFake()),
             new HmRsStatus(HttpURLConnection.HTTP_OK)
         );
         MatcherAssert.assertThat(
@@ -63,7 +63,7 @@ public final class HmRsStatusTest {
     @Test
     public void testsStatusNotFound() throws IOException {
         MatcherAssert.assertThat(
-            new TkHTML("<html><body/></html>").act(new RqFake()),
+            new TkHtml("<html><body/></html>").act(new RqFake()),
             Matchers.not(
                 new HmRsStatus(
                     HttpURLConnection.HTTP_NOT_FOUND

--- a/src/test/java/org/takes/http/BkTimeableTest.java
+++ b/src/test/java/org/takes/http/BkTimeableTest.java
@@ -93,7 +93,7 @@ public final class BkTimeableTest {
                 @Override
                 public void run() {
                     try {
-                        new FtCLI(
+                        new FtCli(
                             take,
                             String.format("--port=%s", file.getAbsoluteFile()),
                             "--threads=1",

--- a/src/test/java/org/takes/http/FtBasicTest.java
+++ b/src/test/java/org/takes/http/FtBasicTest.java
@@ -44,7 +44,7 @@ import org.takes.rq.RqGreedy;
 import org.takes.rq.RqLengthAware;
 import org.takes.rq.RqMethod;
 import org.takes.rq.RqPrint;
-import org.takes.rs.RsHTML;
+import org.takes.rs.RsHtml;
 import org.takes.rs.RsText;
 import org.takes.tk.TkFailure;
 
@@ -247,13 +247,13 @@ public final class FtBasicTest {
      * @throws IOException If some problem inside
      */
     @Test
-    public void consumesTwiceInputStreamWithRsHTML() throws IOException {
+    public void consumesTwiceInputStreamWithRsHtml() throws IOException {
         final String result = "Hello RsHTML!";
         new FtRemote(
             new TkFork(
                 new FkRegex(
                     FtBasicTest.ROOT_PATH,
-                    new RsHTML(
+                    new RsHtml(
                         new ByteArrayInputStream(
                             new Utf8String(result).bytes()
                         )

--- a/src/test/java/org/takes/http/FtCliTest.java
+++ b/src/test/java/org/takes/http/FtCliTest.java
@@ -38,13 +38,13 @@ import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
 
 /**
- * Test case for {@link FtCLI}.
+ * Test case for {@link FtCli}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-public final class FtCLITest {
+public final class FtCliTest {
 
     /**
      * Temp directory.
@@ -74,7 +74,7 @@ public final class FtCLITest {
                 @Override
                 public void run() {
                     try {
-                        new FtCLI(
+                        new FtCli(
                             new TkFork(new FkRegex("/", "hello!")),
                             String.format("--port=%s", file.getAbsoluteFile()),
                             "--threads=1",

--- a/src/test/java/org/takes/http/MainRemoteTest.java
+++ b/src/test/java/org/takes/http/MainRemoteTest.java
@@ -98,7 +98,7 @@ public final class MainRemoteTest {
          * @throws IOException If fails
          */
         public static void main(final String... args) throws IOException {
-            new FtCLI(new TkFixed("works fine!"), args).start(Exit.NEVER);
+            new FtCli(new TkFixed("works fine!"), args).start(Exit.NEVER);
         }
     }
 
@@ -118,7 +118,7 @@ public final class MainRemoteTest {
          * @throws IOException If fails
          */
         public static void main(final String... args) throws IOException {
-            new FtCLI(new TkFixed(args[1]), args[0]).start(Exit.NEVER);
+            new FtCli(new TkFixed(args[1]), args[0]).start(Exit.NEVER);
         }
     }
 

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -105,7 +105,7 @@ public final class HrefTest {
      * Href can accept non properly encoded URL.
      */
     @Test
-    public void acceptsNonProperlyEncodedURL() {
+    public void acceptsNonProperlyEncodedUrl() {
         MatcherAssert.assertThat(
             // @checkstyle LineLength (2 lines)
             new Href("http://www.netbout.com/[foo/bar]/read?file=%5B%5D%28%29.txt").toString(),

--- a/src/test/java/org/takes/rq/RqMethodTest.java
+++ b/src/test/java/org/takes/rq/RqMethodTest.java
@@ -88,7 +88,7 @@ public final class RqMethodTest {
      * @throws IOException If some problem inside
      */
     @Test(expected = IOException.class)
-    public void failsOnMissingURI() throws IOException {
+    public void failsOnMissingUri() throws IOException {
         new RqMethod.Base(new RqSimple(Arrays.asList("GET"), null)).method();
     }
 

--- a/src/test/java/org/takes/rs/BodyTest.java
+++ b/src/test/java/org/takes/rs/BodyTest.java
@@ -137,7 +137,7 @@ public final class BodyTest {
      * @throws Exception If some problem inside.
      */
     @Test
-    public void returnsCorrectInputWithURL() throws Exception {
+    public void returnsCorrectInputWithUrl() throws Exception {
         final Path file = BodyTest.createTempFile();
         try {
             final byte[] bytes =
@@ -146,7 +146,7 @@ public final class BodyTest {
                 Files.copy(input, file, StandardCopyOption.REPLACE_EXISTING);
             }
             try (final InputStream input =
-                new Body.URL(file.toUri().toURL()).input()) {
+                new Body.Url(file.toUri().toURL()).input()) {
                 MatcherAssert.assertThat(
                     ByteStreams.toByteArray(input),
                     Matchers.equalTo(bytes)
@@ -162,7 +162,7 @@ public final class BodyTest {
      * @throws Exception If some problem inside.
      */
     @Test
-    public void returnsCorrectLengthWithURL() throws Exception {
+    public void returnsCorrectLengthWithUrl() throws Exception {
         final Path file = BodyTest.createTempFile();
         try {
             final byte[] bytes =
@@ -171,7 +171,7 @@ public final class BodyTest {
                 Files.copy(input, file, StandardCopyOption.REPLACE_EXISTING);
             }
             MatcherAssert.assertThat(
-                new Body.URL(file.toUri().toURL()).length(),
+                new Body.Url(file.toUri().toURL()).length(),
                 Matchers.equalTo(bytes.length)
             );
         } finally {

--- a/src/test/java/org/takes/rs/RsJsonTest.java
+++ b/src/test/java/org/takes/rs/RsJsonTest.java
@@ -21,40 +21,60 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.takes.rs.xe;
+package org.takes.rs;
 
-import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
-import org.apache.commons.io.IOUtils;
+import javax.json.Json;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonStructure;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link XeSLA}.
+ * Test case for {@link RsJson}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
- * @since 0.3
+ * @since 0.1
  */
-public final class XeSLATest {
+public final class RsJsonTest {
 
     /**
-     * XeSLA can build XML response.
+     * RsJSON can build JSON response.
      * @throws IOException If some problem inside
      */
     @Test
-    public void buildsXmlResponse() throws IOException {
+    public void buildsJsonResponse() throws IOException {
+        final String key = "name";
+        final JsonStructure json = Json.createObjectBuilder()
+            .add(key, "Jeffrey Lebowski")
+            .build();
         MatcherAssert.assertThat(
-            IOUtils.toString(
-                new RsXembly(
-                    new XeAppend(
-                        "root",
-                        new XeSLA()
-                    )
-                ).body()
-            ),
-            XhtmlMatchers.hasXPaths(
-                "/root[@sla]"
-            )
+            Json.createReader(
+                new RsJson(json).body()
+            ).readObject().getString(key),
+            Matchers.startsWith("Jeffrey")
+        );
+    }
+
+    /**
+     * RsJSON can build a big JSON response.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void buildsBigJsonResponse() throws IOException {
+        final int size = 100000;
+        final JsonArrayBuilder builder = Json.createArrayBuilder();
+        for (int idx = 0; idx < size; ++idx) {
+            builder.add(
+                Json.createObjectBuilder().add("number", "212 555-1234")
+            );
+        }
+        MatcherAssert.assertThat(
+            Json.createReader(
+                new RsJson(builder.build()).body()
+            ).readArray().size(),
+            Matchers.equalTo(size)
         );
     }
 

--- a/src/test/java/org/takes/rs/RsPrettyJsonTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyJsonTest.java
@@ -32,12 +32,12 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link RsPrettyJSON}.
+ * Test case for {@link RsPrettyJson}.
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @version $Id$
  * @since 1.0
  */
-public final class RsPrettyJSONTest {
+public final class RsPrettyJsonTest {
 
     /**
      * RsPrettyJSON can format response with JSON body.
@@ -47,7 +47,7 @@ public final class RsPrettyJSONTest {
     public void formatsJsonBody() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyJSON(
+                new RsPrettyJson(
                     new RsWithBody("{\"widget\": {\"debug\": \"on\" }}")
                 )
             ).printBody(),
@@ -63,7 +63,7 @@ public final class RsPrettyJSONTest {
      */
     @Test(expected = IOException.class)
     public void rejectsNonJsonBody() throws Exception {
-        new RsPrint(new RsPrettyJSON(new RsWithBody("foo"))).printBody();
+        new RsPrint(new RsPrettyJson(new RsWithBody("foo"))).printBody();
     }
 
     /**
@@ -80,7 +80,7 @@ public final class RsPrettyJSONTest {
         ).printBody(baos);
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyJSON(
+                new RsPrettyJson(
                     new RsWithBody("{\"test\": {\"test\": \"test\" }}")
                 )
             ).printHead(),
@@ -99,7 +99,7 @@ public final class RsPrettyJSONTest {
      */
     @Test
     public void conformsToEqualsAndHashCode() throws Exception {
-        EqualsVerifier.forClass(RsPrettyJSON.class)
+        EqualsVerifier.forClass(RsPrettyJson.class)
             .suppress(Warning.TRANSIENT_FIELDS)
             .withRedefinedSuperclass()
             .verify();

--- a/src/test/java/org/takes/rs/RsPrettyXmlTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXmlTest.java
@@ -33,12 +33,12 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link RsPrettyXML}.
+ * Test case for {@link RsPrettyXml}.
  * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
  * @version $Id$
  * @since 1.0
  */
-public final class RsPrettyXMLTest {
+public final class RsPrettyXmlTest {
 
     /**
      * RsPrettyXML can format response with XML body.
@@ -48,7 +48,7 @@ public final class RsPrettyXMLTest {
     public void formatsXmlBody() throws IOException {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyXML(
+                new RsPrettyXml(
                     new RsWithBody("<test><a>foo</a></test>")
                 )
             ).printBody(),
@@ -65,7 +65,7 @@ public final class RsPrettyXMLTest {
     public void formatsHtml5DoctypeBody() throws IOException {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyXML(
+                new RsPrettyXml(
                     new RsWithBody(
                         "<!DOCTYPE html><html><head></head><body></body></html>"
                     )
@@ -85,7 +85,7 @@ public final class RsPrettyXMLTest {
     public void formatsHtml5ForLegacyBrowsersDoctypeBody() throws IOException {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyXML(
+                new RsPrettyXml(
                     new RsWithBody(
                         Joiner.on("").appendTo(
                             new StringBuilder("<!DOCTYPE html "),
@@ -124,7 +124,7 @@ public final class RsPrettyXMLTest {
             .concat("lang=\"en\">");
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyXML(
+                new RsPrettyXml(
                     new RsWithBody(
                         Joiner.on("").appendTo(
                             new StringBuilder("<!DOCTYPE HTML "),
@@ -158,7 +158,7 @@ public final class RsPrettyXMLTest {
      */
     @Test(expected = IOException.class)
     public void formatsNonXmlBody() throws IOException {
-        new RsPrint(new RsPrettyXML(new RsWithBody("foo"))).printBody();
+        new RsPrint(new RsPrettyXml(new RsWithBody("foo"))).printBody();
     }
 
     /**
@@ -175,7 +175,7 @@ public final class RsPrettyXMLTest {
         ).printBody(baos);
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsPrettyXML(
+                new RsPrettyXml(
                     new RsWithBody("<test><a>test</a></test>")
                 )
             ).printHead(),
@@ -194,7 +194,7 @@ public final class RsPrettyXMLTest {
      */
     @Test
     public void conformsToEqualsAndHashCode() throws Exception {
-        EqualsVerifier.forClass(RsPrettyXML.class)
+        EqualsVerifier.forClass(RsPrettyXml.class)
             .suppress(Warning.TRANSIENT_FIELDS)
             .withRedefinedSuperclass()
             .verify();

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -142,7 +142,7 @@ public final class RsWithTypeTest {
     public void replacesTypeWithHtml() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.HTML(
+                new RsWithType.Html(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML)
                 )
             ).print(),
@@ -160,7 +160,7 @@ public final class RsWithTypeTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.HTML(
+                new RsWithType.Html(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     StandardCharsets.ISO_8859_1
                 )
@@ -188,7 +188,7 @@ public final class RsWithTypeTest {
     public void replacesTypeWithJson() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.JSON(
+                new RsWithType.Json(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML)
                 )
             ).print(),
@@ -206,7 +206,7 @@ public final class RsWithTypeTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.JSON(
+                new RsWithType.Json(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     StandardCharsets.ISO_8859_1
                 )
@@ -234,7 +234,7 @@ public final class RsWithTypeTest {
     public void replacesTypeWithXml() throws Exception {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.XML(
+                new RsWithType.Xml(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML)
                 )
             ).print(),
@@ -251,7 +251,7 @@ public final class RsWithTypeTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsWithType.XML(
+                new RsWithType.Xml(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML),
                     StandardCharsets.ISO_8859_1
                 )

--- a/src/test/java/org/takes/rs/RsXsltTest.java
+++ b/src/test/java/org/takes/rs/RsXsltTest.java
@@ -39,12 +39,12 @@ import org.junit.Test;
 import org.takes.misc.StateAwareInputStream;
 
 /**
- * Test case for {@link RsXSLT}.
+ * Test case for {@link RsXslt}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.1
  */
-public final class RsXSLTTest {
+public final class RsXsltTest {
 
     /**
      * Validate encoding.
@@ -77,7 +77,7 @@ public final class RsXSLTTest {
         );
         MatcherAssert.assertThat(
             IOUtils.toString(
-                new RsXSLT(
+                new RsXslt(
                     new RsText(xml),
                     new URIResolver() {
                         @Override
@@ -110,7 +110,7 @@ public final class RsXSLTTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsXSLT(
+                new RsXslt(
                     new RsText(xml),
                     new URIResolver() {
                         @Override
@@ -146,7 +146,7 @@ public final class RsXSLTTest {
             new StateAwareInputStream(IOUtils.toInputStream(xml));
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsXSLT(
+                new RsXslt(
                     new RsText(stream),
                     new URIResolver() {
                         @Override
@@ -173,7 +173,7 @@ public final class RsXSLTTest {
     public void resolvesInClasspath() throws IOException {
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsXSLT(
+                new RsXslt(
                     new RsText(
                         Joiner.on(' ').join(
                             "<?xml-stylesheet",
@@ -188,7 +188,7 @@ public final class RsXSLTTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsXSLT(
+                new RsXslt(
                     new RsText(
                         Joiner.on(' ').join(
                             "<?xml-stylesheet ",
@@ -203,7 +203,7 @@ public final class RsXSLTTest {
         );
         MatcherAssert.assertThat(
             new RsPrint(
-                new RsXSLT(
+                new RsXslt(
                     new RsText(
                         Joiner.on(' ').join(
                             "<?xml-stylesheet  ",

--- a/src/test/java/org/takes/rs/xe/XeSlaTest.java
+++ b/src/test/java/org/takes/rs/xe/XeSlaTest.java
@@ -21,46 +21,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.takes.rs.xe;
 
-package org.takes.facets.auth.codecs;
-
+import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.takes.facets.auth.Identity;
 
 /**
- * Test case for {@link CcXOR}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
+ * Test case for {@link XeSla}.
+ * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
- * @since 0.13.7
+ * @since 0.3
  */
-public final class CcXORTest {
+public final class XeSlaTest {
 
     /**
-     * CcXor can encode and decode.
+     * XeSLA can build XML response.
      * @throws IOException If some problem inside
      */
     @Test
-    public void encodesAndDecodes() throws IOException {
-        final String urn = "urn:domain:9";
-        final Codec codec = new CcXOR(
-            new Codec() {
-                @Override
-                public byte[] encode(final Identity identity) {
-                    return identity.urn().getBytes();
-                }
-                @Override
-                public Identity decode(final byte[] bytes) {
-                    return new Identity.Simple(new String(bytes));
-                }
-            },
-            "secret"
-        );
+    public void buildsXmlResponse() throws IOException {
         MatcherAssert.assertThat(
-            codec.decode(codec.encode(new Identity.Simple(urn))).urn(),
-            Matchers.equalTo(urn)
+            IOUtils.toString(
+                new RsXembly(
+                    new XeAppend(
+                        "root",
+                        new XeSla()
+                    )
+                ).body()
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/root[@sla]"
+            )
         );
     }
+
 }

--- a/src/test/java/org/takes/tk/TkCorsTest.java
+++ b/src/test/java/org/takes/tk/TkCorsTest.java
@@ -34,12 +34,12 @@ import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 
 /**
- * Test case for {@link TkCORS}.
+ * Test case for {@link TkCors}.
  * @author Endrigo Antonini (teamed@endrigo.com.br)
  * @version $Id$
  * @since 0.20
  */
-public final class TkCORSTest {
+public final class TkCorsTest {
 
     /**
      * TkCORS can handle connections without origin in the request.
@@ -49,7 +49,7 @@ public final class TkCORSTest {
     public void handleConnectionsWithoutOriginInTheRequest() throws Exception {
         MatcherAssert.assertThat(
             "It was expected to receive a 403 error.",
-            new TkCORS(
+            new TkCors(
                 new TkFixed(new RsText()),
                 "http://www.netbout.io",
                 "http://www.example.com"
@@ -66,7 +66,7 @@ public final class TkCORSTest {
     public void handleConnectionsWithCorrectDomainOnOrigin() throws Exception {
         MatcherAssert.assertThat(
             "Invalid HTTP status for a request with correct domain.",
-            new TkCORS(
+            new TkCors(
                 new TkFixed(new RsText()),
                 "http://teamed.io",
                 "http://example.com"
@@ -90,7 +90,7 @@ public final class TkCORSTest {
         MatcherAssert.assertThat(
             "Wrong value on header.",
             new RsPrint(
-                new TkCORS(
+                new TkCors(
                     new TkFixed(new RsText()),
                     "http://www.teamed.io",
                     "http://sample.com"

--- a/src/test/java/org/takes/tk/TkHtmlTest.java
+++ b/src/test/java/org/takes/tk/TkHtmlTest.java
@@ -33,12 +33,12 @@ import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
 
 /**
- * Test case for {@link TkHTML}.
+ * Test case for {@link TkHtml}.
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.10
  */
-public final class TkHTMLTest {
+public final class TkHtmlTest {
 
     /**
      * TkHTML can create a text.
@@ -48,7 +48,7 @@ public final class TkHTMLTest {
     public void createsTextResponse() throws IOException {
         final String body = "<html>hello, world!</html>";
         MatcherAssert.assertThat(
-            new RsPrint(new TkHTML(body).act(new RqFake())).print(),
+            new RsPrint(new TkHtml(body).act(new RqFake())).print(),
             Matchers.equalTo(
                 Joiner.on("\r\n").join(
                     "HTTP/1.1 200 OK",
@@ -68,7 +68,7 @@ public final class TkHTMLTest {
     @Test
     public void printsResourceMultipleTimes() throws IOException {
         final String body = "<html>hello, dude!</html>";
-        final Take take = new TkHTML(body);
+        final Take take = new TkHtml(body);
         MatcherAssert.assertThat(
             new RsPrint(take.act(new RqFake())).print(),
             Matchers.containsString(body)

--- a/src/test/java/org/takes/tk/TkRedirectTest.java
+++ b/src/test/java/org/takes/tk/TkRedirectTest.java
@@ -53,7 +53,7 @@ public final class TkRedirectTest {
      * @throws IOException If some problem inside
      */
     @Test
-    public void createsRedirectResponseWithURL() throws IOException {
+    public void createsRedirectResponseWithUrl() throws IOException {
         final String url = "/about";
         MatcherAssert.assertThat(
             new RsPrint(
@@ -75,7 +75,7 @@ public final class TkRedirectTest {
      * @throws IOException If some problem inside
      */
     @Test
-    public void createsRedirectResponseWithURLAndStatus() throws IOException {
+    public void createsRedirectResponseWithUrlAndStatus() throws IOException {
         final String url = "/";
         MatcherAssert.assertThat(
             new RsPrint(


### PR DESCRIPTION
#684. I renamed all abbreviations from upper case to camel case. Also I added 3 PMD suppress warnings and puzzle to remove them (see https://github.com/teamed/qulice/issues/760)