### PR TITLE
Issue #707 - Transient is not needed anymore

### DIFF
--- a/src/main/java/org/takes/facets/auth/Identity.java
+++ b/src/main/java/org/takes/facets/auth/Identity.java
@@ -74,11 +74,11 @@ public interface Identity {
         /**
          * URN.
          */
-        private final transient String name;
+        private final String name;
         /**
          * Map of properties.
          */
-        private final transient Map<String, String> props;
+        private final Map<String, String> props;
         /**
          * Ctor.
          * @param urn URN of the identity

--- a/src/main/java/org/takes/facets/auth/PsAll.java
+++ b/src/main/java/org/takes/facets/auth/PsAll.java
@@ -41,12 +41,12 @@ public class PsAll implements Pass {
     /**
      * Passes that have to be entered.
      */
-    private final transient List<? extends Pass> all;
+    private final List<? extends Pass> all;
 
     /**
      * Index of identity to return.
      */
-    private final transient int index;
+    private final int index;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -54,7 +54,7 @@ import org.takes.rs.RsWithHeader;
  * @version $Id$
  * @since 0.20
  */
-@EqualsAndHashCode(of = { "entry", "realm" })
+@EqualsAndHashCode
 @SuppressWarnings("PMD.TooManyMethods")
 public final class PsBasic implements Pass {
 

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -66,12 +66,12 @@ public final class PsBasic implements Pass {
     /**
      * Entry to validate user information.
      */
-    private final transient PsBasic.Entry entry;
+    private final PsBasic.Entry entry;
 
     /**
      * Realm.
      */
-    private final transient String realm;
+    private final String realm;
 
     /**
      * Ctor.
@@ -162,7 +162,7 @@ public final class PsBasic implements Pass {
         /**
          * Should we authenticate a user?
          */
-        private final transient boolean condition;
+        private final boolean condition;
         /**
          * Ctor.
          * @param cond Condition
@@ -221,7 +221,7 @@ public final class PsBasic implements Pass {
         /**
          * Map from login/password pairs to URNs.
          */
-        private final transient Map<String, String> usernames;
+        private final Map<String, String> usernames;
         /**
          * Public ctor.
          * @param users Strings with user's login, password and URN with

--- a/src/main/java/org/takes/facets/auth/PsByFlag.java
+++ b/src/main/java/org/takes/facets/auth/PsByFlag.java
@@ -51,12 +51,12 @@ public final class PsByFlag implements Pass {
     /**
      * The flag.
      */
-    private final transient String flag;
+    private final String flag;
 
     /**
      * Flags and passes.
      */
-    private final transient Map<Pattern, Pass> passes;
+    private final Map<Pattern, Pass> passes;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/PsByFlag.java
+++ b/src/main/java/org/takes/facets/auth/PsByFlag.java
@@ -45,7 +45,7 @@ import org.takes.rq.RqHref;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "flag", "passes" })
+@EqualsAndHashCode
 public final class PsByFlag implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/PsChain.java
+++ b/src/main/java/org/takes/facets/auth/PsChain.java
@@ -45,7 +45,7 @@ public final class PsChain implements Pass {
     /**
      * Passes.
      */
-    private final transient Iterable<Pass> passes;
+    private final Iterable<Pass> passes;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/PsChain.java
+++ b/src/main/java/org/takes/facets/auth/PsChain.java
@@ -39,7 +39,7 @@ import org.takes.misc.Opt;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = "passes")
+@EqualsAndHashCode
 public final class PsChain implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/PsCookie.java
+++ b/src/main/java/org/takes/facets/auth/PsCookie.java
@@ -46,7 +46,7 @@ import org.takes.rs.RsWithCookie;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "codec", "cookie", "age" })
+@EqualsAndHashCode
 public final class PsCookie implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/PsCookie.java
+++ b/src/main/java/org/takes/facets/auth/PsCookie.java
@@ -52,17 +52,17 @@ public final class PsCookie implements Pass {
     /**
      * Codec.
      */
-    private final transient Codec codec;
+    private final Codec codec;
 
     /**
      * Cookie to read.
      */
-    private final transient String cookie;
+    private final String cookie;
 
     /**
      * Max login age, in days.
      */
-    private final transient long age;
+    private final long age;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/PsFake.java
+++ b/src/main/java/org/takes/facets/auth/PsFake.java
@@ -43,7 +43,7 @@ public final class PsFake implements Pass {
     /**
      * Should we authenticate a user?
      */
-    private final transient boolean condition;
+    private final boolean condition;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/PsFake.java
+++ b/src/main/java/org/takes/facets/auth/PsFake.java
@@ -37,7 +37,7 @@ import org.takes.misc.Opt;
  * @version $Id$
  * @since 0.9
  */
-@EqualsAndHashCode(of = "condition")
+@EqualsAndHashCode
 public final class PsFake implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/PsFixed.java
+++ b/src/main/java/org/takes/facets/auth/PsFixed.java
@@ -37,7 +37,7 @@ import org.takes.misc.Opt;
  * @version $Id$
  * @since 0.9
  */
-@EqualsAndHashCode(of = "user")
+@EqualsAndHashCode
 public final class PsFixed implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/PsFixed.java
+++ b/src/main/java/org/takes/facets/auth/PsFixed.java
@@ -43,7 +43,7 @@ public final class PsFixed implements Pass {
     /**
      * User to return always.
      */
-    private final transient Identity user;
+    private final Identity user;
 
     /**
      * Identity to return always.

--- a/src/main/java/org/takes/facets/auth/RqAuth.java
+++ b/src/main/java/org/takes/facets/auth/RqAuth.java
@@ -47,7 +47,7 @@ public final class RqAuth extends RqWrap {
     /**
      * Header with authentication info.
      */
-    private final transient String header;
+    private final String header;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/TkAuth.java
+++ b/src/main/java/org/takes/facets/auth/TkAuth.java
@@ -42,7 +42,7 @@ import org.takes.rq.RqWithoutHeader;
  * @since 0.1
  */
 @ToString(of = { "origin", "pass", "header" })
-@EqualsAndHashCode(of = { "origin", "pass", "header" })
+@EqualsAndHashCode
 public final class TkAuth implements Take {
 
     /**

--- a/src/main/java/org/takes/facets/auth/TkAuth.java
+++ b/src/main/java/org/takes/facets/auth/TkAuth.java
@@ -48,17 +48,17 @@ public final class TkAuth implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Pass.
      */
-    private final transient Pass pass;
+    private final Pass pass;
 
     /**
      * Header to set in case of authentication.
      */
-    private final transient String header;
+    private final String header;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/TkSecure.java
+++ b/src/main/java/org/takes/facets/auth/TkSecure.java
@@ -43,7 +43,7 @@ import org.takes.facets.forward.RsForward;
  * @since 0.1
  */
 @ToString(of = { "origin", "loc" })
-@EqualsAndHashCode(of = { "origin", "loc" })
+@EqualsAndHashCode
 public final class TkSecure implements Take {
 
     /**

--- a/src/main/java/org/takes/facets/auth/TkSecure.java
+++ b/src/main/java/org/takes/facets/auth/TkSecure.java
@@ -49,12 +49,12 @@ public final class TkSecure implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Location where to forward.
      */
-    private final transient String loc;
+    private final String loc;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcAes.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcAes.java
@@ -47,7 +47,7 @@ import org.takes.facets.auth.Identity;
  * @version $Id$
  * @since 0.13.8
  */
-@EqualsAndHashCode(of = {"origin", "key", "spec"})
+@EqualsAndHashCode
 public final class CcAes implements Codec {
     /**
      * The block size constant.

--- a/src/main/java/org/takes/facets/auth/codecs/CcAes.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcAes.java
@@ -57,17 +57,17 @@ public final class CcAes implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * The encryption key.
      */
-    private final transient byte[] key;
+    private final byte[] key;
 
     /**
      * The algorithm parameter spec for cipher.
      */
-    private final transient AlgorithmParameterSpec spec;
+    private final AlgorithmParameterSpec spec;
 
     /**
      * Constructor for the class.

--- a/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
@@ -40,7 +40,7 @@ public final class CcBase64 implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
     /**
      * Ctor.
      * @param codec Original codec

--- a/src/main/java/org/takes/facets/auth/codecs/CcGzip.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcGzip.java
@@ -41,7 +41,7 @@ import org.takes.facets.auth.Identity;
  * @version $Id$
  * @since 0.16
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class CcGzip implements Codec {
 
     /**

--- a/src/main/java/org/takes/facets/auth/codecs/CcGzip.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcGzip.java
@@ -47,7 +47,7 @@ public final class CcGzip implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcHex.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcHex.java
@@ -37,7 +37,7 @@ import org.takes.facets.auth.Identity;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class CcHex implements Codec {
 
     /**

--- a/src/main/java/org/takes/facets/auth/codecs/CcHex.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcHex.java
@@ -71,7 +71,7 @@ public final class CcHex implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcSafe.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSafe.java
@@ -42,7 +42,7 @@ public final class CcSafe implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcSafe.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSafe.java
@@ -36,7 +36,7 @@ import org.takes.facets.auth.Identity;
  * @version $Id$
  * @since 0.5
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class CcSafe implements Codec {
 
     /**

--- a/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
@@ -50,7 +50,7 @@ public final class CcSalted implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
@@ -39,7 +39,7 @@ import org.takes.facets.auth.Identity;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class CcSalted implements Codec {
 
     /**

--- a/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
@@ -48,7 +48,7 @@ public final class CcStrict implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcXor.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcXor.java
@@ -44,12 +44,12 @@ public final class CcXor implements Codec {
     /**
      * Original codec.
      */
-    private final transient Codec origin;
+    private final Codec origin;
 
     /**
      * Secret to use for encoding.
      */
-    private final transient byte[] secret;
+    private final byte[] secret;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/codecs/CcXor.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcXor.java
@@ -38,7 +38,7 @@ import org.takes.misc.Utf8String;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "origin", "secret" })
+@EqualsAndHashCode
 public final class CcXor implements Codec {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsFacebook.java
+++ b/src/main/java/org/takes/facets/auth/social/PsFacebook.java
@@ -91,22 +91,22 @@ public final class PsFacebook implements Pass {
     /**
      * Request for fetching app token.
      */
-    private final transient com.jcabi.http.Request request;
+    private final com.jcabi.http.Request request;
 
     /**
      * Facebook login request handler.
      */
-    private final transient WebRequestor requestor;
+    private final WebRequestor requestor;
 
     /**
      * App name.
      */
-    private final transient String app;
+    private final String app;
 
     /**
      * Key.
      */
-    private final transient String key;
+    private final String key;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/social/PsFacebook.java
+++ b/src/main/java/org/takes/facets/auth/social/PsFacebook.java
@@ -59,7 +59,7 @@ import org.takes.rq.RqHref;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@EqualsAndHashCode(of = { "app", "key" })
+@EqualsAndHashCode
 public final class PsFacebook implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsFacebook.java
+++ b/src/main/java/org/takes/facets/auth/social/PsFacebook.java
@@ -59,7 +59,7 @@ import org.takes.rq.RqHref;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(of = { "app", "key" })
 public final class PsFacebook implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsGithub.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGithub.java
@@ -54,7 +54,7 @@ import org.takes.rq.RqHref;
  * @since 0.1
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(of = { "app", "key" })
 public final class PsGithub implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsGithub.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGithub.java
@@ -54,7 +54,7 @@ import org.takes.rq.RqHref;
  * @since 0.1
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-@EqualsAndHashCode(of = { "app", "key" })
+@EqualsAndHashCode
 public final class PsGithub implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsGithub.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGithub.java
@@ -75,22 +75,22 @@ public final class PsGithub implements Pass {
     /**
      * App name.
      */
-    private final transient String app;
+    private final String app;
 
     /**
      * Key.
      */
-    private final transient String key;
+    private final String key;
 
     /**
      * GitHub OAuth url.
      */
-    private final transient String github;
+    private final String github;
 
     /**
      * GitHub API url.
      */
-    private final transient String api;
+    private final String api;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -88,27 +88,27 @@ public final class PsGoogle implements Pass {
     /**
      * App name.
      */
-    private final transient String app;
+    private final String app;
 
     /**
      * Key.
      */
-    private final transient String key;
+    private final String key;
 
     /**
      * Redirect URI.
      */
-    private final transient String redir;
+    private final String redir;
 
     /**
      * Google OAuth url.
      */
-    private final transient String gauth;
+    private final String gauth;
 
     /**
      * Google API url.
      */
-    private final transient String gapi;
+    private final String gapi;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -52,7 +52,7 @@ import org.takes.rq.RqHref;
  * @since 0.9
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-@EqualsAndHashCode(of = { "app", "key", "redir" })
+@EqualsAndHashCode
 public final class PsGoogle implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -52,7 +52,7 @@ import org.takes.rq.RqHref;
  * @since 0.9
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(of = { "app", "key", "redir" })
 public final class PsGoogle implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
+++ b/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
@@ -51,7 +51,7 @@ import org.takes.rq.RqHref;
  * @version $Id$
  * @since 0.11.3
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(of = { "app", "key" })
 public final class PsLinkedin implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
+++ b/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
@@ -62,22 +62,22 @@ public final class PsLinkedin implements Pass {
     /**
      * App name.
      */
-    private final transient String app;
+    private final String app;
 
     /**
      * Key.
      */
-    private final transient String key;
+    private final String key;
 
     /**
      * Linkedin token href.
      */
-    private final transient Href tkhref;
+    private final Href tkhref;
 
     /**
      * Linkedin api href.
      */
-    private final transient Href apihref;
+    private final Href apihref;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
+++ b/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
@@ -51,7 +51,7 @@ import org.takes.rq.RqHref;
  * @version $Id$
  * @since 0.11.3
  */
-@EqualsAndHashCode(of = { "app", "key" })
+@EqualsAndHashCode
 public final class PsLinkedin implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsTwitter.java
+++ b/src/main/java/org/takes/facets/auth/social/PsTwitter.java
@@ -52,7 +52,7 @@ import org.takes.misc.Utf8String;
  * @since 0.16
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(of = { "app", "key" })
 public final class PsTwitter implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsTwitter.java
+++ b/src/main/java/org/takes/facets/auth/social/PsTwitter.java
@@ -52,7 +52,7 @@ import org.takes.misc.Utf8String;
  * @since 0.16
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-@EqualsAndHashCode(of = { "app", "key" })
+@EqualsAndHashCode
 public final class PsTwitter implements Pass {
 
     /**

--- a/src/main/java/org/takes/facets/auth/social/PsTwitter.java
+++ b/src/main/java/org/takes/facets/auth/social/PsTwitter.java
@@ -74,22 +74,22 @@ public final class PsTwitter implements Pass {
     /**
      * App name.
      */
-    private final transient String app;
+    private final String app;
 
     /**
      * Key.
      */
-    private final transient String key;
+    private final String key;
 
     /**
      * Request for fetching app token.
      */
-    private final transient com.jcabi.http.Request token;
+    private final com.jcabi.http.Request token;
 
     /**
      * Request for verifying user credentials.
      */
-    private final transient com.jcabi.http.Request user;
+    private final com.jcabi.http.Request user;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fallback/FbWrap.java
+++ b/src/main/java/org/takes/facets/fallback/FbWrap.java
@@ -43,7 +43,7 @@ public class FbWrap implements Fallback {
     /**
      * Original fallback.
      */
-    private final transient Fallback origin;
+    private final Fallback origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fallback/FbWrap.java
+++ b/src/main/java/org/takes/facets/fallback/FbWrap.java
@@ -37,7 +37,7 @@ import org.takes.misc.Opt;
  * @version $Id$
  * @since 0.13
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class FbWrap implements Fallback {
 
     /**

--- a/src/main/java/org/takes/facets/fallback/RqFallback.java
+++ b/src/main/java/org/takes/facets/fallback/RqFallback.java
@@ -70,15 +70,15 @@ public interface RqFallback extends Request {
         /**
          * Original request.
          */
-        private final transient Request request;
+        private final Request request;
         /**
          * HTTP status code.
          */
-        private final transient int status;
+        private final int status;
         /**
          * Throwable.
          */
-        private final transient Throwable err;
+        private final Throwable err;
         /**
          * Ctor.
          * @param code HTTP status code

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -111,7 +111,7 @@ public final class RsFlash extends RsWrap {
     /**
      * To string.
      */
-    private final transient CharSequence text;
+    private final CharSequence text;
 
     /**
      * Constructs a {@code RsFlash} with the specified message.

--- a/src/main/java/org/takes/facets/flash/TkFlash.java
+++ b/src/main/java/org/takes/facets/flash/TkFlash.java
@@ -66,12 +66,12 @@ public final class TkFlash implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Cookie name.
      */
-    private final transient String cookie;
+    private final String cookie;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/flash/TkFlash.java
+++ b/src/main/java/org/takes/facets/flash/TkFlash.java
@@ -60,7 +60,7 @@ import org.takes.rs.RsWithCookie;
  * @since 0.1
  */
 @ToString(of = { "origin", "cookie" })
-@EqualsAndHashCode(of = { "origin", "cookie" })
+@EqualsAndHashCode
 public final class TkFlash implements Take {
 
     /**

--- a/src/main/java/org/takes/facets/flash/XeFlash.java
+++ b/src/main/java/org/takes/facets/flash/XeFlash.java
@@ -45,7 +45,7 @@ import org.xembly.Directives;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "req", "cookie" })
+@EqualsAndHashCode
 public final class XeFlash implements XeSource {
     /**
      * Compiled RsFlash message regexp pattern.

--- a/src/main/java/org/takes/facets/flash/XeFlash.java
+++ b/src/main/java/org/takes/facets/flash/XeFlash.java
@@ -57,12 +57,12 @@ public final class XeFlash implements XeSource {
     /**
      * Request.
      */
-    private final transient Request req;
+    private final Request req;
 
     /**
      * Cookie name.
      */
-    private final transient String cookie;
+    private final String cookie;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkAnonymous.java
+++ b/src/main/java/org/takes/facets/fork/FkAnonymous.java
@@ -62,7 +62,7 @@ public final class FkAnonymous implements Fork {
     /**
      * Take.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkAnonymous.java
+++ b/src/main/java/org/takes/facets/fork/FkAnonymous.java
@@ -56,7 +56,7 @@ import org.takes.misc.Opt;
  * @see TkFork
  * @see TkRegex
  */
-@EqualsAndHashCode(of = "take")
+@EqualsAndHashCode
 public final class FkAnonymous implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkAuthenticated.java
+++ b/src/main/java/org/takes/facets/fork/FkAuthenticated.java
@@ -62,7 +62,7 @@ public final class FkAuthenticated implements Fork {
     /**
      * Take.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkAuthenticated.java
+++ b/src/main/java/org/takes/facets/fork/FkAuthenticated.java
@@ -56,7 +56,7 @@ import org.takes.misc.Opt;
  * @see TkFork
  * @see TkRegex
  */
-@EqualsAndHashCode(of = "take")
+@EqualsAndHashCode
 public final class FkAuthenticated implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkChain.java
+++ b/src/main/java/org/takes/facets/fork/FkChain.java
@@ -43,7 +43,7 @@ public final class FkChain implements Fork {
     /**
      * Forks.
      */
-    private final transient Collection<Fork> forks;
+    private final Collection<Fork> forks;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -42,7 +42,7 @@ import org.takes.tk.TkFixed;
  * @since 1.0
  * @see RsFork
  */
-@EqualsAndHashCode(of = { "type", "take" })
+@EqualsAndHashCode
 public final class FkContentType implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -48,12 +48,12 @@ public final class FkContentType implements Fork {
     /**
      * Type we can deliver.
      */
-    private final transient MediaTypes type;
+    private final MediaTypes type;
 
     /**
      * Take to handle the request and dynamically return the response.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -68,12 +68,12 @@ public final class FkEncoding implements Fork {
     /**
      * Encoding we can deliver (or empty string).
      */
-    private final transient String encoding;
+    private final String encoding;
 
     /**
      * Response to return.
      */
-    private final transient Response origin;
+    private final Response origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -57,7 +57,7 @@ import org.takes.rq.RqHeaders;
  * @see org.takes.facets.fork.RsFork
  * @since 0.10
  */
-@EqualsAndHashCode(of = { "encoding", "origin" })
+@EqualsAndHashCode
 public final class FkEncoding implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -53,22 +53,22 @@ public final class FkHitRefresh implements Fork {
     /**
      * Directory to watch.
      */
-    private final transient File dir;
+    private final File dir;
 
     /**
      * Command to execute.
      */
-    private final transient Runnable exec;
+    private final Runnable exec;
 
     /**
      * Target.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * File touched on every exec run.
      */
-    private final transient File last;
+    private final File last;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -47,7 +47,7 @@ import org.takes.rq.RqHeaders;
  * @since 0.9
  * @see TkFork
  */
-@EqualsAndHashCode(of = { "dir", "exec", "last", "take" })
+@EqualsAndHashCode
 public final class FkHitRefresh implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkMethods.java
+++ b/src/main/java/org/takes/facets/fork/FkMethods.java
@@ -59,12 +59,12 @@ public final class FkMethods implements Fork {
     /**
      * Methods to match.
      */
-    private final transient Collection<String> methods;
+    private final Collection<String> methods;
 
     /**
      * Target.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkMethods.java
+++ b/src/main/java/org/takes/facets/fork/FkMethods.java
@@ -53,7 +53,7 @@ import org.takes.tk.TkFixed;
  * @since 0.4
  * @see TkFork
  */
-@EqualsAndHashCode(of = { "methods", "take" })
+@EqualsAndHashCode
 public final class FkMethods implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkParams.java
+++ b/src/main/java/org/takes/facets/fork/FkParams.java
@@ -43,7 +43,7 @@ import org.takes.rq.RqHref;
  * @since 0.4
  * @see TkFork
  */
-@EqualsAndHashCode(of = { "name", "pattern", "take" })
+@EqualsAndHashCode
 public final class FkParams implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkParams.java
+++ b/src/main/java/org/takes/facets/fork/FkParams.java
@@ -49,17 +49,17 @@ public final class FkParams implements Fork {
     /**
      * Param name.
      */
-    private final transient String name;
+    private final String name;
 
     /**
      * Pattern for param value.
      */
-    private final transient Pattern pattern;
+    private final Pattern pattern;
 
     /**
      * Take.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -87,12 +87,12 @@ public final class FkRegex implements Fork {
     /**
      * Pattern.
      */
-    private final transient Pattern pattern;
+    private final Pattern pattern;
 
     /**
      * Target.
      */
-    private final transient TkRegex target;
+    private final TkRegex target;
 
     /**
      * Ctor.
@@ -209,12 +209,12 @@ public final class FkRegex implements Fork {
         /**
          * Matcher.
          */
-        private final transient Matcher mtr;
+        private final Matcher mtr;
 
         /**
          * Original request.
          */
-        private final transient Request req;
+        private final Request req;
 
         /**
          * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -81,7 +81,7 @@ import org.takes.tk.TkText;
  * @see TkFork
  * @see TkRegex
  */
-@EqualsAndHashCode(of = { "pattern", "target" })
+@EqualsAndHashCode
 public final class FkRegex implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkTypes.java
+++ b/src/main/java/org/takes/facets/fork/FkTypes.java
@@ -47,17 +47,17 @@ public final class FkTypes implements Fork {
     /**
      * Types we can deliver.
      */
-    private final transient MediaTypes types;
+    private final MediaTypes types;
 
     /**
      * Response to return.
      */
-    private final transient Opt<Response> response;
+    private final Opt<Response> response;
 
     /**
      * Response to return.
      */
-    private final transient Opt<Take> take;
+    private final Opt<Take> take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/FkTypes.java
+++ b/src/main/java/org/takes/facets/fork/FkTypes.java
@@ -41,7 +41,7 @@ import org.takes.rq.RqHeaders;
  * @since 0.6
  * @see RsFork
  */
-@EqualsAndHashCode(of = { "types", "response", "take" })
+@EqualsAndHashCode
 public final class FkTypes implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkWrap.java
+++ b/src/main/java/org/takes/facets/fork/FkWrap.java
@@ -39,7 +39,7 @@ import org.takes.misc.Opt;
  * @since 0.13
  * @see org.takes.facets.fork.RsFork
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class FkWrap implements Fork {
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkWrap.java
+++ b/src/main/java/org/takes/facets/fork/FkWrap.java
@@ -45,7 +45,7 @@ public class FkWrap implements Fork {
     /**
      * Original fork.
      */
-    private final transient Fork origin;
+    private final Fork origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -39,7 +39,7 @@ import org.takes.misc.EnglishLowerCase;
  * @see org.takes.facets.fork.FkTypes
  */
 @ToString
-@EqualsAndHashCode(of = { "high", "low" })
+@EqualsAndHashCode
 final class MediaType implements Comparable<MediaType> {
 
     /**

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -50,17 +50,17 @@ final class MediaType implements Comparable<MediaType> {
     /**
      * Priority.
      */
-    private final transient Double prio;
+    private final Double prio;
 
     /**
      * High part.
      */
-    private final transient String high;
+    private final String high;
 
     /**
      * Low part.
      */
-    private final transient String low;
+    private final String low;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -41,7 +41,7 @@ import org.takes.misc.EnglishLowerCase;
  * @see org.takes.facets.fork.FkTypes
  */
 @ToString
-@EqualsAndHashCode(of = "list")
+@EqualsAndHashCode
 final class MediaTypes {
 
     /**

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -47,7 +47,7 @@ final class MediaTypes {
     /**
      * Set of types.
      */
-    private final transient SortedSet<MediaType> list;
+    private final SortedSet<MediaType> list;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/RqRegex.java
+++ b/src/main/java/org/takes/facets/fork/RqRegex.java
@@ -64,11 +64,11 @@ public interface RqRegex extends Request {
         /**
          * Original request.
          */
-        private final transient Request request;
+        private final Request request;
         /**
          * Matcher.
          */
-        private final transient Matcher mtr;
+        private final Matcher mtr;
         /**
          * Ctor.
          * @param ptn Pattern

--- a/src/main/java/org/takes/facets/fork/TkFork.java
+++ b/src/main/java/org/takes/facets/fork/TkFork.java
@@ -70,7 +70,7 @@ public final class TkFork implements Take {
     /**
      * Patterns and their respective take.
      */
-    private final transient Collection<Fork> forks;
+    private final Collection<Fork> forks;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/fork/TkFork.java
+++ b/src/main/java/org/takes/facets/fork/TkFork.java
@@ -64,7 +64,7 @@ import org.takes.misc.Opt;
  * @see org.takes.facets.fork.FkParams
  */
 @ToString(of = "forks")
-@EqualsAndHashCode(of = "forks")
+@EqualsAndHashCode
 public final class TkFork implements Take {
 
     /**

--- a/src/main/java/org/takes/facets/fork/TkRegex.java
+++ b/src/main/java/org/takes/facets/fork/TkRegex.java
@@ -57,11 +57,11 @@ public interface TkRegex {
         /**
          * Original take, expecting {@link RqRegex}.
          */
-        private final transient TkRegex origin;
+        private final TkRegex origin;
         /**
          * Matcher.
          */
-        private final transient Matcher matcher;
+        private final Matcher matcher;
         /**
          * Ctor.
          * @param rgx Original destination

--- a/src/main/java/org/takes/facets/forward/TkForward.java
+++ b/src/main/java/org/takes/facets/forward/TkForward.java
@@ -46,7 +46,7 @@ import org.takes.rs.RsSimple;
  * @see org.takes.facets.forward.TkForward
  */
 @ToString(of = "origin")
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class TkForward implements Take {
 
     /**

--- a/src/main/java/org/takes/facets/forward/TkForward.java
+++ b/src/main/java/org/takes/facets/forward/TkForward.java
@@ -52,7 +52,7 @@ public final class TkForward implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Ctor.
@@ -81,11 +81,11 @@ public final class TkForward implements Take {
         /**
          * Original response.
          */
-        private final transient Response origin;
+        private final Response origin;
         /**
          * Saved response.
          */
-        private final transient List<Response> saved;
+        private final List<Response> saved;
         /**
          * Ctor.
          * @param res Original response

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmHeader.java
@@ -56,17 +56,17 @@ abstract class AbstractHmHeader<T> extends TypeSafeMatcher<T> {
     /**
      * Header matcher.
      */
-    private final transient Matcher<String> header;
+    private final Matcher<String> header;
 
     /**
      * Value matcher.
      */
-    private final transient Matcher<Iterable<String>> value;
+    private final Matcher<Iterable<String>> value;
 
     /**
      * Mismatched header values.
      */
-    private transient Collection<String> failed;
+    private Collection<String> failed;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/ret/TkReturn.java
+++ b/src/main/java/org/takes/facets/ret/TkReturn.java
@@ -52,12 +52,12 @@ public final class TkReturn implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Cookie name.
      */
-    private final transient String cookie;
+    private final String cookie;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/facets/ret/TkReturn.java
+++ b/src/main/java/org/takes/facets/ret/TkReturn.java
@@ -46,7 +46,7 @@ import org.takes.rs.RsWithCookie;
  * @since 0.20
  */
 @ToString(of = { "origin", "cookie" })
-@EqualsAndHashCode(of = { "origin", "cookie" })
+@EqualsAndHashCode
 public final class TkReturn implements Take {
 
     /**

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -61,7 +61,7 @@ public final class BkBasic implements Back {
     /**
      * Take.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -55,7 +55,7 @@ import org.takes.rs.RsWithStatus;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle IndentationCheck (500 lines)
  */
-@EqualsAndHashCode(of = "take")
+@EqualsAndHashCode
 public final class BkBasic implements Back {
 
     /**

--- a/src/main/java/org/takes/http/BkParallel.java
+++ b/src/main/java/org/takes/http/BkParallel.java
@@ -105,7 +105,7 @@ public final class BkParallel extends BkWrap {
         /**
          * Total threads created so far.
          */
-        private final transient AtomicInteger total = new AtomicInteger();
+        private final AtomicInteger total = new AtomicInteger();
 
         @Override
         public Thread newThread(final Runnable runnable) {

--- a/src/main/java/org/takes/http/BkTimeable.java
+++ b/src/main/java/org/takes/http/BkTimeable.java
@@ -45,15 +45,15 @@ public final class BkTimeable extends Thread implements Back {
     /**
      * Original back.
      */
-    private final transient Back back;
+    private final Back back;
     /**
      * Maximum latency in milliseconds.
      */
-    private final transient long latency;
+    private final long latency;
     /**
      * Threads storage.
      */
-    private final transient ConcurrentMap<Thread, Long> threads;
+    private final ConcurrentMap<Thread, Long> threads;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/http/BkWrap.java
+++ b/src/main/java/org/takes/http/BkWrap.java
@@ -33,7 +33,7 @@ import lombok.EqualsAndHashCode;
  * @version $Id$
  * @since 0.28
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class BkWrap implements Back {
     /**
      * Original back.

--- a/src/main/java/org/takes/http/BkWrap.java
+++ b/src/main/java/org/takes/http/BkWrap.java
@@ -38,7 +38,7 @@ public class BkWrap implements Back {
     /**
      * Original back.
      */
-    private final transient Back origin;
+    private final Back origin;
     /**
      * Ctor.
      * @param back Original back

--- a/src/main/java/org/takes/http/Exit.java
+++ b/src/main/java/org/takes/http/Exit.java
@@ -58,11 +58,11 @@ public interface Exit {
         /**
          * Left.
          */
-        private final transient Exit left;
+        private final Exit left;
         /**
          * Right.
          */
-        private final transient Exit right;
+        private final Exit right;
         /**
          * Ctor.
          * @param lft Left
@@ -86,11 +86,11 @@ public interface Exit {
         /**
          * Left.
          */
-        private final transient Exit left;
+        private final Exit left;
         /**
          * Right.
          */
-        private final transient Exit right;
+        private final Exit right;
         /**
          * Ctor.
          * @param lft Left
@@ -114,7 +114,7 @@ public interface Exit {
         /**
          * Origin.
          */
-        private final transient Exit origin;
+        private final Exit origin;
         /**
          * Ctor.
          * @param exit Original

--- a/src/main/java/org/takes/http/FtBasic.java
+++ b/src/main/java/org/takes/http/FtBasic.java
@@ -45,12 +45,12 @@ public final class FtBasic implements Front {
     /**
      * Back.
      */
-    private final transient Back back;
+    private final Back back;
 
     /**
      * Server socket.
      */
-    private final transient ServerSocket socket;
+    private final ServerSocket socket;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/http/FtBasic.java
+++ b/src/main/java/org/takes/http/FtBasic.java
@@ -39,7 +39,7 @@ import org.takes.Take;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "back", "socket" })
+@EqualsAndHashCode
 public final class FtBasic implements Front {
 
     /**

--- a/src/main/java/org/takes/http/FtCli.java
+++ b/src/main/java/org/takes/http/FtCli.java
@@ -57,7 +57,7 @@ import org.takes.rq.RqWithHeader;
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "take", "options" })
+@EqualsAndHashCode
 public final class FtCli implements Front {
 
     /**

--- a/src/main/java/org/takes/http/FtCli.java
+++ b/src/main/java/org/takes/http/FtCli.java
@@ -63,12 +63,12 @@ public final class FtCli implements Front {
     /**
      * Take.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Command line args.
      */
-    private final transient Options options;
+    private final Options options;
 
     /**
      * Ctor.
@@ -165,12 +165,12 @@ public final class FtCli implements Front {
         /**
          * Start time.
          */
-        private final transient long start;
+        private final long start;
 
         /**
          * Max lifetime.
          */
-        private final transient long max;
+        private final long max;
 
         /**
          * Ctor.

--- a/src/main/java/org/takes/http/FtRemote.java
+++ b/src/main/java/org/takes/http/FtRemote.java
@@ -48,17 +48,17 @@ public final class FtRemote implements Front {
     /**
      * Original front.
      */
-    private final transient Front origin;
+    private final Front origin;
 
     /**
      * Server socket.
      */
-    private final transient ServerSocket socket;
+    private final ServerSocket socket;
 
     /**
      * Indicates whether the front is secure (HTTPS).
      */
-    private final transient boolean secured;
+    private final boolean secured;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/http/FtRemote.java
+++ b/src/main/java/org/takes/http/FtRemote.java
@@ -42,7 +42,7 @@ import org.takes.Take;
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@EqualsAndHashCode(of = { "origin", "socket" })
+@EqualsAndHashCode
 public final class FtRemote implements Front {
 
     /**

--- a/src/main/java/org/takes/http/FtSecure.java
+++ b/src/main/java/org/takes/http/FtSecure.java
@@ -41,7 +41,7 @@ import org.takes.Take;
  * @version $Id$
  * @since 0.25
  */
-@EqualsAndHashCode(of = { "front" })
+@EqualsAndHashCode
 public final class FtSecure implements Front {
 
     /**

--- a/src/main/java/org/takes/http/FtSecure.java
+++ b/src/main/java/org/takes/http/FtSecure.java
@@ -47,7 +47,7 @@ public final class FtSecure implements Front {
     /**
      * The original front that is initialized with an SSLServerSocket.
      */
-    private final transient Front front;
+    private final Front front;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -45,7 +45,7 @@ import org.takes.misc.Utf8String;
  * @since 0.23
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@EqualsAndHashCode(of = "app")
+@EqualsAndHashCode
 public final class MainRemote {
 
     /**

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -51,12 +51,12 @@ public final class MainRemote {
     /**
      * Application with {@code main()} method.
      */
-    private final transient Class<?> app;
+    private final Class<?> app;
 
     /**
      * Additional arguments to be passed to the main class.
      */
-    private final transient String[] args;
+    private final String[] args;
 
     /**
      * Ctor.
@@ -189,12 +189,12 @@ public final class MainRemote {
         /**
          * Method.
          */
-        private final transient Method method;
+        private final Method method;
 
         /**
          * Additional arguments.
          */
-        private final transient String[] passed;
+        private final String[] passed;
 
         /**
          * Ctor.

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -54,7 +54,7 @@ final class Options {
     /**
      * Map of arguments and their values.
      */
-    private final transient Map<String, String> map;
+    private final Map<String, String> map;
 
     /**
      * Constructs an {@code Options} with the specified arguments.

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -48,7 +48,7 @@ import org.takes.misc.Utf8OutputStreamWriter;
  * @version $Id$
  * @since 0.2
  */
-@EqualsAndHashCode(of = "map")
+@EqualsAndHashCode
 final class Options {
 
     /**

--- a/src/main/java/org/takes/misc/Concat.java
+++ b/src/main/java/org/takes/misc/Concat.java
@@ -39,12 +39,12 @@ public final class Concat<T> implements Iterable<T> {
     /**
      * Internal reference to hold the first elements from constructor.
      */
-    private final transient Iterable<T> left;
+    private final Iterable<T> left;
 
     /**
      * Internal reference to hold the second elements from constructor.
      */
-    private final transient Iterable<T> right;
+    private final Iterable<T> right;
 
     /**
      * Ctor.
@@ -81,11 +81,11 @@ public final class Concat<T> implements Iterable<T> {
         /**
          * Internal reference for holding the first iterator from constructor.
          */
-        private final transient Iterator<E> left;
+        private final Iterator<E> left;
         /**
          * Internal reference for holding the second iterator from constructor.
          */
-        private final transient Iterator<E> right;
+        private final Iterator<E> right;
         /**
          * Ctor.
          * @param aitr The first iterable to traverse

--- a/src/main/java/org/takes/misc/Condition.java
+++ b/src/main/java/org/takes/misc/Condition.java
@@ -48,7 +48,7 @@ public interface Condition<T> {
         /**
          * Condition.
          */
-        private final transient Condition<T> condition;
+        private final Condition<T> condition;
         /**
          * Ctor.
          * @param cond The condition to negate

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -36,7 +36,7 @@ public final class EnglishLowerCase {
     /**
      * String value.
      */
-    private final transient String value;
+    private final String value;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/EntryImpl.java
+++ b/src/main/java/org/takes/misc/EntryImpl.java
@@ -40,12 +40,12 @@ public final class EntryImpl<K, V> implements Map.Entry<K, V> {
     /**
      * Key.
      */
-    private final transient K key;
+    private final K key;
 
     /**
      * Value.
      */
-    private final transient V value;
+    private final V value;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -62,12 +62,12 @@ public final class Href implements CharSequence {
     /**
      * URI (without the query part).
      */
-    private final transient URI uri;
+    private final URI uri;
 
     /**
      * Params.
      */
-    private final transient SortedMap<String, List<String>> params;
+    private final SortedMap<String, List<String>> params;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/Opt.java
+++ b/src/main/java/org/takes/misc/Opt.java
@@ -57,7 +57,7 @@ public interface Opt<T> {
      * @since 0.14
      * @param <T> Type of item
      */
-    @EqualsAndHashCode(of = "origin")
+    @EqualsAndHashCode
     final class Single<T> implements Opt<T> {
         /**
          * Origin.

--- a/src/main/java/org/takes/misc/Opt.java
+++ b/src/main/java/org/takes/misc/Opt.java
@@ -62,7 +62,7 @@ public interface Opt<T> {
         /**
          * Origin.
          */
-        private final transient T origin;
+        private final T origin;
         /**
          * Ctor.
          * @param orgn Origin

--- a/src/main/java/org/takes/misc/Select.java
+++ b/src/main/java/org/takes/misc/Select.java
@@ -41,12 +41,12 @@ public final class Select<T> implements Iterable<T> {
     /**
      * Internal storage to hold the elements from iterables.
      */
-    private final transient Iterable<T> list;
+    private final Iterable<T> list;
 
     /**
      * The condition to filter the element in the iterator.
      */
-    private final transient Condition<T> condition;
+    private final Condition<T> condition;
 
     /**
      * To produce an iterable collection, determined by condition, combining a
@@ -84,15 +84,15 @@ public final class Select<T> implements Iterable<T> {
         /**
          * The iterator to reflect the traverse state.
          */
-        private final transient Iterator<E> iterator;
+        private final Iterator<E> iterator;
         /**
          * The condition to filter the elements in the iterator.
          */
-        private final transient Condition<E> condition;
+        private final Condition<E> condition;
         /**
          * The buffer storing the objects of the iterator.
          */
-        private final transient Queue<E> buffer;
+        private final Queue<E> buffer;
         /**
          * Ctor. ConcatIterator traverses the element.
          * @param itr Iterator of the original iterable

--- a/src/main/java/org/takes/misc/Sprintf.java
+++ b/src/main/java/org/takes/misc/Sprintf.java
@@ -40,12 +40,12 @@ public final class Sprintf implements CharSequence {
     /**
      * Pattern.
      */
-    private final transient String pattern;
+    private final String pattern;
 
     /**
      * Arguments.
      */
-    private final transient Collection<Object> args;
+    private final Collection<Object> args;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/Transform.java
+++ b/src/main/java/org/takes/misc/Transform.java
@@ -39,12 +39,12 @@ public class Transform<T, K> implements Iterable<K> {
     /**
      * Internal storage.
      */
-    private final transient Iterable<T> list;
+    private final Iterable<T> list;
 
     /**
      * The action to transform the elements in the iterator.
      */
-    private final transient TransformAction<T, K> action;
+    private final TransformAction<T, K> action;
 
     /**
      * Ctor.
@@ -81,12 +81,12 @@ public class Transform<T, K> implements Iterable<K> {
         /**
          * The iterator to reflect the traverse state.
          */
-        private final transient Iterator<B> iterator;
+        private final Iterator<B> iterator;
 
         /**
          * The action to transform the elements in the iterator.
          */
-        private final transient TransformAction<B, A> action;
+        private final TransformAction<B, A> action;
 
         /**
          * Ctor. ConcatIterator traverses the element.

--- a/src/main/java/org/takes/misc/Utf8String.java
+++ b/src/main/java/org/takes/misc/Utf8String.java
@@ -41,7 +41,7 @@ public final class Utf8String {
     /**
      * String value.
      */
-    private final transient String value;
+    private final String value;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/VerboseIterable.java
+++ b/src/main/java/org/takes/misc/VerboseIterable.java
@@ -38,12 +38,12 @@ public final class VerboseIterable<T> implements Iterable<T> {
     /**
      * Original iterator.
      */
-    private final transient Iterable<T> origin;
+    private final Iterable<T> origin;
 
     /**
      * Error message when running out of items.
      */
-    private final transient CharSequence error;
+    private final CharSequence error;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/VerboseIterator.java
+++ b/src/main/java/org/takes/misc/VerboseIterator.java
@@ -39,12 +39,12 @@ public final class VerboseIterator<T> implements Iterator<T> {
     /**
      * Original iterator.
      */
-    private final transient Iterator<T> origin;
+    private final Iterator<T> origin;
 
     /**
      * Error message when running out of items.
      */
-    private final transient CharSequence error;
+    private final CharSequence error;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/misc/VerboseList.java
+++ b/src/main/java/org/takes/misc/VerboseList.java
@@ -43,12 +43,12 @@ public final class VerboseList<T> implements List<T> {
     /**
      * Original list.
      */
-    private final transient List<T> origin;
+    private final List<T> origin;
 
     /**
      * Error message for IndexOutOfBoundsException.
      */
-    private final transient String message;
+    private final String message;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/CapInputStream.java
+++ b/src/main/java/org/takes/rq/CapInputStream.java
@@ -40,12 +40,12 @@ final class CapInputStream extends InputStream {
     /**
      * Original stream.
      */
-    private final transient InputStream origin;
+    private final InputStream origin;
 
     /**
      * More bytes to read.
      */
-    private transient long more;
+    private long more;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/ChunkedInputStream.java
+++ b/src/main/java/org/takes/rq/ChunkedInputStream.java
@@ -42,27 +42,27 @@ final class ChunkedInputStream extends InputStream {
     /**
      * The inputstream that we're wrapping.
      */
-    private final transient InputStream origin;
+    private final InputStream origin;
 
     /**
      * The chunk size.
      */
-    private transient int size;
+    private int size;
 
     /**
      * The current position within the current chunk.
      */
-    private transient int pos;
+    private int pos;
 
     /**
      * True if we'are at the beginning of stream.
      */
-    private transient boolean bof;
+    private boolean bof;
 
     /**
      * True if we've reached the end of stream.
      */
-    private transient boolean eof;
+    private boolean eof;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -170,7 +170,7 @@ public interface RqHeaders extends Request {
      * @author Yegor Bugayenko (yegor@teamed.io)
      * @since 0.16
      */
-    @EqualsAndHashCode(of = "origin")
+    @EqualsAndHashCode
     final class Smart implements RqHeaders {
         /**
          * Original.

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -175,7 +175,7 @@ public interface RqHeaders extends Request {
         /**
          * Original.
          */
-        private final transient RqHeaders origin;
+        private final RqHeaders origin;
         /**
          * Ctor.
          * @param req Original request

--- a/src/main/java/org/takes/rq/RqHref.java
+++ b/src/main/java/org/takes/rq/RqHref.java
@@ -93,7 +93,7 @@ public interface RqHref extends Request {
      * @author Yegor Bugayenko (yegor@teamed.io)
      * @since 0.14
      */
-    @EqualsAndHashCode(of = "origin")
+    @EqualsAndHashCode
     final class Smart implements RqHref {
         /**
          * Original.

--- a/src/main/java/org/takes/rq/RqHref.java
+++ b/src/main/java/org/takes/rq/RqHref.java
@@ -98,7 +98,7 @@ public interface RqHref extends Request {
         /**
          * Original.
          */
-        private final transient RqHref origin;
+        private final RqHref origin;
         /**
          * Ctor.
          * @param req Original request

--- a/src/main/java/org/takes/rq/RqWrap.java
+++ b/src/main/java/org/takes/rq/RqWrap.java
@@ -37,7 +37,7 @@ import org.takes.Request;
  * @version $Id$
  * @since 0.6
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class RqWrap implements Request {
 
     /**

--- a/src/main/java/org/takes/rq/RqWrap.java
+++ b/src/main/java/org/takes/rq/RqWrap.java
@@ -43,7 +43,7 @@ public class RqWrap implements Request {
     /**
      * Original request.
      */
-    private final transient Request origin;
+    private final Request origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/TempInputStream.java
+++ b/src/main/java/org/takes/rq/TempInputStream.java
@@ -42,12 +42,12 @@ public final class TempInputStream extends InputStream {
     /**
      * Original stream.
      */
-    private final transient InputStream origin;
+    private final InputStream origin;
 
     /**
      * Associated File instance.
      */
-    private final transient File file;
+    private final File file;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -58,12 +58,12 @@ public final class RqFormBase extends RqWrap implements RqForm {
     /**
      * Request.
      */
-    private final transient Request req;
+    private final Request req;
 
     /**
      * Saved map.
      */
-    private final transient List<Map<String, List<String>>> saved;
+    private final List<Map<String, List<String>>> saved;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -52,7 +52,7 @@ import org.takes.rq.RqWrap;
  * @since 0.33
  */
 @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-@EqualsAndHashCode(callSuper = true, of = "req")
+@EqualsAndHashCode(callSuper = true)
 public final class RqFormBase extends RqWrap implements RqForm {
 
     /**

--- a/src/main/java/org/takes/rq/form/RqFormSmart.java
+++ b/src/main/java/org/takes/rq/form/RqFormSmart.java
@@ -40,7 +40,7 @@ import org.takes.rq.RqForm;
  * @version $Id$
  * @since 0.33
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class RqFormSmart implements RqForm {
 
     /**

--- a/src/main/java/org/takes/rq/form/RqFormSmart.java
+++ b/src/main/java/org/takes/rq/form/RqFormSmart.java
@@ -46,7 +46,7 @@ public final class RqFormSmart implements RqForm {
     /**
      * Original.
      */
-    private final transient RqForm origin;
+    private final RqForm origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -97,19 +97,19 @@ public final class RqMtBase implements RqMultipart {
     /**
      * Map of params and values.
      */
-    private final transient Map<String, List<Request>> map;
+    private final Map<String, List<Request>> map;
     /**
      * Internal buffer.
      */
-    private final transient ByteBuffer buffer;
+    private final ByteBuffer buffer;
     /**
      * InputStream based on request body.
      */
-    private final transient InputStream stream;
+    private final InputStream stream;
     /**
      * Original request.
      */
-    private final transient Request origin;
+    private final Request origin;
     /**
      * Ctor.
      * @param req Original request

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -51,7 +51,7 @@ public final class RqMtFake implements RqMultipart {
     /**
      * Fake multipart request.
      */
-    private final transient RqMultipart fake;
+    private final RqMultipart fake;
     /**
      * Fake ctor.
      * @param req Fake request header holder
@@ -124,11 +124,11 @@ public final class RqMtFake implements RqMultipart {
         /**
          * Request object. Holds a value for the header.
          */
-        private final transient Request req;
+        private final Request req;
         /**
          * Holding multiple request body parts.
          */
-        private final transient String parts;
+        private final String parts;
         /**
          * The Constructor for the class.
          * @param rqst The Request object

--- a/src/main/java/org/takes/rq/multipart/RqMtSmart.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtSmart.java
@@ -41,7 +41,7 @@ public final class RqMtSmart implements RqMultipart {
     /**
      * Original request.
      */
-    private final transient RqMultipart origin;
+    private final RqMultipart origin;
     /**
      * Ctor.
      * @param req Original

--- a/src/main/java/org/takes/rs/Body.java
+++ b/src/main/java/org/takes/rs/Body.java
@@ -68,7 +68,7 @@ interface Body {
         /**
          * The {@link java.net.URL} of the content.
          */
-        private final transient java.net.URL url;
+        private final java.net.URL url;
 
         /**
          * Constructs an {@code URL} with the specified {@link java.net.URL}.
@@ -99,7 +99,7 @@ interface Body {
         /**
          * The content of the body in a byte array.
          */
-        private final transient byte[] bytes;
+        private final byte[] bytes;
 
         /**
          * Constructs an {@code ByteArray} with the specified byte array.
@@ -128,12 +128,12 @@ interface Body {
         /**
          * The content of the body in an InputStream.
          */
-        private final transient InputStream stream;
+        private final InputStream stream;
 
         /**
          * The length of the stream.
          */
-        private final transient AtomicInteger length;
+        private final AtomicInteger length;
 
         /**
          * Constructs an {@code Stream} with the specified {@link InputStream}.
@@ -180,12 +180,12 @@ interface Body {
         /**
          * The temporary file that contains the content of the body.
          */
-        private final transient File file;
+        private final File file;
 
         /**
          * The underlying body.
          */
-        private final transient Body body;
+        private final Body body;
 
         /**
          * Constructs a {@code TempFile} with the specified {@link Body}.

--- a/src/main/java/org/takes/rs/RsGzip.java
+++ b/src/main/java/org/takes/rs/RsGzip.java
@@ -51,12 +51,12 @@ public final class RsGzip implements Response {
     /**
      * Original response.
      */
-    private final transient Response origin;
+    private final Response origin;
 
     /**
      * Compressed and cached response.
      */
-    private final transient List<Response> zipped;
+    private final List<Response> zipped;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/RsGzip.java
+++ b/src/main/java/org/takes/rs/RsGzip.java
@@ -45,7 +45,7 @@ import org.takes.Response;
  * @since 0.10
  */
 @ToString(of = "origin")
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class RsGzip implements Response {
 
     /**

--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -51,7 +51,7 @@ import org.takes.Response;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = "origin")
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class RsPrettyJson implements Response {
 
     /**

--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -57,12 +57,12 @@ public final class RsPrettyJson implements Response {
     /**
      * Original response.
      */
-    private final transient Response origin;
+    private final Response origin;
 
     /**
      * Response with properly transformed body.
      */
-    private final transient List<Response> transformed;
+    private final List<Response> transformed;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/RsPrettyXml.java
+++ b/src/main/java/org/takes/rs/RsPrettyXml.java
@@ -69,12 +69,12 @@ public final class RsPrettyXml implements Response {
     /**
      * Original response.
      */
-    private final transient Response origin;
+    private final Response origin;
 
     /**
      * Response with properly transformed body.
      */
-    private final transient List<Response> transformed;
+    private final List<Response> transformed;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/RsPrettyXml.java
+++ b/src/main/java/org/takes/rs/RsPrettyXml.java
@@ -57,7 +57,7 @@ import org.xml.sax.XMLReader;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = "origin")
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public final class RsPrettyXml implements Response {
 
     /**

--- a/src/main/java/org/takes/rs/RsWrap.java
+++ b/src/main/java/org/takes/rs/RsWrap.java
@@ -39,7 +39,7 @@ import org.takes.Response;
  * @since 0.1
  */
 @ToString(of = "origin")
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class RsWrap implements Response {
 
     /**

--- a/src/main/java/org/takes/rs/RsWrap.java
+++ b/src/main/java/org/takes/rs/RsWrap.java
@@ -45,7 +45,7 @@ public class RsWrap implements Response {
     /**
      * Original response.
      */
-    private final transient Response origin;
+    private final Response origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/xe/XeDirectives.java
+++ b/src/main/java/org/takes/rs/xe/XeDirectives.java
@@ -46,7 +46,7 @@ public final class XeDirectives implements XeSource {
     /**
      * Items.
      */
-    private final transient Iterable<Directive> directives;
+    private final Iterable<Directive> directives;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/xe/XeDirectives.java
+++ b/src/main/java/org/takes/rs/xe/XeDirectives.java
@@ -40,7 +40,7 @@ import org.xembly.SyntaxException;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = "directives")
+@EqualsAndHashCode
 public final class XeDirectives implements XeSource {
 
     /**

--- a/src/main/java/org/takes/rs/xe/XeMillis.java
+++ b/src/main/java/org/takes/rs/xe/XeMillis.java
@@ -36,7 +36,7 @@ import org.xembly.Directives;
  * @version $Id$
  * @since 0.1
  */
-@EqualsAndHashCode(of = { "name", "finish" })
+@EqualsAndHashCode
 public final class XeMillis implements XeSource {
 
     /**

--- a/src/main/java/org/takes/rs/xe/XeMillis.java
+++ b/src/main/java/org/takes/rs/xe/XeMillis.java
@@ -42,12 +42,12 @@ public final class XeMillis implements XeSource {
     /**
      * Name of element.
      */
-    private final transient CharSequence name;
+    private final CharSequence name;
 
     /**
      * Is it a finish?
      */
-    private final transient boolean finish;
+    private final boolean finish;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/xe/XeTransform.java
+++ b/src/main/java/org/takes/rs/xe/XeTransform.java
@@ -64,7 +64,7 @@ import lombok.EqualsAndHashCode;
  * @since 0.1
  * @param <T> Type of item
  */
-@EqualsAndHashCode(of = { "objects", "func" })
+@EqualsAndHashCode
 public final class XeTransform<T> implements Iterable<XeSource> {
 
     /**

--- a/src/main/java/org/takes/rs/xe/XeTransform.java
+++ b/src/main/java/org/takes/rs/xe/XeTransform.java
@@ -70,12 +70,12 @@ public final class XeTransform<T> implements Iterable<XeSource> {
     /**
      * Iterable of objects.
      */
-    private final transient Iterable<T> objects;
+    private final Iterable<T> objects;
 
     /**
      * Function to use for mapping.
      */
-    private final transient XeTransform.Func<T> func;
+    private final XeTransform.Func<T> func;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/rs/xe/XeWrap.java
+++ b/src/main/java/org/takes/rs/xe/XeWrap.java
@@ -36,7 +36,7 @@ import org.xembly.Directive;
  * @version $Id$
  * @since 0.4
  */
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class XeWrap implements XeSource {
 
     /**

--- a/src/main/java/org/takes/rs/xe/XeWrap.java
+++ b/src/main/java/org/takes/rs/xe/XeWrap.java
@@ -42,7 +42,7 @@ public class XeWrap implements XeSource {
     /**
      * Source to add.
      */
-    private final transient XeSource origin;
+    private final XeSource origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -57,7 +57,7 @@ import org.takes.rs.RsWithStatus;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ToString(of = { "origin", "allowed" })
-@EqualsAndHashCode(of = { "origin", "allowed" })
+@EqualsAndHashCode
 public final class TkCors implements Take {
 
     /**

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -63,12 +63,12 @@ public final class TkCors implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * List of allowed domains.
      */
-    private final transient Set<String> allowed;
+    private final Set<String> allowed;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/tk/TkProxy.java
+++ b/src/main/java/org/takes/tk/TkProxy.java
@@ -59,12 +59,12 @@ public final class TkProxy implements Take {
     /**
      * Target.
      */
-    private final transient URI target;
+    private final URI target;
 
     /**
      * Label, to add to the HTTP header.
      */
-    private final transient String label;
+    private final String label;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/tk/TkReadAlways.java
+++ b/src/main/java/org/takes/tk/TkReadAlways.java
@@ -40,7 +40,7 @@ import org.takes.Take;
  * @since 0.30
  */
 @ToString(of = {"origin"})
-@EqualsAndHashCode(of = {"origin"})
+@EqualsAndHashCode
 public final class TkReadAlways implements Take {
 
     /**

--- a/src/main/java/org/takes/tk/TkReadAlways.java
+++ b/src/main/java/org/takes/tk/TkReadAlways.java
@@ -46,7 +46,7 @@ public final class TkReadAlways implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/tk/TkRetry.java
+++ b/src/main/java/org/takes/tk/TkRetry.java
@@ -48,17 +48,17 @@ public final class TkRetry implements Take {
     /**
      * Maximum number of retry attempts.
      */
-    private final transient int count;
+    private final int count;
 
     /**
      * Amount of time between retries, in milliseconds.
      */
-    private final transient int delay;
+    private final int delay;
 
     /**
      * Original Take.
      */
-    private final transient Take take;
+    private final Take take;
 
     /**
      * Constructor.

--- a/src/main/java/org/takes/tk/TkSlf4j.java
+++ b/src/main/java/org/takes/tk/TkSlf4j.java
@@ -52,12 +52,12 @@ public final class TkSlf4j implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Log target.
      */
-    private final transient String target;
+    private final String target;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/tk/TkSlf4j.java
+++ b/src/main/java/org/takes/tk/TkSlf4j.java
@@ -46,7 +46,7 @@ import org.takes.rq.RqMethod;
  * @since 0.11.2
  */
 @ToString(of = { "origin", "target" })
-@EqualsAndHashCode(of = { "origin", "target" })
+@EqualsAndHashCode
 public final class TkSlf4j implements Take {
 
     /**

--- a/src/main/java/org/takes/tk/TkWrap.java
+++ b/src/main/java/org/takes/tk/TkWrap.java
@@ -46,7 +46,7 @@ public class TkWrap implements Take {
     /**
      * Original take.
      */
-    private final transient Take origin;
+    private final Take origin;
 
     /**
      * Ctor.

--- a/src/main/java/org/takes/tk/TkWrap.java
+++ b/src/main/java/org/takes/tk/TkWrap.java
@@ -40,7 +40,7 @@ import org.takes.Take;
  * @since 0.4
  */
 @ToString(of = "origin")
-@EqualsAndHashCode(of = "origin")
+@EqualsAndHashCode
 public class TkWrap implements Take {
 
     /**

--- a/src/test/java/org/takes/rs/RsPrettyJsonTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyJsonTest.java
@@ -26,7 +26,6 @@ package org.takes.rs;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -100,7 +99,6 @@ public final class RsPrettyJsonTest {
     @Test
     public void conformsToEqualsAndHashCode() throws Exception {
         EqualsVerifier.forClass(RsPrettyJson.class)
-            .suppress(Warning.TRANSIENT_FIELDS)
             .withRedefinedSuperclass()
             .verify();
     }

--- a/src/test/java/org/takes/rs/RsPrettyXmlTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXmlTest.java
@@ -27,7 +27,6 @@ import com.google.common.base.Joiner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -195,7 +194,6 @@ public final class RsPrettyXmlTest {
     @Test
     public void conformsToEqualsAndHashCode() throws Exception {
         EqualsVerifier.forClass(RsPrettyXml.class)
-            .suppress(Warning.TRANSIENT_FIELDS)
             .withRedefinedSuperclass()
             .verify();
     }


### PR DESCRIPTION
Issue #707. Transient requirement has been removed from qulice and is not needed anymore.
This PR do the following changes:

- Removes transient everywhere where it was not added explicitly.
- Removes 'of' parameter from all '@EqualsAndHashCode'.
- Fixes some junit tests.