### PR TITLE
Update README.md with info about TkSlf4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,12 @@ port number, use it to start a server, and save it to the file.
 The framework sends all logs to SLF4J logging facility. If you want to see them,
 configure one of [SLF4J bindings](http://www.slf4j.org/manual.html).
 
+To make a `Take` log, wrap it in a `TkSlf4j` - for example:
+
+     new TkSlf4j(
+         new TkFork(...)
+     )
+
 ## Directory Layout
 
 You are free to use any build tool, but we recommend Maven. This is how your project directory layout may/should look like:


### PR DESCRIPTION
README.md implied that just configuring SLF4J was enough to get logs. In fact you need to wrap your Takes in TkSlf4j. Suggested update to the docs to make this clear.