### PR TITLE
Implementation of JSON Web Token

### DIFF
--- a/src/main/java/org/takes/facets/auth/PsToken.java
+++ b/src/main/java/org/takes/facets/auth/PsToken.java
@@ -1,0 +1,195 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.facets.auth.signatures.SiHmac;
+import org.takes.misc.Base64;
+import org.takes.misc.Opt;
+import org.takes.rq.RqHeaders;
+import org.takes.rs.RsJson;
+
+/**
+ * Pass with JSON Web Token (JWT).
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.4
+ */
+@EqualsAndHashCode
+// @checkstyle ClassDataAbstractionCoupling
+public final class PsToken implements Pass {
+
+    /**
+     * Signature algorithm.
+     */
+    private final SiHmac signature;
+
+    /**
+     * HTTP Header to read.
+     */
+    private final String header;
+
+    /**
+     * Max age of token, in seconds.
+     */
+    private final long age;
+
+    /**
+     * Ctor.
+     * This is equivalent to {@code PsToken(key, 3600)}, signing with 256 bit.
+     * @param key The secret key to sign with
+     */
+    public PsToken(final String key) {
+        // @checkstyle MagicNumber (1 line)
+        this(new SiHmac(key, SiHmac.HMAC256), 3600L);
+    }
+
+    /**
+     * Ctor.
+     * This uses a 256-bit HMAC signature.
+     * @param key The secret key to sign with
+     * @param seconds The life span of the token.
+     */
+    public PsToken(final String key, final long seconds) {
+        this(new SiHmac(key, SiHmac.HMAC256), seconds);
+    }
+
+    /**
+     * Ctor.
+     * @param sign A {@see Signature}.
+     * @param seconds The life span of the token.
+     */
+    private PsToken(final SiHmac sign, final long seconds) {
+        this.header = "Authorization";
+        this.signature = sign;
+        this.age = seconds;
+    }
+
+    @Override
+    public Opt<Identity> enter(final Request req) throws IOException {
+        final Iterator<String> headers = new RqHeaders.Base(req)
+            .header(this.header).iterator();
+        Opt<Identity> user = new Opt.Empty<>();
+        while (headers.hasNext()) {
+            final String head = headers.next();
+            if (head.trim().startsWith("Bearer")) {
+                final String jwt = head.trim().split(" ", 2)[1].trim();
+                final byte[] jwtheader = jwt.split("\\.")[0].getBytes();
+                final byte[] jwtpayload = jwt.split("\\.")[1].getBytes();
+                final byte[] jwtsign = jwt.split("\\.")[2].getBytes();
+                final ByteBuffer tocheck = ByteBuffer.allocate(
+                    jwtheader.length + jwtheader.length + 1
+                );
+                tocheck.put(jwtheader);
+                tocheck.put(".".getBytes());
+                tocheck.put(jwtpayload);
+                final byte[] checked = this.signature.sign(tocheck.array());
+                if (jwtsign.equals(checked)) {
+                    final JsonObject jsonv = Json.createReader(
+                        new StringReader(
+                            new String(jwtpayload)
+                        )
+                    ).readObject();
+                    final String subject = jsonv.getString("sub", new String());
+                    user = new Opt.Single<Identity>(
+                        new Identity.Simple(subject)
+                    );
+                }
+                break;
+            }
+        }
+        return user;
+    }
+
+    @Override
+    public Response exit(final Response res,
+        final Identity idt) throws IOException {
+        final byte[] jwtheader =
+            new Base64().encode(
+                Json.createObjectBuilder()
+                .add("alg", String.format("HS%s", this.signature.bits()))
+                .add("typ", "JWT")
+                .build()
+                .toString()
+            );
+        final String identifier;
+        if (idt.equals(Identity.ANONYMOUS)) {
+            identifier = "";
+        } else {
+            identifier = idt.urn();
+        }
+        final byte[] jwtpayload =
+            new Base64().encode(Json
+                .createObjectBuilder()
+                .add(
+                    "exp", DateFormat.getDateInstance()
+                        .format(
+                            new Date(System.currentTimeMillis()
+                                // @checkstyle MagicNumber (1 line)
+                                + (this.age * 1000)
+                            )
+                        )
+                )
+                .add("sub", identifier)
+                .build()
+                .toString()
+            );
+        final ByteBuffer tosign = ByteBuffer.allocate(
+            jwtheader.length + jwtpayload.length + 1
+        );
+        tosign.put(jwtheader);
+        tosign.put(".".getBytes());
+        tosign.put(jwtpayload);
+        final byte[] sign = this.signature.sign(tosign.array());
+        final JsonReader reader = Json.createReader(res.body());
+        final JsonObject target = Json.createObjectBuilder()
+            .add("data", reader.read())
+            .add(
+                "jwt", String.format(
+                    "%s.%s.%s",
+                    new String(jwtheader),
+                    new String(jwtpayload),
+                    new String(sign)
+                )
+            )
+            .build();
+        return new RsJson(
+            target
+        );
+    }
+}

--- a/src/main/java/org/takes/facets/auth/PsToken.java
+++ b/src/main/java/org/takes/facets/auth/PsToken.java
@@ -125,10 +125,11 @@ public final class PsToken implements Pass {
         }
         final String dot = "\\.";
         if (head.length() > 0) {
-            final String jwt = head.trim().split(" ", 2)[1].trim();
-            final byte[] jwtheader = jwt.split(dot)[0].getBytes();
-            final byte[] jwtpayload = jwt.split(dot)[1].getBytes();
-            final byte[] jwtsign = jwt.split(dot)[2].getBytes();
+            final String jwt = head.split(" ", 2)[1].trim();
+            final String[] parts = jwt.split(dot);
+            final byte[] jwtheader = parts[0].getBytes();
+            final byte[] jwtpayload = parts[1].getBytes();
+            final byte[] jwtsign = parts[2].getBytes();
             final ByteBuffer tocheck = ByteBuffer.allocate(
                 jwtheader.length + jwtpayload.length + 1
             );

--- a/src/main/java/org/takes/facets/auth/Token.java
+++ b/src/main/java/org/takes/facets/auth/Token.java
@@ -53,8 +53,9 @@ public interface Token {
      * Base64 encoded JSON output.
      *
      * @return The Token in JSON notation, Base64-encoded.
+     * @throws IOException If encoding fails
      */
-    byte[] encoded();
+    byte[] encoded() throws IOException;
 
     /**
      * JSON Object Signing and Encryption Header.
@@ -92,14 +93,8 @@ public interface Token {
         }
 
         @Override
-        public byte[] encoded() {
-            byte[] bytes;
-            try {
-                bytes = new Base64().encode(this.joseo.toString());
-            } catch (final IOException ignore) {
-                bytes = new byte[] {};
-            }
-            return bytes;
+        public byte[] encoded() throws IOException {
+            return new Base64().encode(this.joseo.toString());
         }
     };
 
@@ -108,10 +103,7 @@ public interface Token {
      */
     @SuppressWarnings
         (
-            {
-                "PMD.ConstructorShouldDoInitialization",
-                "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
-            }
+            "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
         )
     final class Jwt implements Token {
         /**
@@ -142,16 +134,12 @@ public interface Token {
         /**
          * Time of lifespan start.
          */
-        private final Calendar now = Calendar.getInstance(
-            TimeZone.getTimeZone("Z")
-        );
+        private final Calendar now;
 
         /**
          * Time of lifespan end.
          */
-        private final Calendar exp = Calendar.getInstance(
-            TimeZone.getTimeZone("Z")
-        );
+        private final Calendar exp;
 
         /**
          * JSON Web Token.
@@ -159,6 +147,8 @@ public interface Token {
          * @param age Lifetime of token.
          */
         public Jwt(final Identity idt, final long age) {
+            this.now = Calendar.getInstance(TimeZone.getTimeZone("Z"));
+            this.exp = Calendar.getInstance(TimeZone.getTimeZone("Z"));
             // @checkstyle MagicNumber (1 line)
             this.exp.setTimeInMillis(this.now.getTimeInMillis() + (age * 1000));
             this.jwto = Json.createObjectBuilder()
@@ -174,14 +164,8 @@ public interface Token {
         }
 
         @Override
-        public byte[] encoded() {
-            byte[] bytes;
-            try {
-                bytes = new Base64().encode(this.jwto.toString());
-            } catch (final IOException ignore) {
-                bytes = new byte[] {};
-            }
-            return bytes;
+        public byte[] encoded() throws IOException {
+            return new Base64().encode(this.jwto.toString());
         }
     };
 }

--- a/src/main/java/org/takes/facets/auth/Token.java
+++ b/src/main/java/org/takes/facets/auth/Token.java
@@ -1,0 +1,187 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.TimeZone;
+import javax.json.Json;
+import javax.json.JsonObject;
+import org.takes.misc.Base64;
+
+/**
+ * JSON Token.
+ *
+ * <p>
+ * All implementations of this interface must be immutable and thread-safe.
+ *
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.4
+ */
+public interface Token {
+
+    /**
+     * JSON output.
+     *
+     * @return The Token in JSON notation.
+     */
+    JsonObject json();
+
+    /**
+     * Base64 encoded JSON output.
+     *
+     * @return The Token in JSON notation, Base64-encoded.
+     */
+    byte[] encoded();
+
+    /**
+     * JSON Object Signing and Encryption Header.
+     */
+    final class Jose implements Token {
+        /**
+         * The header short for algorithm.
+         */
+        public static final String ALGORITHM = "alg";
+
+        /**
+         * The header short for token type.
+         */
+        public static final String TYP = "typ";
+
+        /**
+         * JOSE object.
+         */
+        private final JsonObject joseo;
+
+        /**
+         * JSON Object Signing and Encryption Header.
+         * @param bitlength Of encryption bits.
+         */
+        public Jose(final int bitlength) {
+            this.joseo = Json.createObjectBuilder()
+                .add(Jose.ALGORITHM, String.format("HS%s", bitlength))
+                .add(Jose.TYP, "JWT")
+                .build();
+        }
+
+        @Override
+        public JsonObject json() {
+            return this.joseo;
+        }
+
+        @Override
+        public byte[] encoded() {
+            byte[] bytes;
+            try {
+                bytes = new Base64().encode(this.joseo.toString());
+            } catch (final IOException ignore) {
+                bytes = new byte[] {};
+            }
+            return bytes;
+        }
+    };
+
+    /**
+     * JSON Web Token.
+     */
+    @SuppressWarnings
+        (
+            {
+                "PMD.ConstructorShouldDoInitialization",
+                "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
+            }
+        )
+    final class Jwt implements Token {
+        /**
+         * The header short for subject.
+         */
+        public static final String SUBJECT = "sub";
+
+        /**
+         * The header short for issuing time.
+         */
+        public static final String ISSUED = "iat";
+
+        /**
+         * The header short for expiration.
+         */
+        public static final String EXPIRATION = "exp";
+
+        /**
+         * The header short for expiration.
+         */
+        private static final String ISOFORMAT = "%tFT%<tRZ";
+
+        /**
+         * JWT object.
+         */
+        private final JsonObject jwto;
+
+        /**
+         * Time of lifespan start.
+         */
+        private final Calendar now = Calendar.getInstance(
+            TimeZone.getTimeZone("Z")
+        );
+
+        /**
+         * Time of lifespan end.
+         */
+        private final Calendar exp = Calendar.getInstance(
+            TimeZone.getTimeZone("Z")
+        );
+
+        /**
+         * JSON Web Token.
+         * @param idt Identity
+         * @param age Lifetime of token.
+         */
+        public Jwt(final Identity idt, final long age) {
+            // @checkstyle MagicNumber (1 line)
+            this.exp.setTimeInMillis(this.now.getTimeInMillis() + (age * 1000));
+            this.jwto = Json.createObjectBuilder()
+                .add(Jwt.ISSUED, String.format(Jwt.ISOFORMAT, this.now))
+                .add(Jwt.EXPIRATION, String.format(Jwt.ISOFORMAT, this.exp))
+                .add(Jwt.SUBJECT, idt.urn())
+                .build();
+        }
+
+        @Override
+        public JsonObject json() {
+            return this.jwto;
+        }
+
+        @Override
+        public byte[] encoded() {
+            byte[] bytes;
+            try {
+                bytes = new Base64().encode(this.jwto.toString());
+            } catch (final IOException ignore) {
+                bytes = new byte[] {};
+            }
+            return bytes;
+        }
+    };
+}

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -145,14 +145,12 @@ public final class SiHmac implements Signature {
      *  for all unexpected exceptions
      */
     private byte[] encrypt(final byte[] bytes) throws IOException {
-        final byte[] encrypted;
         try (final Formatter formatter = new Formatter()) {
             for (final byte byt : this.create().doFinal(bytes)) {
                 formatter.format("%02x", byt);
             }
-            encrypted = formatter.toString().getBytes();
+            return formatter.toString().getBytes();
         }
-        return encrypted;
     }
 
     /**

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -37,7 +37,7 @@ import lombok.EqualsAndHashCode;
  *
  * <p>
  * The class is immutable and thread-safe.
- * 
+ *
  * @author Sven Windisch (sven.windisch@gmail.com)
  * @version $Id$
  * @since 1.4
@@ -73,7 +73,7 @@ public final class SiHmac implements Signature {
      * Ctor.
      *
      * @param key
-     *            The encryption key
+     *  The encryption key
      */
     public SiHmac(final String key) {
         this(key.getBytes(Charset.defaultCharset()), SiHmac.HMAC256);
@@ -83,9 +83,9 @@ public final class SiHmac implements Signature {
      * Ctor.
      *
      * @param key
-     *            The encryption key
+     *  The encryption key
      * @param bits
-     *            The signature bit length
+     *  The signature bit length
      */
     public SiHmac(final String key, final int bits) {
         this(key.getBytes(Charset.defaultCharset()), bits);
@@ -95,9 +95,9 @@ public final class SiHmac implements Signature {
      * Ctor.
      *
      * @param key
-     *            The encryption key
+     *  The encryption key
      * @param bits
-     *            The signature bit length
+     *  The signature bit length
      */
     public SiHmac(final byte[] key, final int bits) {
         this.key = key.clone();
@@ -111,10 +111,10 @@ public final class SiHmac implements Signature {
 
     /**
      * Signature bit length.
-     * 
-     * @return bitlength
+     *
+     * @return The bitlength
      */
-    public int bits() {
+    public int bitlength() {
         return this.bits;
     }
 
@@ -122,7 +122,7 @@ public final class SiHmac implements Signature {
      * Check for correct bit length.
      *
      * @param bits
-     *            Given bit length
+     *  Given bit length
      * @return Original bit length when appropriate, 256 bits otherwise.
      */
     private static int bitLength(final int bits) {
@@ -139,10 +139,10 @@ public final class SiHmac implements Signature {
      * Encrypt the given bytes using HMAC.
      *
      * @param bytes
-     *            Bytes to encrypt
+     *  Bytes to encrypt
      * @return Encrypted bytes
      * @throws IOException
-     *             for all unexpected exceptions
+     *  for all unexpected exceptions
      */
     @SuppressWarnings("resource")
     private byte[] encrypt(final byte[] bytes) throws IOException {
@@ -158,15 +158,17 @@ public final class SiHmac implements Signature {
      *
      * @return The mac
      * @throws IOException
-     *             For any unexpected exceptions
+     *  For any unexpected exceptions
      */
     private Mac create()
         throws IOException {
+        final String algo = String.format("HmacSHA%s", this.bits);
         try {
             final SecretKeySpec secret = new SecretKeySpec(
-                this.key, String.format("HmacSHA%s", this.bits));
+                this.key, algo
+            );
             final Mac mac = Mac
-                .getInstance(String.format("HmacSHA%s", this.bits));
+                .getInstance(algo);
             mac.init(secret);
             return mac;
         } catch (final InvalidKeyException ex) {

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -144,13 +144,15 @@ public final class SiHmac implements Signature {
      * @throws IOException
      *  for all unexpected exceptions
      */
-    @SuppressWarnings("resource")
     private byte[] encrypt(final byte[] bytes) throws IOException {
-        final Formatter formatter = new Formatter();
-        for (final byte byt : this.create().doFinal(bytes)) {
-            formatter.format("%02x", byt);
+        final byte[] encrypted;
+        try (final Formatter formatter = new Formatter()) {
+            for (final byte byt : this.create().doFinal(bytes)) {
+                formatter.format("%02x", byt);
+            }
+            encrypted = formatter.toString().getBytes();
         }
-        return formatter.toString().getBytes();
+        return encrypted;
     }
 
     /**

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -1,0 +1,178 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.signatures;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Formatter;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.EqualsAndHashCode;
+
+/**
+ * HMAC codec which supports 256, 384 and 512 bit hash.
+ *
+ * <p>
+ * The class is immutable and thread-safe.
+ * 
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.4
+ */
+@EqualsAndHashCode
+public final class SiHmac implements Signature {
+    /**
+     * The HMAC 256 bit variant.
+     */
+    public static final int HMAC256 = 256;
+
+    /**
+     * The HMAC 384 bit variant.
+     */
+    public static final int HMAC384 = 384;
+
+    /**
+     * The HMAC 512 bit variant.
+     */
+    public static final int HMAC512 = 512;
+
+    /**
+     * The encryption key.
+     */
+    private final byte[] key;
+
+    /**
+     * The bit length parameter.
+     */
+    private final int bits;
+
+    /**
+     * Ctor.
+     *
+     * @param key
+     *            The encryption key
+     */
+    public SiHmac(final String key) {
+        this(key.getBytes(Charset.defaultCharset()), SiHmac.HMAC256);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param key
+     *            The encryption key
+     * @param bits
+     *            The signature bit length
+     */
+    public SiHmac(final String key, final int bits) {
+        this(key.getBytes(Charset.defaultCharset()), bits);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param key
+     *            The encryption key
+     * @param bits
+     *            The signature bit length
+     */
+    public SiHmac(final byte[] key, final int bits) {
+        this.key = key.clone();
+        this.bits = SiHmac.bitLength(bits);
+    }
+
+    @Override
+    public byte[] sign(final byte[] data) throws IOException {
+        return this.encrypt(data);
+    }
+
+    /**
+     * Signature bit length.
+     * 
+     * @return bitlength
+     */
+    public int bits() {
+        return this.bits;
+    }
+
+    /**
+     * Check for correct bit length.
+     *
+     * @param bits
+     *            Given bit length
+     * @return Original bit length when appropriate, 256 bits otherwise.
+     */
+    private static int bitLength(final int bits) {
+        int correct = bits;
+        if (bits != SiHmac.HMAC256
+            && bits != SiHmac.HMAC384
+            && bits != SiHmac.HMAC512) {
+            correct = SiHmac.HMAC256;
+        }
+        return correct;
+    }
+
+    /**
+     * Encrypt the given bytes using HMAC.
+     *
+     * @param bytes
+     *            Bytes to encrypt
+     * @return Encrypted bytes
+     * @throws IOException
+     *             for all unexpected exceptions
+     */
+    @SuppressWarnings("resource")
+    private byte[] encrypt(final byte[] bytes) throws IOException {
+        final Formatter formatter = new Formatter();
+        for (final byte byt : this.create().doFinal(bytes)) {
+            formatter.format("%02x", byt);
+        }
+        return formatter.toString().getBytes();
+    }
+
+    /**
+     * Create new mac based on a valid bit length from {@link Mac} class.
+     *
+     * @return The mac
+     * @throws IOException
+     *             For any unexpected exceptions
+     */
+    private Mac create()
+        throws IOException {
+        try {
+            final SecretKeySpec secret = new SecretKeySpec(
+                this.key, String.format("HmacSHA%s", this.bits));
+            final Mac mac = Mac
+                .getInstance(String.format("HmacSHA%s", this.bits));
+            mac.init(secret);
+            return mac;
+        } catch (final InvalidKeyException ex) {
+            throw new IOException(ex);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IOException(ex);
+        }
+    }
+}

--- a/src/main/java/org/takes/facets/auth/signatures/Signature.java
+++ b/src/main/java/org/takes/facets/auth/signatures/Signature.java
@@ -1,0 +1,46 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.signatures;
+
+import java.io.IOException;
+
+/**
+ * Signature.
+ *
+ * <p>All implementations of this interface must be immutable and thread-safe.
+ *
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.4
+ */
+public interface Signature {
+
+    /**
+     * Create signature for data bytes.
+     * @param data The data to be signed
+     * @return Signature
+     * @throws IOException If anything fails
+     */
+    byte[] sign(byte[] data) throws IOException;
+}

--- a/src/main/java/org/takes/facets/auth/signatures/package-info.java
+++ b/src/main/java/org/takes/facets/auth/signatures/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Signatures.
+ *
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.4
+ */
+package org.takes.facets.auth.signatures;

--- a/src/test/java/org/takes/facets/auth/TokenTest.java
+++ b/src/test/java/org/takes/facets/auth/TokenTest.java
@@ -1,0 +1,122 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import javax.json.JsonObject;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.facets.auth.Token.Jose;
+import org.takes.facets.auth.Token.Jwt;
+import org.takes.misc.Base64;
+
+/**
+ * Test case for {@link Token}.
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.5
+ */
+public final class TokenTest {
+    /**
+     * JOSE header has correct algorithm name.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void joseAlgorithm() throws IOException {
+        // @checkstyle MagicNumber (1 line)
+        final JsonObject jose = new Token.Jose(256).json();
+        MatcherAssert.assertThat(
+            jose.getString(Jose.ALGORITHM),
+            Matchers.equalTo("HS256")
+        );
+    }
+
+    /**
+     * JOSE header is encoded correctly.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void joseEncoded() throws IOException {
+        // @checkstyle MagicNumber (2 lines)
+        final byte[] code = new Token.Jose(256).encoded();
+        final JsonObject jose = new Token.Jose(256).json();
+        MatcherAssert.assertThat(
+            code,
+            Matchers.equalTo(new Base64().encode(jose.toString()))
+        );
+    }
+
+    /**
+     * JWT header exp date is set correctly.
+     * @throws IOException If some problem inside
+     * @throws ParseException If date parsing fails
+     */
+    @Test
+    public void jwtExpiration() throws IOException, ParseException {
+        final JsonObject jose = new Token.Jwt(
+            (Identity) new Identity.Simple("user"),
+            // @checkstyle MagicNumber (1 line)
+            3600L
+        ).json();
+        MatcherAssert.assertThat(
+            jose.getString(Jwt.ISSUED),
+            Matchers.not(jose.getString(Jwt.EXPIRATION))
+        );
+        final SimpleDateFormat format =
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'", Locale.GERMAN);
+        MatcherAssert.assertThat(
+            "does not expire after issued",
+            format.parse(
+                jose.getString(Jwt.ISSUED)
+            ).before(
+                format.parse(jose.getString(Jwt.EXPIRATION))
+            )
+        );
+    }
+
+    /**
+     * JWT header is encoded correctly.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void jwtEncoded() throws IOException {
+        final Identity user = new Identity.Simple("test");
+        final byte[] code = new Token.Jwt(
+            // @checkstyle MagicNumber (1 line)
+            user, 3600L
+        ).encoded();
+        final JsonObject jose = new Token.Jwt(
+            // @checkstyle MagicNumber (1 line)
+            user, 3600L
+        ).json();
+        MatcherAssert.assertThat(
+            code,
+            Matchers.equalTo(new Base64().encode(jose.toString()))
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
+++ b/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
@@ -1,0 +1,80 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.signatures;
+
+import java.io.IOException;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link SiHmac}.
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.3
+ */
+public final class SiHmacTest {
+    /**
+     * SiHmac corrects wrong bit length.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void corrects() throws IOException {
+        MatcherAssert.assertThat(
+            // @checkstyle MagicNumber (1 line)
+            new SiHmac("key", 123).bits(),
+            Matchers.equalTo(SiHmac.HMAC256)
+        );
+    }
+    /**
+     * SiHmac can sign.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void signs() throws IOException {
+        MatcherAssert.assertThat(
+            new String(
+                new SiHmac("key", SiHmac.HMAC256)
+                .sign("The quick brown fox jumps over the lazy dog".getBytes())
+            ),
+            Matchers.equalTo(
+                // @checkstyle LineLength (1 line)
+                "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"
+            )
+        );
+    }
+    /**
+     * Checks SiHmac equals method.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void equalsAndHashCodeEqualTest() throws Exception {
+        EqualsVerifier.forClass(SiHmac.class)
+            .suppress(Warning.ALL_FIELDS_SHOULD_BE_USED)
+            .suppress(Warning.INHERITED_DIRECTLY_FROM_OBJECT)
+            .verify();
+    }
+}

--- a/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
+++ b/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
@@ -45,7 +45,7 @@ public final class SiHmacTest {
     public void corrects() throws IOException {
         MatcherAssert.assertThat(
             // @checkstyle MagicNumber (1 line)
-            new SiHmac("key", 123).bits(),
+            new SiHmac("test", 123).bitlength(),
             Matchers.equalTo(SiHmac.HMAC256)
         );
     }

--- a/src/test/java/org/takes/facets/auth/signatures/package-info.java
+++ b/src/test/java/org/takes/facets/auth/signatures/package-info.java
@@ -1,0 +1,32 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Signatures, tests.
+ *
+ * @author Sven Windisch (sven.windisch@gmail.com)
+ * @version $Id$
+ * @since 1.3
+ */
+package org.takes.facets.auth.signatures;


### PR DESCRIPTION
These commits introduce the following things in order to make JSON Web Token (JWT, see https://jwt.io/) usable in takes:

1. A new Signature interface, similar to the Codec interface. The main difference is that while Codecs can encrypt and decrypt data, a Signature can only encrypt (aka sign) data. 
2. An HMAC-SHA implementation of that interface with variations of 256, 384 and 512 bitlength. This is the standard signature algorithm for JWT.
2. A new interface for Token and two implementations that provide a JOSE token (JWT header) and a JWT payload token.
3. A new Pass that accepts JWT from a Bearer header and adds a new JWT to its response (obviously, that works only with JSON responses).