### PR TITLE
AbstractHmBody doesn't allow to use different matchers for text bodies

### DIFF
--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmBody.java
@@ -40,21 +40,8 @@ import org.hamcrest.TypeSafeMatcher;
  * @param <T> Item type. Should be able to return own item
  * @since 2.0
  *
- * @todo #485:30min Right now we can only check that InputStream
- *  have the same content as other InputStream. This is very
- *  limited usage. Task is to introduce `HmTextBody` that will
- *  make available to us to use useful string matchers from
- *  hamcrest. The usage will be like that:
- *  ```
- *  MatcherAssert.assertThat(
- *  response,
- *  new HmRsTextBody<>(Matchers.startsWith("<html>"))
- *  );
- *  ```
- *  The default constructor should use `Matcher.containsString`
- *  as default matcher, which is used for matching string to body.
- *  Current implementation of `AbstractHmBody` should be converted
- *  to `HmBytesBody` that will check equality of bytes. We can think
+ * @todo #794:30min Current implementation of `AbstractHmBody` should be
+ *  converted to `HmBytesBody` that will check equality of bytes. We can think
  *  of improving that class lately.
  *
  * @todo #485:30min Right now the describeTo doesn't properly

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
@@ -43,8 +43,10 @@ import org.hamcrest.TypeSafeMatcher;
  * @since 2.0
  *
  * @todo #794:30min Implement describeMismatchSafely and cover mismatch
- *  descriptions with relevant test cases. It should show, what was
- *  expected and what was actually in the body for clear understanding.
+ *  descriptions with relevant test cases. Update describeTo implementation
+ *  to be more informative and add relevant test cases for that. Both  should
+ *  show, what was expected, what was actually in the body and text description
+ *  for clear understanding.
  */
 public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
 

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
@@ -1,0 +1,119 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Text body matcher.
+ *
+ * <p>This "matcher" tests given item body, assuming that it has text content.
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Izbassar Tolegen (t.izbassar@gmail.com)
+ * @version $Id$
+ * @param <T> Item type. Should be able to return own body
+ * @since 2.0
+ *
+ * @todo #794:30min Implement describeMismatchSafely and cover mismatch
+ *  descriptions with relevant test cases. It should show, what was
+ *  expected and what was actually in the body for clear understanding.
+ */
+public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
+
+    /**
+     * Body matcher.
+     */
+    private final Matcher<String> body;
+
+    /**
+     * Charset of the text.
+     */
+    private final Charset charset;
+
+    /**
+     * Ctor.
+     * @param body Body matcher.
+     * @param charset Charset of the text.
+     */
+    public AbstractHmTextBody(final Matcher<String> body,
+        final Charset charset) {
+        super();
+        this.body = body;
+        this.charset = charset;
+    }
+
+    @Override
+    public final void describeTo(final Description description) {
+        description.appendDescriptionOf(this.body);
+    }
+
+    @Override
+    protected final boolean matchesSafely(final T item) {
+        try {
+            return this.body.matches(this.text(item));
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Item's body.
+     * @param item Item to retrieve body from
+     * @return InputStream of body
+     * @throws IOException If some problem inside
+     */
+    protected abstract InputStream itemBody(final T item) throws IOException;
+
+    /**
+     * Text from item.
+     * @param item Item
+     * @return Text contents of item
+     * @throws IOException If some problem inside
+     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private String text(final T item) throws IOException {
+        final String text;
+        try (
+            final InputStream input = this.itemBody(item);
+            final ByteArrayOutputStream output = new ByteArrayOutputStream()
+        ) {
+            // @checkstyle MagicNumberCheck (1 line)
+            final byte[] buffer = new byte[1024];
+            int len;
+            while ((len = input.read(buffer, 0, buffer.length)) != -1) {
+                output.write(buffer, 0, len);
+            }
+            output.flush();
+            text = new String(output.toByteArray(), this.charset);
+        }
+        return text;
+    }
+}

--- a/src/main/java/org/takes/facets/hamcrest/HmRqTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqTextBody.java
@@ -44,11 +44,11 @@ import org.takes.Request;
 public final class HmRqTextBody extends AbstractHmTextBody<Request> {
 
     /**
-     * Ctor with containsString matcher and default charset.
+     * Ctor with equalTo matcher and default charset.
      * @param expected String to test against
      */
     public HmRqTextBody(final String expected) {
-        this(Matchers.containsString(expected));
+        this(Matchers.equalTo(expected));
     }
 
     /**

--- a/src/main/java/org/takes/facets/hamcrest/HmRqTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqTextBody.java
@@ -1,0 +1,75 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.takes.Request;
+
+/**
+ * Request text body matcher.
+ *
+ * <p>This "matcher" tests given request body,
+ * assuming that it has text content.</p>
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Izbassar Tolegen (t.izbassar@gmail.com)
+ * @version $Id$
+ * @since 2.0
+ */
+public final class HmRqTextBody extends AbstractHmTextBody<Request> {
+
+    /**
+     * Ctor with containsString matcher and default charset.
+     * @param expected String to test against
+     */
+    public HmRqTextBody(final String expected) {
+        this(Matchers.containsString(expected));
+    }
+
+    /**
+     * Ctor with charset set to default one.
+     * @param bdm Text body matcher
+     */
+    public HmRqTextBody(final Matcher<String> bdm) {
+        this(bdm, Charset.defaultCharset());
+    }
+
+    /**
+     * Ctor.
+     * @param bdm Text body matcher
+     * @param charset Text body charset
+     */
+    public HmRqTextBody(final Matcher<String> bdm, final Charset charset) {
+        super(bdm, charset);
+    }
+
+    @Override
+    public InputStream itemBody(final Request item) throws IOException {
+        return item.body();
+    }
+}

--- a/src/main/java/org/takes/facets/hamcrest/HmRsTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsTextBody.java
@@ -44,11 +44,11 @@ import org.takes.Response;
 public final class HmRsTextBody extends AbstractHmTextBody<Response> {
 
     /**
-     * Ctor with containsString matcher and default charset.
+     * Ctor with equalTo matcher and default charset.
      * @param expected String to test against
      */
     public HmRsTextBody(final String expected) {
-        this(Matchers.containsString(expected));
+        this(Matchers.equalTo(expected));
     }
 
     /**

--- a/src/main/java/org/takes/facets/hamcrest/HmRsTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsTextBody.java
@@ -1,0 +1,75 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.takes.Response;
+
+/**
+ * Response text body matcher.
+ *
+ * <p>This "matcher" tests given response body,
+ * assuming that it has text content.</p>
+ * <p>The class is immutable and thread-safe.
+ *
+ * @author Izbassar Tolegen (t.izbassar@gmail.com)
+ * @version $Id$
+ * @since 2.0
+ */
+public final class HmRsTextBody extends AbstractHmTextBody<Response> {
+
+    /**
+     * Ctor with containsString matcher and default charset.
+     * @param expected String to test against
+     */
+    public HmRsTextBody(final String expected) {
+        this(Matchers.containsString(expected));
+    }
+
+    /**
+     * Ctor with charset set to default one.
+     * @param bdm Text body matcher
+     */
+    public HmRsTextBody(final Matcher<String> bdm) {
+        this(bdm, Charset.defaultCharset());
+    }
+
+    /**
+     * Ctor.
+     * @param bdm Text body matcher
+     * @param charset Text body charset
+     */
+    public HmRsTextBody(final Matcher<String> bdm, final Charset charset) {
+        super(bdm, charset);
+    }
+
+    @Override
+    public InputStream itemBody(final Response item) throws IOException {
+        return item.body();
+    }
+}

--- a/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
@@ -39,21 +39,22 @@ import org.takes.rq.RqFake;
 public final class HmRqTextBodyTest {
 
     /**
-     * HmRqTextBody can test if body contains text.
+     * HmRqTextBody can test if body equals text.
      */
     @Test
     public void testsBodyValueContainsText() {
+        final String same = "Same text";
         MatcherAssert.assertThat(
             new RqFake(
                 Collections.<String>emptyList(),
-                "Some text"
+                same
             ),
-            new HmRqTextBody("text")
+            new HmRqTextBody(same)
         );
     }
 
     /**
-     * HmRqTextBody can test if body doesn't contains text.
+     * HmRqTextBody can test if body doesn't equal to text.
      */
     @Test
     public void testsBodyValueDoesNotContainsText() {

--- a/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
@@ -1,0 +1,68 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.rq.RqFake;
+
+/**
+ * Test case for {@link HmRqTextBody}.
+ *
+ * @author Izbassar Tolegen (t.izbassar@gmail.com)
+ * @version $Id$
+ * @since 2.0
+ */
+public final class HmRqTextBodyTest {
+
+    /**
+     * HmRqTextBody can test if body contains text.
+     */
+    @Test
+    public void testsBodyValueContainsText() {
+        MatcherAssert.assertThat(
+            new RqFake(
+                Collections.<String>emptyList(),
+                "Some text"
+            ),
+            new HmRqTextBody("text")
+        );
+    }
+
+    /**
+     * HmRqTextBody can test if body doesn't contains text.
+     */
+    @Test
+    public void testsBodyValueDoesNotContainsText() {
+        MatcherAssert.assertThat(
+            new RqFake(
+                Collections.<String>emptyList(),
+                "some"
+            ),
+            Matchers.not(new HmRqTextBody("other"))
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
@@ -38,18 +38,19 @@ import org.takes.rs.RsWithBody;
 public final class HmRsTextBodyTest {
 
     /**
-     * HmRsTextBody can test if body contains text.
+     * HmRsTextBody can test if body equals text.
      */
     @Test
     public void testsBodyValueContainsText() {
+        final String same = "<h1>Hello</h1>";
         MatcherAssert.assertThat(
-            new RsWithBody("<html><h1>Hello</h1></html>"),
-            new HmRsTextBody("<h1>Hello</h1>")
+            new RsWithBody(same),
+            new HmRsTextBody(same)
         );
     }
 
     /**
-     * HmRsTextBody can test if body doesn't contains text.
+     * HmRsTextBody can test if body doesn't equal to text.
      */
     @Test
     public void testsBodyValueDoesNotContainsText() {

--- a/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
@@ -1,0 +1,61 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.rs.RsWithBody;
+
+/**
+ * Test case for {@link HmRsTextBody}.
+ *
+ * @author Izbassar Tolegen (t.izbassar@gmail.com)
+ * @version $Id$
+ * @since 2.0
+ */
+public final class HmRsTextBodyTest {
+
+    /**
+     * HmRsTextBody can test if body contains text.
+     */
+    @Test
+    public void testsBodyValueContainsText() {
+        MatcherAssert.assertThat(
+            new RsWithBody("<html><h1>Hello</h1></html>"),
+            new HmRsTextBody("<h1>Hello</h1>")
+        );
+    }
+
+    /**
+     * HmRsTextBody can test if body doesn't contains text.
+     */
+    @Test
+    public void testsBodyValueDoesNotContainsText() {
+        MatcherAssert.assertThat(
+            new RsWithBody("Some response"),
+            Matchers.not(new HmRsTextBody("expected something else"))
+        );
+    }
+}


### PR DESCRIPTION
Fix for #794.

I've added `AbstractHmTextBody` matcher, that converts body contents to `String` and use that to match the contents with provided matcher. Added text body matchers for `Request` and `Response` with relevant test cases. 

However, there still not covered descriptions of the fails and `describeMismatchSafely` is not implemented. Left puzzle to address this issue.

This PR partially solves original issue. Left puzzle to address what was left (converting `AbstractHmBody` to `AbstractHmBytesBody`) as those are beyond 30 mins mark. 