### PR TITLE
OutputStream in RsPrint may fail to flush() in case of IOException

### DIFF
--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -161,14 +161,17 @@ public final class RsPrint extends RsWrap {
         final InputStream body = this.body();
         //@checkstyle MagicNumberCheck (1 line)
         final byte[] buf = new byte[4096];
-        while (true) {
-            final int bytes = body.read(buf);
-            if (bytes < 0) {
-                break;
+        try {
+            while (true) {
+                final int bytes = body.read(buf);
+                if (bytes < 0) {
+                    break;
+                }
+                output.write(buf, 0, bytes);
             }
-            output.write(buf, 0, bytes);
+        } finally {
+            output.flush();
         }
-        output.flush();
     }
 
 }

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -24,6 +24,10 @@
 package org.takes.rs;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -43,4 +47,99 @@ public final class RsPrintTest {
         new RsPrint(new RsWithHeader("name", "\n\n\n")).print();
     }
 
+    /**
+     * RsPrint can flush body contents even when exception happens.
+     * @throws IOException If some problem inside
+     */
+    @Test
+    public void flushBodyEvenWhenExceptionHappens() throws IOException {
+        final IOException exception = new IOException("Failure");
+        final FailOutputStream output = new FailOutputStream(exception);
+        try {
+            new RsPrint(new RsText("Hello"))
+                .printBody(output);
+        } catch (final IOException ex) {
+            if (!ex.equals(exception)) {
+                throw ex;
+            }
+        }
+        MatcherAssert.assertThat(
+            output.haveFlushed(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * RsPrint can flush head contents even when exception happens.
+     * @throws IOException If some problem inside
+     * @todo #778:30min Fix flushHeadEvenWhenExceptionHappens test
+     *  and remove Ignore annotation. Implementation could not rely
+     *  on simple try-finally block as OutputStreamWriter do not call
+     *  to the flush() of OutputStream. It has additional checks.
+     */
+    @Test
+    @Ignore
+    public void flushHeadEvenWhenExceptionHappens() throws IOException {
+        final IOException exception = new IOException("Error");
+        final FailOutputStream output = new FailOutputStream(exception);
+        try {
+            new RsPrint(new RsText("World!"))
+                .printHead(output);
+        } catch (final IOException ex) {
+            if (!ex.equals(exception)) {
+                throw ex;
+            }
+        }
+        MatcherAssert.assertThat(
+            output.haveFlushed(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * FailOutputStream that throws IOException on method write.
+     *
+     * @author Izbassar Tolegen (t.izbassar@gmail.com)
+     * @version $Id$
+     * @since 2.0
+     */
+    private static final class FailOutputStream extends OutputStream {
+
+        /**
+         * Have contents been flushed?
+         */
+        private boolean flushed;
+
+        /**
+         * Exception, that needs to be thrown.
+         */
+        private final IOException exception;
+
+        /**
+         * Ctor.
+         * @param exception Exception to throw
+         */
+        FailOutputStream(final IOException exception) {
+            super();
+            this.exception = exception;
+        }
+
+        @Override
+        public void write(final int value) throws IOException {
+            throw this.exception;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            this.flushed = true;
+        }
+
+        /**
+         * Have contents been flushed?
+         * @return True, if contents were flushed, false - otherwise
+         */
+        public boolean haveFlushed() {
+            return this.flushed;
+        }
+    }
 }


### PR DESCRIPTION
PR for #778. Partially implemented by adding `try-finally` block for the `RsPrint.printBody()` method. The `try-finally` block works fine for `RsPrint.printBody()`, but for `RsPrint.printHead()` there should be additional work done as `OutputStreamWriter` which is used to write head contents do not call `flush()` method of `OutputStream`. Leaved puzzle to address this issue.