### PR TITLE
Base64 de/encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.takes</groupId>
     <artifactId>takes</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>take</name>
     <description>Immutable Java Web Framework</description>

--- a/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
@@ -23,12 +23,10 @@
  */
 package org.takes.facets.auth.codecs;
 
-import lombok.EqualsAndHashCode;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
-
+import lombok.EqualsAndHashCode;
 import org.takes.facets.auth.Identity;
 import org.takes.misc.Base64;
 
@@ -45,16 +43,17 @@ import org.takes.misc.Base64;
 @EqualsAndHashCode
 public final class CcBase64 implements Codec {
 
-	/**
-	 * All legal Base64 chars.
-	 */
-	private final static String base64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    /**
+     * All legal Base64 chars.
+     */
+    private static final String BASE64CHARS =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
     /**
      * Original codec.
      */
     private final Codec origin;
-    
+
     /**
      * Ctor.
      * @param codec Original codec
@@ -65,32 +64,36 @@ public final class CcBase64 implements Codec {
 
     @Override
     public byte[] encode(final Identity identity) throws IOException {
-    	return new Base64().encode(this.origin.encode(identity));
+        return new Base64().encode(this.origin.encode(identity));
     }
 
     @Override
     public Identity decode(final byte[] bytes) throws IOException {
-    	final byte[] illegal = CcBase64.checkIllegalCharacters(bytes);
-    	if (illegal.length > 0) {
-    		throw new DecodingException("Illegal character in Base64 encoded data. " + Arrays.toString(illegal));
-    	}
-    	return this.origin.decode(new Base64().decode(bytes));
+        final byte[] illegal = CcBase64.checkIllegalCharacters(bytes);
+        if (illegal.length > 0) {
+            throw new DecodingException(
+                String.format(
+                    "Illegal character in Base64 encoded data. %s",
+                    Arrays.toString(illegal)
+                    )
+                );
+        }
+        return this.origin.decode(new Base64().decode(bytes));
     }
-    
+
     /**
      * Check the byte array for non-Base64 characters.
-     * 
+     *
      * @param bytes The values to check
      * @return An array of the found non-Base64 characters.
      */
-    private static byte[] checkIllegalCharacters(byte[] bytes) {
-    	final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    	
-    	for (int c = 0; c < bytes.length; c++) {
-    		if (base64chars.indexOf(bytes[c]) < 0) {
-				out.write(bytes[c]);
-			}
-    	}
-    	return out.toByteArray();
+    private static byte[] checkIllegalCharacters(final byte[] bytes) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (int pos = 0; pos < bytes.length; ++pos) {
+            if (BASE64CHARS.indexOf(bytes[pos]) < 0) {
+                out.write(bytes[pos]);
+            }
+        }
+        return out.toByteArray();
     }
 }

--- a/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
@@ -24,7 +24,13 @@
 package org.takes.facets.auth.codecs;
 
 import lombok.EqualsAndHashCode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
 import org.takes.facets.auth.Identity;
+import org.takes.misc.Base64;
 
 /**
  * Base64 codec.
@@ -32,15 +38,23 @@ import org.takes.facets.auth.Identity;
  * <p>The class is immutable and thread-safe.
  *
  * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
+ * @author Sven Windisch (sven.windisch@gmail.com)
  * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode
 public final class CcBase64 implements Codec {
+
+	/**
+	 * All legal Base64 chars.
+	 */
+	private final static String base64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
     /**
      * Original codec.
      */
     private final Codec origin;
+    
     /**
      * Ctor.
      * @param codec Original codec
@@ -49,24 +63,34 @@ public final class CcBase64 implements Codec {
         this.origin = codec;
     }
 
-    //@todo #19:30min to implement own simple Base64 encode algorithm
-    // without using 3d-party Base64 encode libraries. Tests for this
-    // method have been already created, do not forget to remove Ignore
-    // annotation on it.
     @Override
-    public byte[] encode(final Identity identity) {
-        assert this.origin != null;
-        throw new UnsupportedOperationException("#encode()");
+    public byte[] encode(final Identity identity) throws IOException {
+    	return new Base64().encode(this.origin.encode(identity));
     }
 
-    //@todo #19:30min to implement own simple Base64 decode algorithm
-    // without using 3d-party Base64 decode libraries. Tests for this
-    // method have been already created, do not forget to remove Ignore
-    // annotation on it.
     @Override
-    public Identity decode(final byte[] bytes) {
-        assert this.origin != null;
-        throw new UnsupportedOperationException("#decode()");
+    public Identity decode(final byte[] bytes) throws IOException {
+    	final byte[] illegal = CcBase64.checkIllegalCharacters(bytes);
+    	if (illegal.length > 0) {
+    		throw new DecodingException("Illegal character in Base64 encoded data. " + Arrays.toString(illegal));
+    	}
+    	return this.origin.decode(new Base64().decode(bytes));
     }
-
+    
+    /**
+     * Check the byte array for non-Base64 characters.
+     * 
+     * @param bytes The values to check
+     * @return An array of the found non-Base64 characters.
+     */
+    private static byte[] checkIllegalCharacters(byte[] bytes) {
+    	final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	
+    	for (int c = 0; c < bytes.length; c++) {
+    		if (base64chars.indexOf(bytes[c]) < 0) {
+				out.write(bytes[c]);
+			}
+    	}
+    	return out.toByteArray();
+    }
 }

--- a/src/main/java/org/takes/misc/Base64.java
+++ b/src/main/java/org/takes/misc/Base64.java
@@ -27,6 +27,7 @@ package org.takes.misc;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 
 /**
  * Encoding and decoding of Base64.
@@ -40,8 +41,20 @@ public final class Base64 {
     /**
      * All legal Base64 chars.
      */
-    private final String basechars =
+    private static final String BASECHARS =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    /**
+     * The charset.
+     */
+    private final Charset charset;
+
+    /**
+     * Ctor.
+     */
+    public Base64() {
+        this.charset = Charset.defaultCharset();
+    }
 
     /**
      * Base64-encode the input string.
@@ -52,7 +65,7 @@ public final class Base64 {
      * @throws IOException For anything gone wrong
      */
     public byte[] encode(final String input) throws IOException {
-        return this.encode(input.getBytes(), false);
+        return this.encode(input.getBytes(this.charset), false);
     }
 
     /**
@@ -65,7 +78,7 @@ public final class Base64 {
      */
     public byte[] encode(final String input, final boolean linebreak)
         throws IOException {
-        return this.encode(input.getBytes(), linebreak);
+        return this.encode(input.getBytes(this.charset), linebreak);
     }
 
     /**
@@ -90,13 +103,50 @@ public final class Base64 {
      */
     public byte[] encode(final byte[] input, final boolean linebreak)
         throws IOException {
+        return this.toBase(input, linebreak);
+    }
+
+    /**
+     * Base64-decode the input string.
+     * Prior to decoding, all non-Base64 characters are removed.
+     *
+     * @param input The value to be decoded.
+     * @return Decoded
+     * @throws IOException For anything gone wrong
+     */
+    public byte[] decode(final String input) throws IOException {
+        return this.decode(input.getBytes(this.charset));
+    }
+
+    /**
+     * Base64-decode the input array.
+     * Prior to decoding, all non-Base64 characters are removed.
+     *
+     * @param input The value to be decoded.
+     * @return Decoded
+     * @throws IOException For anything gone wrong
+     */
+    public byte[] decode(final byte[] input) throws IOException {
+        return this.fromBase(input);
+    }
+
+    /**
+     * Base64-encode the input data.
+     *
+     * @param input The value to be encoded.
+     * @param linebreak Set to true to insert line breaks after 76 chars.
+     * @return Encoded
+     * @throws IOException For anything gone wrong
+     */
+    private byte[] toBase(final byte[] input, final boolean linebreak)
+        throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final StringBuilder padding = new StringBuilder();
         // @checkstyle MagicNumber (3 lines)
         int pos = input.length % 3;
         if (pos > 0) {
             for (; pos < 3; ++pos) {
-                padding.append("=");
+                padding.append('=');
             }
         }
         final ByteBuffer tmp = ByteBuffer.allocate(
@@ -106,31 +156,22 @@ public final class Base64 {
         // @checkstyle MagicNumber (2 lines)
         for (pos = 0; pos < bytes.length; pos += 3) {
             if (linebreak && pos > 0 && (pos / 3 * 4) % 76 == 0) {
-                out.write(System.lineSeparator().getBytes());
+                out.write(
+                    System.lineSeparator().getBytes(this.charset)
+                );
             }
             // @checkstyle MagicNumber (6 lines)
             final int inbits =
                 (bytes[pos] << 16) + (bytes[pos + 1] << 8) + (bytes[pos + 2]);
-            out.write(this.basechars.charAt((inbits >> 18) & 63));
-            out.write(this.basechars.charAt((inbits >> 12) & 63));
-            out.write(this.basechars.charAt((inbits >> 6) & 63));
-            out.write(this.basechars.charAt(inbits & 63));
+            out.write(Base64.BASECHARS.charAt((inbits >> 18) & 63));
+            out.write(Base64.BASECHARS.charAt((inbits >> 12) & 63));
+            out.write(Base64.BASECHARS.charAt((inbits >> 6) & 63));
+            out.write(Base64.BASECHARS.charAt(inbits & 63));
         }
-        final String encoded = out.toString();
+        final String encoded = out.toString(this.charset.name());
         return (encoded.substring(
             0, encoded.length() - padding.length()
-        ) + padding).getBytes();
-    }
-
-    /**
-     * Base64-decode the input string.
-     * Prior to decoding, all non-Base64 characters are removed.
-     *
-     * @param input The value to be decoded.
-     * @return Decoded
-     */
-    public byte[] decode(final String input) {
-        return this.decode(input.getBytes());
+        ) + padding).getBytes(this.charset);
     }
 
     /**
@@ -139,8 +180,9 @@ public final class Base64 {
      *
      * @param input The value to be decoded.
      * @return Decoded
+     * @throws IOException For anything gone wrong
      */
-    public byte[] decode(final byte[] input) {
+    private byte[] fromBase(final byte[] input) throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final ByteBuffer tmp = ByteBuffer.allocate(input.length);
         int padding = 0;
@@ -153,7 +195,7 @@ public final class Base64 {
             ++padding;
         }
         for (int pos = 0; pos < input.length; ++pos) {
-            if (this.basechars.indexOf(input[pos]) >= 0) {
+            if (Base64.BASECHARS.indexOf(input[pos]) >= 0) {
                 tmp.put(input[pos]);
             }
         }
@@ -161,15 +203,17 @@ public final class Base64 {
         // @checkstyle MagicNumber (9 lines)
         for (int pos = 0; pos < bytes.length; pos += 4) {
             final int bits =
-                (this.basechars.indexOf(bytes[pos]) << 18)
-                + (this.basechars.indexOf(bytes[pos + 1]) << 12)
-                + (this.basechars.indexOf(bytes[pos + 2]) << 6)
-                + this.basechars.indexOf(bytes[pos + 3]);
+                (Base64.BASECHARS.indexOf(bytes[pos]) << 18)
+                + (Base64.BASECHARS.indexOf(bytes[pos + 1]) << 12)
+                + (Base64.BASECHARS.indexOf(bytes[pos + 2]) << 6)
+                + Base64.BASECHARS.indexOf(bytes[pos + 3]);
             out.write((char) ((bits >>> 16) & 0xFF));
             out.write((char) ((bits >>> 8) & 0xFF));
             out.write((char) (bits & 0xFF));
         }
-        final String decoded = out.toString();
-        return decoded.substring(0, decoded.length() - padding).getBytes();
+        final String decoded = out.toString(this.charset.name());
+        return decoded.substring(
+            0, decoded.length() - padding
+        ).getBytes(this.charset);
     }
 }

--- a/src/main/java/org/takes/misc/Base64.java
+++ b/src/main/java/org/takes/misc/Base64.java
@@ -88,15 +88,15 @@ public final class Base64 {
 		final StringBuilder padding = new StringBuilder();
 
 		int c = input.length % 3;
-		final ByteBuffer bb = ByteBuffer.allocate(input.length + c);
-		bb.put(input);
 
 		if (c > 0) {
 			for (; c < 3; c++) {
 				padding.append("=");
-				bb.putChar('\0');
 			}
 		}
+
+		final ByteBuffer bb = ByteBuffer.allocate(input.length + padding.length());
+		bb.put(input);
 
 		final byte[] bytes = bb.array();
 

--- a/src/main/java/org/takes/misc/Base64.java
+++ b/src/main/java/org/takes/misc/Base64.java
@@ -1,0 +1,176 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.takes.misc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Encoding and decoding of Base64.
+ *
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.1
+ */
+public final class Base64 {
+
+	private final static String base64chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+	/**
+	 * Base64-encode the input string.
+	 * This is the same as {@code encode(input, false)}.
+	 * 
+	 * @param input The value to be encoded.
+	 * @return Encoded
+	 * @throws IOException
+	 */
+	public byte[] encode(String input) throws IOException {
+		return encode(input.getBytes(), false);
+	}
+
+	/**
+	 * Base64-encode the input string.
+	 * 
+	 * @param input The value to be encoded.
+	 * @param linebreak Set to true to insert line breaks after 76 chars.
+	 * @return Encoded
+	 * @throws IOException
+	 */
+	public byte[] encode(String input, boolean linebreak) throws IOException {
+		return encode(input.getBytes(), linebreak);
+	}
+
+	/**
+	 * Base64-encode the input array.
+	 * This is the same as {@code encode(input, false)}.
+	 * 
+	 * @param input The value to be encoded.
+	 * @return Encoded
+	 * @throws IOException
+	 */
+	public byte[] encode(byte[] input) throws IOException {
+		return encode(input, false);
+	}
+	
+	/**
+	 * Base64-encode the input array.
+	 * 
+	 * @param input The value to be encoded.
+	 * @param linebreak Set to true to insert line breaks after 76 chars.
+	 * @return Encoded
+	 * @throws IOException
+	 */
+	public byte[] encode(byte[] input, boolean linebreak) throws IOException {
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		final StringBuilder padding = new StringBuilder();
+
+		int c = input.length % 3;
+		final ByteBuffer bb = ByteBuffer.allocate(input.length + c);
+		bb.put(input);
+
+		if (c > 0) {
+			for (; c < 3; c++) {
+				padding.append("=");
+				bb.putChar('\0');
+			}
+		}
+
+		final byte[] bytes = bb.array();
+
+		for (c = 0; c < bytes.length; c += 3) {
+
+			if (linebreak && c > 0 && (c / 3 * 4) % 76 == 0) {
+				out.write(System.lineSeparator().getBytes());
+			}
+
+			int n = (bytes[c] << 16) + (bytes[c + 1] << 8) + (bytes[c + 2]);
+			int n1 = (n >> 18) & 63, n2 = (n >> 12) & 63, n3 = (n >> 6) & 63, n4 = n & 63;
+
+			out.write(base64chars.charAt(n1));
+			out.write(base64chars.charAt(n2));
+			out.write(base64chars.charAt(n3));
+			out.write(base64chars.charAt(n4));
+		}
+		String encoded = out.toString();
+
+		return (encoded.substring(0, encoded.length() - padding.length()) + padding).getBytes();
+	}
+
+	/**
+	 * Base64-decode the input string.
+	 * Prior to decoding, all non-Base64 characters are removed.
+	 * 
+	 * @param input The value to be decoded.
+	 * @return Decoded
+	 */
+	public byte[] decode(String input) {
+		return decode(input.getBytes());
+	}
+
+	/**
+	 * Base64-decode the input array.
+	 * Prior to decoding, all non-Base64 characters are removed.
+	 * 
+	 * @param input The value to be decoded.
+	 * @return Decoded
+	 */
+	public byte[] decode(byte[] input) {
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		final ByteBuffer bb = ByteBuffer.allocate(input.length);
+		int padding = 0;
+
+		if (input[input.length - 1] == '=') {
+			input[input.length - 1] = 'A';
+			padding++;
+		}
+		if (input[input.length - 2] == '=') {
+			input[input.length - 2] = 'A';
+			padding++;
+		}
+
+		for (int c = 0; c < input.length; c++) {
+			if (base64chars.indexOf(input[c]) >= 0) {
+				bb.put(input[c]);
+			}
+		}
+
+		final byte[] bytes = bb.array();
+
+		for (int c = 0; c < bytes.length; c += 4) {
+
+			int n = (base64chars.indexOf(bytes[c]) << 18) + (base64chars.indexOf(bytes[c + 1]) << 12)
+					+ (base64chars.indexOf(bytes[c + 2]) << 6) + base64chars.indexOf(bytes[c + 3]);
+
+			out.write((char) ((n >>> 16) & 0xFF));
+			out.write((char) ((n >>> 8) & 0xFF));
+			out.write((char) ((n) & 0xFF));
+		}
+
+		String decoded = out.toString();
+
+		return decoded.substring(0, decoded.length() - padding).getBytes();
+	}
+}

--- a/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
@@ -32,7 +32,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.facets.auth.Identity;
-import org.takes.misc.Base64;
 
 /**
  * Test case for {@link CcBase64}.

--- a/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
@@ -30,9 +30,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.facets.auth.Identity;
+import org.takes.misc.Base64;
 
 /**
  * Test case for {@link CcBase64}.
@@ -40,7 +40,6 @@ import org.takes.facets.auth.Identity;
  * @version $Id$
  * @since 0.13
  */
-@Ignore
 public final class CcBase64Test {
     /**
      * CcBase64 can encode.

--- a/src/test/java/org/takes/misc/Base64Test.java
+++ b/src/test/java/org/takes/misc/Base64Test.java
@@ -37,6 +37,48 @@ import org.junit.Test;
  */
 @Ignore
 public final class Base64Test {
+	/**
+     * Base64 can encode a String.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void encodeThreeString() throws IOException {
+        MatcherAssert.assertThat(
+            new String(
+                new Base64().encode("Pia")
+            ),
+            Matchers.equalTo("UGlh")
+        );
+    }
+
+    /**
+     * Base64 can encode a String.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void encodeFourString() throws IOException {
+        MatcherAssert.assertThat(
+            new String(
+                new Base64().encode("Pian")
+            ),
+            Matchers.equalTo("UGlhbg==")
+        );
+    }
+
+    /**
+     * Base64 can encode a String.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void encodeFiveString() throws IOException {
+        MatcherAssert.assertThat(
+            new String(
+                new Base64().encode("Piano")
+            ),
+            Matchers.equalTo("UGlhbm8=")
+        );
+    }
+
     /**
      * Base64 can encode a String.
      * @throws IOException If some problem inside

--- a/src/test/java/org/takes/misc/Base64Test.java
+++ b/src/test/java/org/takes/misc/Base64Test.java
@@ -1,0 +1,123 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test case for {@link Base64}.
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.1
+ */
+@Ignore
+public final class Base64Test {
+    /**
+     * Base64 can encode a String.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void encodeString() throws IOException {
+        MatcherAssert.assertThat(
+            new String(
+                new Base64().encode("We didn't start the fire!")
+            ),
+            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+        );
+    }
+
+    /**
+     * Base64 can encode a byte[].
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void encodeByteArray() throws IOException {
+        MatcherAssert.assertThat(
+            new String(
+                new Base64().encode("We didn't start the fire!".getBytes())
+            ),
+            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+        );
+    }
+
+    /**
+     * Base64 can decode a String.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void decodeString() throws IOException {
+        MatcherAssert.assertThat(
+        	new String(
+            	new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+            ),
+            Matchers.equalTo("We didn't start the fire!")
+        );
+    }
+
+    /**
+     * Base64 can decode a byte[].
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void decodeByteArray() throws IOException {
+        MatcherAssert.assertThat(
+        	new String(
+            	new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==".getBytes())
+            ),
+            Matchers.equalTo("We didn't start the fire!")
+        );
+    }
+
+    /**
+     * Base64 can encode and insert line breaks.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void encodeWithLineBreaks() throws IOException {
+        MatcherAssert.assertThat(
+        	new String(
+            	new Base64().encode("We didn't start the fire, it was always burning, since the world's been turning.", true)
+            ),
+            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=")
+        );
+    }
+
+    /**
+     * Base64 can decode a String with line breaks.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void decodeWithLineBreaks() throws IOException {
+        MatcherAssert.assertThat(
+        	new String(
+            	new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=")
+            ),
+            Matchers.equalTo("We didn't start the fire, it was always burning, since the world's been turning.")
+        );
+    }
+}

--- a/src/test/java/org/takes/misc/Base64Test.java
+++ b/src/test/java/org/takes/misc/Base64Test.java
@@ -39,30 +39,6 @@ import org.junit.Test;
 public final class Base64Test {
 
     /**
-     * A short text to encode with Base64.
-     */
-    private static final String SHORTTEXT =
-        "We didn't start the fire!";
-    /**
-     * The corresponding short Base64 key.
-     */
-    private static final String SHORTKEY =
-        "V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==";
-    /**
-     * A long text that ensures a linebreak in the key.
-     * @checkstyle LineLength (3 lines)
-     */
-    private static final String LONGTEXT =
-        "We didn't start the fire, it was always burning, since the world's been turning.";
-    /**
-     * The corresponding key.
-     * @checkstyle LineLength (4 lines)
-     * @checkstyle StringLiteralsConcatenation (3 lines)
-     */
-    private static final String LONGKEY =
-        "V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=";
-
-    /**
      * Base64 can encode a String.
      * @throws IOException If some problem inside
      */
@@ -105,20 +81,6 @@ public final class Base64Test {
     }
 
     /**
-     * Base64 can encode a String.
-     * @throws IOException If some problem inside
-     */
-    @Test
-    public void encodeString() throws IOException {
-        MatcherAssert.assertThat(
-            new String(
-                new Base64().encode(Base64Test.SHORTTEXT)
-            ),
-            Matchers.equalTo(Base64Test.SHORTKEY)
-        );
-    }
-
-    /**
      * Base64 can encode a byte[].
      * @throws IOException If some problem inside
      */
@@ -126,9 +88,9 @@ public final class Base64Test {
     public void encodeByteArray() throws IOException {
         MatcherAssert.assertThat(
             new String(
-                new Base64().encode(Base64Test.SHORTTEXT.getBytes())
+                new Base64().encode("We didn't start the fire!".getBytes())
             ),
-            Matchers.equalTo(Base64Test.SHORTKEY)
+            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
         );
     }
 
@@ -140,9 +102,9 @@ public final class Base64Test {
     public void decodeString() throws IOException {
         MatcherAssert.assertThat(
             new String(
-                new Base64().decode(Base64Test.SHORTKEY)
+                new Base64().decode("SSBhbSB0aGU=")
             ),
-            Matchers.equalTo(Base64Test.SHORTTEXT)
+            Matchers.equalTo("I am the")
         );
     }
 
@@ -155,9 +117,9 @@ public final class Base64Test {
         MatcherAssert.assertThat(
             new String(
                 new Base64()
-                    .decode(Base64Test.SHORTKEY.getBytes())
+                    .decode("ZW50ZXJ0YWluZXI=".getBytes())
             ),
-            Matchers.equalTo(Base64Test.SHORTTEXT)
+            Matchers.equalTo("entertainer")
         );
     }
 
@@ -170,9 +132,12 @@ public final class Base64Test {
         MatcherAssert.assertThat(
             new String(
                 new Base64()
-                    .encode(Base64Test.LONGTEXT, true)
+                    // @checkstyle LineLength (1 line)
+                    .encode("We didn't start the fire, it was always burning, since the world's been turning.", true)
             ),
-            Matchers.equalTo(Base64Test.LONGKEY)
+            // @checkstyle LineLength (2 lines)
+            // @checkstyle StringLiteralsConcatenation (1 line)
+            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=")
         );
     }
 
@@ -184,9 +149,12 @@ public final class Base64Test {
     public void decodeWithLineBreaks() throws IOException {
         MatcherAssert.assertThat(
             new String(
-                new Base64().decode(Base64Test.LONGKEY)
+                // @checkstyle LineLength (2 lines)
+                // @checkstyle StringLiteralsConcatenation (1 line)
+                new Base64().decode("V2hvIG5lZWRzIGEgaG91c2Ugb3V0IGluIEhhY2tlbnNhY2s/IElzIHRoYXQgYWxsIHlvdSBnZXQ" + System.lineSeparator() + "gZm9yIHlvdXIgbW9uZXk/")
             ),
-            Matchers.equalTo(Base64Test.LONGTEXT)
+            // @checkstyle LineLength (1 line)
+            Matchers.equalTo("Who needs a house out in Hackensack? Is that all you get for your money?")
         );
     }
 }

--- a/src/test/java/org/takes/misc/Base64Test.java
+++ b/src/test/java/org/takes/misc/Base64Test.java
@@ -37,6 +37,31 @@ import org.junit.Test;
  */
 @Ignore
 public final class Base64Test {
+
+    /**
+     * A short text to encode with Base64.
+     */
+    private static final String SHORTTEXT =
+        "We didn't start the fire!";
+    /**
+     * The corresponding short Base64 key.
+     */
+    private static final String SHORTKEY =
+        "V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==";
+    /**
+     * A long text that ensures a linebreak in the key.
+     * @checkstyle LineLength (3 lines)
+     */
+    private static final String LONGTEXT =
+        "We didn't start the fire, it was always burning, since the world's been turning.";
+    /**
+     * The corresponding key.
+     * @checkstyle LineLength (4 lines)
+     * @checkstyle StringLiteralsConcatenation (3 lines)
+     */
+    private static final String LONGKEY =
+        "V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=";
+
     /**
      * Base64 can encode a String.
      * @throws IOException If some problem inside
@@ -87,9 +112,9 @@ public final class Base64Test {
     public void encodeString() throws IOException {
         MatcherAssert.assertThat(
             new String(
-                new Base64().encode("We didn't start the fire!")
+                new Base64().encode(Base64Test.SHORTTEXT)
             ),
-            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+            Matchers.equalTo(Base64Test.SHORTKEY)
         );
     }
 
@@ -101,9 +126,9 @@ public final class Base64Test {
     public void encodeByteArray() throws IOException {
         MatcherAssert.assertThat(
             new String(
-                new Base64().encode("We didn't start the fire!".getBytes())
+                new Base64().encode(Base64Test.SHORTTEXT.getBytes())
             ),
-            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+            Matchers.equalTo(Base64Test.SHORTKEY)
         );
     }
 
@@ -115,9 +140,9 @@ public final class Base64Test {
     public void decodeString() throws IOException {
         MatcherAssert.assertThat(
             new String(
-                new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+                new Base64().decode(Base64Test.SHORTKEY)
             ),
-            Matchers.equalTo("We didn't start the fire!")
+            Matchers.equalTo(Base64Test.SHORTTEXT)
         );
     }
 
@@ -130,9 +155,9 @@ public final class Base64Test {
         MatcherAssert.assertThat(
             new String(
                 new Base64()
-                    .decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==".getBytes())
+                    .decode(Base64Test.SHORTKEY.getBytes())
             ),
-            Matchers.equalTo("We didn't start the fire!")
+            Matchers.equalTo(Base64Test.SHORTTEXT)
         );
     }
 
@@ -142,21 +167,12 @@ public final class Base64Test {
      */
     @Test
     public void encodeWithLineBreaks() throws IOException {
-        final StringBuilder longtext = new StringBuilder();
-        longtext.append("We didn't start the fire, ");
-        longtext.append("it was always burning, ");
-        longtext.append("since the world's been turning.");
-        final StringBuilder longkey = new StringBuilder();
-        longkey.append("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCB");
-        longkey.append("pdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR");
-        longkey.append(System.lineSeparator());
-        longkey.append("oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=");
         MatcherAssert.assertThat(
             new String(
                 new Base64()
-                    .encode(longtext.toString(), true)
+                    .encode(Base64Test.LONGTEXT, true)
             ),
-            Matchers.equalTo(longkey.toString())
+            Matchers.equalTo(Base64Test.LONGKEY)
         );
     }
 
@@ -166,20 +182,11 @@ public final class Base64Test {
      */
     @Test
     public void decodeWithLineBreaks() throws IOException {
-        final StringBuilder longtext = new StringBuilder();
-        longtext.append("We didn't start the fire, ");
-        longtext.append("it was always burning, ");
-        longtext.append("since the world's been turning.");
-        final StringBuilder longkey = new StringBuilder();
-        longkey.append("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCB");
-        longkey.append("pdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR");
-        longkey.append(System.lineSeparator());
-        longkey.append("oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=");
         MatcherAssert.assertThat(
             new String(
-                new Base64().decode(longkey.toString())
+                new Base64().decode(Base64Test.LONGKEY)
             ),
-            Matchers.equalTo(longtext.toString())
+            Matchers.equalTo(Base64Test.LONGTEXT)
         );
     }
 }

--- a/src/test/java/org/takes/misc/Base64Test.java
+++ b/src/test/java/org/takes/misc/Base64Test.java
@@ -37,7 +37,7 @@ import org.junit.Test;
  */
 @Ignore
 public final class Base64Test {
-	/**
+    /**
      * Base64 can encode a String.
      * @throws IOException If some problem inside
      */
@@ -114,8 +114,8 @@ public final class Base64Test {
     @Test
     public void decodeString() throws IOException {
         MatcherAssert.assertThat(
-        	new String(
-            	new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
+            new String(
+                new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==")
             ),
             Matchers.equalTo("We didn't start the fire!")
         );
@@ -128,8 +128,9 @@ public final class Base64Test {
     @Test
     public void decodeByteArray() throws IOException {
         MatcherAssert.assertThat(
-        	new String(
-            	new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==".getBytes())
+            new String(
+                new Base64()
+                    .decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlIQ==".getBytes())
             ),
             Matchers.equalTo("We didn't start the fire!")
         );
@@ -141,11 +142,21 @@ public final class Base64Test {
      */
     @Test
     public void encodeWithLineBreaks() throws IOException {
+        final StringBuilder longtext = new StringBuilder();
+        longtext.append("We didn't start the fire, ");
+        longtext.append("it was always burning, ");
+        longtext.append("since the world's been turning.");
+        final StringBuilder longkey = new StringBuilder();
+        longkey.append("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCB");
+        longkey.append("pdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR");
+        longkey.append(System.lineSeparator());
+        longkey.append("oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=");
         MatcherAssert.assertThat(
-        	new String(
-            	new Base64().encode("We didn't start the fire, it was always burning, since the world's been turning.", true)
+            new String(
+                new Base64()
+                    .encode(longtext.toString(), true)
             ),
-            Matchers.equalTo("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=")
+            Matchers.equalTo(longkey.toString())
         );
     }
 
@@ -155,11 +166,20 @@ public final class Base64Test {
      */
     @Test
     public void decodeWithLineBreaks() throws IOException {
+        final StringBuilder longtext = new StringBuilder();
+        longtext.append("We didn't start the fire, ");
+        longtext.append("it was always burning, ");
+        longtext.append("since the world's been turning.");
+        final StringBuilder longkey = new StringBuilder();
+        longkey.append("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCB");
+        longkey.append("pdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR");
+        longkey.append(System.lineSeparator());
+        longkey.append("oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=");
         MatcherAssert.assertThat(
-        	new String(
-            	new Base64().decode("V2UgZGlkbid0IHN0YXJ0IHRoZSBmaXJlLCBpdCB3YXMgYWx3YXlzIGJ1cm5pbmcsIHNpbmNlIHR" + System.lineSeparator() + "oZSB3b3JsZCdzIGJlZW4gdHVybmluZy4=")
+            new String(
+                new Base64().decode(longkey.toString())
             ),
-            Matchers.equalTo("We didn't start the fire, it was always burning, since the world's been turning.")
+            Matchers.equalTo(longtext.toString())
         );
     }
 }


### PR DESCRIPTION
Hi.

I implemented a simple Base64 de/encoder (with tests) and used it to enable the CcBase64 codec and its tests. This is only the foundation for more thing to come, but these changes work for themselves and could thus be pulled separately. Also, bumped the version in pom.xml.

Regards, Sven