### PR TITLE
Issue #695 - RqFormBase: Get rid of the checkstyle suppression of ClassDataAbstractionCouplingCheck.

### DIFF
--- a/src/main/java/org/takes/misc/Utf8String.java
+++ b/src/main/java/org/takes/misc/Utf8String.java
@@ -24,7 +24,6 @@
 package org.takes.misc;
 
 import java.nio.charset.Charset;
-import java.util.Locale;
 
 /**
  * String that uses UTF-8 encoding for all byte operations.
@@ -74,13 +73,5 @@ public final class Utf8String {
      */
     public String string() {
         return this.value;
-    }
-
-    /**
-     * Returns the english lower case string representation.
-     * @return String value
-     */
-    public String englishLowerCase() {
-        return this.value.toLowerCase(Locale.ENGLISH);
     }
 }

--- a/src/main/java/org/takes/misc/Utf8String.java
+++ b/src/main/java/org/takes/misc/Utf8String.java
@@ -24,6 +24,7 @@
 package org.takes.misc;
 
 import java.nio.charset.Charset;
+import java.util.Locale;
 
 /**
  * String that uses UTF-8 encoding for all byte operations.
@@ -73,5 +74,13 @@ public final class Utf8String {
      */
     public String string() {
         return this.value;
+    }
+
+    /**
+     * Returns the english lower case string representation.
+     * @return String value
+     */
+    public String englishLowerCase() {
+        return this.value.toLowerCase(Locale.ENGLISH);
     }
 }

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -24,7 +24,6 @@
 package org.takes.rq.form;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
@@ -39,6 +38,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.EqualsAndHashCode;
 import org.takes.HttpException;
 import org.takes.Request;
+import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Sprintf;
 import org.takes.misc.Utf8String;
 import org.takes.misc.VerboseIterable;
@@ -80,7 +80,7 @@ public final class RqFormBase extends RqWrap implements RqForm {
     public Iterable<String> param(final CharSequence key)
         throws IOException {
         final List<String> values =
-            this.map().get(new Utf8String(key.toString()).englishLowerCase());
+            this.map().get(new EnglishLowerCase(key.toString()).string());
         final Iterable<String> iter;
         if (values == null) {
             iter = new VerboseIterable<>(
@@ -143,9 +143,9 @@ public final class RqFormBase extends RqWrap implements RqForm {
      * @throws IOException If something fails reading or parsing body
      */
     private Map<String, List<String>> freshMap() throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new RqPrint(this.req).printBody(baos);
-        final String body = new Utf8String(baos.toByteArray()).string();
+        final String body = new Utf8String(
+            new RqPrint(this.req).printBody()
+        ).string();
         final Map<String, List<String>> map = new HashMap<>(1);
         // @checkstyle MultipleStringLiteralsCheck (1 line)
         for (final String pair : body.split("&")) {
@@ -163,7 +163,7 @@ public final class RqFormBase extends RqWrap implements RqForm {
                 );
             }
             final String key = decode(
-                new Utf8String(parts[0].trim()).englishLowerCase()
+                new EnglishLowerCase(parts[0].trim()).string()
             );
             if (!map.containsKey(key)) {
                 map.put(key, new LinkedList<String>());

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -40,7 +40,6 @@ import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Sprintf;
-import org.takes.misc.Utf8String;
 import org.takes.misc.VerboseIterable;
 import org.takes.rq.RqForm;
 import org.takes.rq.RqPrint;
@@ -143,9 +142,7 @@ public final class RqFormBase extends RqWrap implements RqForm {
      * @throws IOException If something fails reading or parsing body
      */
     private Map<String, List<String>> freshMap() throws IOException {
-        final String body = new Utf8String(
-            new RqPrint(this.req).printBody()
-        ).string();
+        final String body = new RqPrint(this.req).printBody();
         final Map<String, List<String>> map = new HashMap<>(1);
         // @checkstyle MultipleStringLiteralsCheck (1 line)
         for (final String pair : body.split("&")) {

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -39,7 +39,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.EqualsAndHashCode;
 import org.takes.HttpException;
 import org.takes.Request;
-import org.takes.misc.EnglishLowerCase;
 import org.takes.misc.Sprintf;
 import org.takes.misc.Utf8String;
 import org.takes.misc.VerboseIterable;
@@ -52,10 +51,6 @@ import org.takes.rq.RqWrap;
  * @author Aleksey Popov (alopen@yandex.ru)
  * @version $Id$
  * @since 0.33
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #687:30min Refactor this class to reduce the data abstraction
- *  coupling in order to get rid of the checkstyle suppression of
- *  ClassDataAbstractionCouplingCheck.
  */
 @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
 @EqualsAndHashCode(callSuper = true, of = "req")
@@ -85,7 +80,7 @@ public final class RqFormBase extends RqWrap implements RqForm {
     public Iterable<String> param(final CharSequence key)
         throws IOException {
         final List<String> values =
-            this.map().get(new EnglishLowerCase(key.toString()).string());
+            this.map().get(new Utf8String(key.toString()).englishLowerCase());
         final Iterable<String> iter;
         if (values == null) {
             iter = new VerboseIterable<>(
@@ -168,7 +163,7 @@ public final class RqFormBase extends RqWrap implements RqForm {
                 );
             }
             final String key = decode(
-                new EnglishLowerCase(parts[0].trim()).string()
+                new Utf8String(parts[0].trim()).englishLowerCase()
             );
             if (!map.containsKey(key)) {
                 map.put(key, new LinkedList<String>());


### PR DESCRIPTION
Issue #695. Refactor the RqFormBase class to reduce the data abstraction coupling in order to get rid of the checkstyle suppression of ClassDataAbstractionCouplingCheck. This PR do the following changes:

- Adds a englishLowerCase method to the Utf8String class;
- Refactor the RqFormBase class and removes the ClassDataAbstractionCouplingCheck checkstyle suppression;