### PR TITLE
Response pipe broke

### DIFF
--- a/src/main/java/org/takes/http/Back.java
+++ b/src/main/java/org/takes/http/Back.java
@@ -34,6 +34,10 @@ import java.net.Socket;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
+ *
+ * @todo #373:15min Document usage of Back interface in README.md.
+ *  Provide information about implementations and how and when they
+ *  can be used in client's code.
  */
 public interface Back {
 

--- a/src/main/java/org/takes/http/Front.java
+++ b/src/main/java/org/takes/http/Front.java
@@ -33,6 +33,10 @@ import java.io.IOException;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.1
+ *
+ * @todo #373:15min Document usage of Front interface in README.md.
+ *  Provide information about implementations and how and when
+ *  they can be used in client's code.
  */
 public interface Front {
 

--- a/src/main/java/org/takes/http/FtBasic.java
+++ b/src/main/java/org/takes/http/FtBasic.java
@@ -60,7 +60,7 @@ public final class FtBasic implements Front {
      */
     public FtBasic(final Take tks) throws IOException {
         // @checkstyle MagicNumber (1 line)
-        this(new BkBasic(tks), 80);
+        this(new BkSafe(new BkBasic(tks)), 80);
     }
 
     /**
@@ -70,7 +70,7 @@ public final class FtBasic implements Front {
      * @throws IOException If fails
      */
     public FtBasic(final Take tks, final int prt) throws IOException {
-        this(new BkBasic(tks), prt);
+        this(new BkSafe(new BkBasic(tks)), prt);
     }
 
     /**

--- a/src/test/java/org/takes/http/FtBasicTest.java
+++ b/src/test/java/org/takes/http/FtBasicTest.java
@@ -28,6 +28,9 @@ import com.jcabi.http.response.RestResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
@@ -35,6 +38,9 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -48,6 +54,7 @@ import org.takes.rq.RqPrint;
 import org.takes.rs.RsHtml;
 import org.takes.rs.RsText;
 import org.takes.tk.TkFailure;
+import org.takes.tk.TkText;
 
 /**
  * Test case for {@link FtBasic}.
@@ -56,7 +63,7 @@ import org.takes.tk.TkFailure;
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports"})
 public final class FtBasicTest {
 
     /**
@@ -279,5 +286,49 @@ public final class FtBasicTest {
                 }
             }
         );
+    }
+
+    /**
+     * FtBasic can work with broken pipe.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    @Ignore
+    public void gracefullyHandlesBrokenPipe() throws IOException {
+        new FtBasic(
+            new BkBasic(
+                new TkText("Body")
+            ),
+            FtBasicTest.server()
+        ).start(
+            new Exit() {
+                @Override
+                public boolean ready() {
+                    return true;
+                }
+            }
+        );
+    }
+
+    /**
+     * Mocked ServerSocket so that Socket will throw SocketException.
+     * @return Mocked instance of ServerSocket
+     * @throws IOException If some problem inside
+     */
+    private static ServerSocket server() throws IOException {
+        final ServerSocket server = Mockito.mock(ServerSocket.class);
+        final Socket socket = Mockito.mock(
+            Socket.class,
+            new Answer<Socket>() {
+                @Override
+                public Socket answer(
+                    final InvocationOnMock invocation
+                ) throws Throwable {
+                    throw new SocketException("Broken pipe");
+                }
+            }
+        );
+        Mockito.when(server.accept()).thenReturn(socket);
+        return server;
     }
 }

--- a/src/test/java/org/takes/http/FtBasicTest.java
+++ b/src/test/java/org/takes/http/FtBasicTest.java
@@ -289,15 +289,16 @@ public final class FtBasicTest {
     }
 
     /**
-     * FtBasic can work with broken pipe.
+     * FtBasic can work with broken pipe if {@link BkSafe} is used.
      * @throws IOException If some problem inside
      */
     @Test
-    @Ignore
     public void gracefullyHandlesBrokenPipe() throws IOException {
         new FtBasic(
-            new BkBasic(
-                new TkText("Body")
+            new BkSafe(
+                new BkBasic(
+                    new TkText("Body")
+                )
             ),
             FtBasicTest.server()
         ).start(


### PR DESCRIPTION
Implementation for #373 . I decided to wrap `Back` in `FtBasic` in `BkSafe` so that default usage of `FtBasic` will be safe.