### PR TITLE
Issue #698 - RsFlash: Get rid of the SingularField PMD suppression

### DIFF
--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -190,7 +190,11 @@ public final class RsFlash extends RsWrap {
 
     @Override
     public String toString() {
-        return String.valueOf(this.text);
+        return String.format(
+            "%s(text=%s)", 
+            RsFlash.class.getSimpleName(), 
+            this.text
+        );
     }
 
     /**

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -100,11 +100,7 @@ import org.takes.rs.RsWrap;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 0.1
- * @todo #686:15min After upgrade to qulice 0.16.4 we have to fix
- *  SingularField PMD warings in this class. Fix this warning
- *  and rid of the PMD suppression here.
  */
-@SuppressWarnings("PMD.SingularField")
 @ToString(callSuper = true, of = "text")
 @EqualsAndHashCode(callSuper = true)
 public final class RsFlash extends RsWrap {
@@ -117,7 +113,6 @@ public final class RsFlash extends RsWrap {
     /**
      * To string.
      */
-    @SuppressWarnings("unused")
     private final transient CharSequence text;
 
     /**

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -191,8 +191,9 @@ public final class RsFlash extends RsWrap {
     @Override
     public String toString() {
         return String.format(
-            "%s(text=%s)",
+            "%s(super=%s, text=%s)",
             RsFlash.class.getSimpleName(),
+            super.toString(),
             this.text
         );
     }

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -192,9 +192,7 @@ public final class RsFlash extends RsWrap {
     public String toString() {
         return String.format(
             "%s(super=%s, text=%s)",
-            RsFlash.class.getSimpleName(),
-            super.toString(),
-            this.text
+            RsFlash.class.getSimpleName(), super.toString(), this.text
         );
     }
 

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -188,6 +188,11 @@ public final class RsFlash extends RsWrap {
         this.text = String.format(RsFlash.TEXT_FORMAT, level, msg);
     }
 
+    @Override
+    public String toString() {
+        return String.valueOf(this.text);
+    }
+
     /**
      * Make a response.
      * @param msg Message
@@ -219,10 +224,5 @@ public final class RsFlash extends RsWrap {
                 )
             )
         );
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(this.text);
     }
 }

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -191,8 +191,8 @@ public final class RsFlash extends RsWrap {
     @Override
     public String toString() {
         return String.format(
-            "%s(text=%s)", 
-            RsFlash.class.getSimpleName(), 
+            "%s(text=%s)",
+            RsFlash.class.getSimpleName(),
             this.text
         );
     }

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.takes.Response;
 import org.takes.misc.Sprintf;
 import org.takes.rs.RsWithCookie;
@@ -101,7 +100,6 @@ import org.takes.rs.RsWrap;
  * @version $Id$
  * @since 0.1
  */
-@ToString(callSuper = true, of = "text")
 @EqualsAndHashCode(callSuper = true)
 public final class RsFlash extends RsWrap {
 
@@ -223,4 +221,8 @@ public final class RsFlash extends RsWrap {
         );
     }
 
+    @Override
+    public String toString() {
+        return String.valueOf(this.text);
+    }
 }


### PR DESCRIPTION
Issue #698. After upgrade to qulice 0.16.4 we have to fix SingularField PMD warings in the RSFlash class. 
This PR do the following changes:
- Removes the SingularField PMD supression on RsFlash.java.
- Removes the lombok.ToString and override toString using the text variable