### PR TITLE
#730 Problem do not relate to TkSlf4j, but to FtRemote

### DIFF
--- a/src/test/java/org/takes/http/FtRemoteTest.java
+++ b/src/test/java/org/takes/http/FtRemoteTest.java
@@ -36,11 +36,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.rq.form.RqFormBase;
 import org.takes.rs.RsText;
+import org.takes.tk.TkEmpty;
 import org.takes.tk.TkFixed;
 
 /**
@@ -48,6 +51,12 @@ import org.takes.tk.TkFixed;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.21
+ *
+ * @todo #730:30min Fix FtRemote for empty response body test case and
+ *  unignore returnsAnEmptyResponseBody. After that the
+ *  {@link org.takes.tk.TkSlf4jRemoteTest} should be fixed and relevant
+ *  test case should be unignored.
+ *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class FtRemoteTest {
@@ -121,4 +130,28 @@ public final class FtRemoteTest {
         }
     }
 
+    /**
+     * FtRemote can return empty response body for {@link TkEmpty}.
+     * @throws IOException If some problems inside
+     */
+    @Ignore
+    @Test
+    public void returnsAnEmptyResponseBody() throws IOException {
+        new FtRemote(
+            new TkEmpty()
+        ).exec(
+            new FtRemote.Script() {
+                @Override
+                public void exec(final URI home) throws IOException {
+                    new JdkRequest(home)
+                        .method("POST")
+                        .body().set("returnsAnEmptyResponseBody").back()
+                        .fetch()
+                        .as(RestResponse.class)
+                        .assertBody(new IsEqual<>(""))
+                        .assertStatus(HttpURLConnection.HTTP_OK);
+                }
+            }
+        );
+    }
 }

--- a/src/test/java/org/takes/tk/TkSlf4jRemoteTest.java
+++ b/src/test/java/org/takes/tk/TkSlf4jRemoteTest.java
@@ -41,10 +41,6 @@ import org.takes.http.FtRemote;
  * @author Yegor Bugayenko (yegor256@gmail.com)
  * @version $Id$
  * @since 0.11.2
- *
- * @todo #712:30min Prepare implementation for empty response body test and
- *  unignore returnsAnEmptyResponseBody test to fix such error which was
- *  reported in #712.
  */
 public final class TkSlf4jRemoteTest {
 

--- a/src/test/java/org/takes/tk/TkSlf4jTest.java
+++ b/src/test/java/org/takes/tk/TkSlf4jTest.java
@@ -54,4 +54,13 @@ public final class TkSlf4jTest {
     public void logsException() throws IOException {
         new TkSlf4j(new TkFailure(new IOException(""))).act(new RqFake());
     }
+
+    /**
+     * TkSlf4j can work with {@link TkEmpty}.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void logsEmptyMessage() throws IOException {
+        new TkSlf4j(new TkEmpty()).act(new RqFake());
+    }
 }


### PR DESCRIPTION
Added test cases that proves that problem is not about `TkSlf4j`, but `FtRemote` itself could not work properly with `TkEmpty`. The thing is that it prints additional things to the body, even though the response from Take is empty.

`TkSlf4j` wasn't working because in `FtBasic` the call to `input.available` returned some value, although it shouldn't. So it tries to log, what comes to him, but couldn't as it is not real request. So it works as it should be I believe, and the thing that it's failing - is a good thing. We should concentrate on issue in `FtBasic` instead. 
