### PR TITLE
fix build & run link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These two web systems use Takes, and they are open source:
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Build and Run With Maven](#build-a-run-with-maven)
+- [Build and Run With Maven](#build-and-run-with-maven)
 - [Unit Testing](#unit-testing)
 - [Integration Testing](#integration-testing)
 - [A Bigger Example](#a-bigger-example)


### PR DESCRIPTION
This link was not pointing to the correct anchor tag in the README. Now it correctly takes the user to the right section.

Thanks for the project!