### PR TITLE
HmBodyMatchers doesn't show mismatch in readable way

### DIFF
--- a/src/test/java/org/takes/facets/hamcrest/HmRqBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqBodyTest.java
@@ -27,7 +27,9 @@ package org.takes.facets.hamcrest;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.StringDescription;
 import org.junit.Test;
+import org.takes.Request;
 import org.takes.rq.RqFake;
 
 /**
@@ -67,5 +69,25 @@ public final class HmRqBodyTest {
             Matchers.not(new HmRqBody("that"))
         );
     }
-}
 
+    /**
+     * HmRqBody can describe mismatch in readable way.
+     */
+    @Test
+    public void describesMismatchInReadableWay() {
+        final Request request = new RqFake(
+            Collections.<String>emptyList(),
+            "other"
+        );
+        final HmRqBody matcher = new HmRqBody("some");
+        matcher.matchesSafely(request);
+        final StringDescription description = new StringDescription();
+        matcher.describeMismatchSafely(request, description);
+        MatcherAssert.assertThat(
+            description.toString(),
+            Matchers.equalTo(
+                "body was: [111, 116, 104, 101, 114]"
+            )
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/hamcrest/HmRsBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsBodyTest.java
@@ -27,7 +27,9 @@ package org.takes.facets.hamcrest;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.StringDescription;
 import org.junit.Test;
+import org.takes.Response;
 import org.takes.rs.RsSimple;
 
 /**
@@ -67,5 +69,25 @@ public final class HmRsBodyTest {
             Matchers.not(new HmRsBody("that"))
         );
     }
-}
 
+    /**
+     * HmRsBody can describe mismatch in readable way.
+     */
+    @Test
+    public void describesMismatchInReadableWay() {
+        final Response response = new RsSimple(
+            Collections.<String>emptyList(),
+            "other"
+        );
+        final HmRsBody matcher = new HmRsBody("some");
+        matcher.matchesSafely(response);
+        final StringDescription description = new StringDescription();
+        matcher.describeMismatchSafely(response, description);
+        MatcherAssert.assertThat(
+            description.toString(),
+            Matchers.equalTo(
+                "body was: [111, 116, 104, 101, 114]"
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fix for #795. Improved describeTo and describeMismatchSafely so that they show the actual and expected bytes in the bodies to make it more readable.
