### PR TITLE
CcAes and CcSigned

### DIFF
--- a/src/main/java/org/takes/facets/auth/codecs/CcSigned.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSigned.java
@@ -1,0 +1,122 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.codecs;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import javax.crypto.Mac;
+import org.takes.facets.auth.Identity;
+
+/**
+ * MAC codec which sign identity with provided algorithm and key.
+ * @author Kirill (g4s8.public@gmail.com)
+ * @version $Id$
+ * @since 1.11.1
+ */
+public final class CcSigned implements Codec {
+    /**
+     * Origin codec.
+     */
+    private final Codec cdc;
+    /**
+     * MAC algorithm.
+     */
+    private final String alg;
+    /**
+     * Secret key.
+     */
+    private final Key key;
+    /**
+     * Ctor.
+     * @param origin Origin codec
+     * @param algorithm Algorithm name
+     * @param secret Secret key
+     */
+    public CcSigned(
+        final Codec origin,
+        final String algorithm,
+        final Key secret
+    ) {
+        this.cdc = origin;
+        this.alg = algorithm;
+        this.key = secret;
+    }
+
+    @Override
+    public byte[] encode(final Identity identity) throws IOException {
+        final byte[] encoded = this.cdc.encode(identity);
+        final byte[] signature = this.mac().doFinal(encoded);
+        final byte[] signed = new byte[encoded.length + signature.length];
+        System.arraycopy(encoded, 0, signed, 0, encoded.length);
+        System.arraycopy(
+            signature,
+            0,
+            signed,
+            encoded.length,
+            signature.length
+        );
+        return signed;
+    }
+
+    @Override
+    public Identity decode(final byte[] bytes) throws IOException {
+        final Mac mac = this.mac();
+        if (bytes.length < mac.getMacLength()) {
+            throw new IOException("Invalid data size");
+        }
+        final byte[] signature = new byte[mac.getMacLength()];
+        final byte[] encoded = new byte[bytes.length - signature.length];
+        System.arraycopy(bytes, 0, encoded, 0, encoded.length);
+        System.arraycopy(
+            bytes,
+            encoded.length,
+            signature,
+            0,
+            signature.length
+        );
+        final byte[] actual = mac.doFinal(encoded);
+        if (!Arrays.equals(actual, signature)) {
+            throw new IOException("Bad signature");
+        }
+        return this.cdc.decode(encoded);
+    }
+
+    /**
+     * Obtain MAC instance.
+     * @return Initialized MAC
+     * @throws IOException If algorithm missed or invalid key
+     */
+    private Mac mac() throws IOException {
+        try {
+            final Mac mac = Mac.getInstance(this.alg);
+            mac.init(this.key);
+            return mac;
+        } catch (final NoSuchAlgorithmException | InvalidKeyException err) {
+            throw new IOException(err);
+        }
+    }
+}

--- a/src/test/java/org/takes/facets/auth/codecs/CcAesTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcAesTest.java
@@ -23,8 +23,11 @@
  */
 package org.takes.facets.auth.codecs;
 
-import java.io.IOException;
+import java.security.SecureRandom;
+import java.security.SecureRandomSpi;
+import java.util.Arrays;
 import javax.crypto.KeyGenerator;
+import javax.crypto.spec.SecretKeySpec;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -35,8 +38,89 @@ import org.takes.facets.auth.Identity;
  * @author Jason Wong (super132j@yahoo.com)
  * @version $Id$
  * @since 0.13.8
+ * @checkstyle MagicNumber (500 line)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class CcAesTest {
+    /**
+     * CcAes can encrypt identity.
+     * @throws Exception If fails
+     */
+    @Test
+    public void encryptIdentity() throws Exception {
+        final byte[] key = {
+            (byte) -25, (byte) 62, (byte) 118, (byte) 92,
+            (byte) -35, (byte) -24, (byte) 92, (byte) 48,
+            (byte) 5, (byte) -4, (byte) -88, (byte) -95,
+            (byte) -110, (byte) -54, (byte) 43, (byte) -1,
+        };
+        final byte[] random = {
+            (byte) 63, (byte) -27, (byte) -43, (byte) -52,
+            (byte) -70, (byte) -44, (byte) 86, (byte) -43,
+            (byte) -43, (byte) 116, (byte) -122, (byte) 105,
+            (byte) 108, (byte) -25, (byte) -126, (byte) 90,
+        };
+        final byte[] encrypted = new CcAes(
+            new CcTest(),
+            new CcAesTest.FkRandom(random),
+            new SecretKeySpec(key, "AES")
+        ).encode(new Identity.Simple("urg:github:0000"));
+        MatcherAssert.assertThat(
+            "Encrypted identity does not start with IV",
+            Arrays.copyOf(encrypted, 16),
+            Matchers.equalTo(random)
+        );
+        final byte[] message = new byte[encrypted.length - 16];
+        System.arraycopy(encrypted, 16, message, 0, message.length);
+        MatcherAssert.assertThat(
+            "Encrypted message did not match",
+            message,
+            Matchers.equalTo(
+                new byte[]{
+                    (byte) -119, (byte) -114, (byte) 19, (byte) 21,
+                    (byte) 77, (byte) 59, (byte) 22, (byte) 100,
+                    (byte) 121, (byte) -116, (byte) -43, (byte) 24,
+                    (byte) 86, (byte) 24, (byte) -42, (byte) 119,
+                }
+            )
+        );
+    }
+
+    /**
+     * CcAes can decrypt identity.
+     * @throws Exception If fails
+     */
+    @Test
+    public void decryptIdentity() throws Exception {
+        final byte[] encrypted = {
+            (byte) 83, (byte) -12, (byte) -8, (byte) 30,
+            (byte) -24, (byte) -5, (byte) -72, (byte) -33,
+            (byte) 13, (byte) 57, (byte) -37, (byte) -47,
+            (byte) -95, (byte) 108, (byte) 43, (byte) 101,
+            (byte) -87, (byte) -108, (byte) -41, (byte) 0,
+            (byte) 97, (byte) 1, (byte) -120, (byte) -39,
+            (byte) -114, (byte) 80, (byte) 18, (byte) -76,
+            (byte) -12, (byte) 10, (byte) -50, (byte) 51,
+            (byte) 66, (byte) 11, (byte) 13, (byte) -115,
+            (byte) 17, (byte) -41, (byte) -84, (byte) -78,
+            (byte) 48, (byte) 47, (byte) 42, (byte) -92,
+            (byte) -127, (byte) 16, (byte) -74, (byte) -61,
+        };
+        final byte[] key = {
+            (byte) 25, (byte) 92, (byte) 9, (byte) -75,
+            (byte) 54, (byte) 20, (byte) -118, (byte) 73,
+            (byte) -2, (byte) 81, (byte) 24, (byte) -5,
+            (byte) 20, (byte) 122, (byte) 92, (byte) -128,
+        };
+        MatcherAssert.assertThat(
+            new CcAes(
+                new CcTest(),
+                new SecureRandom(),
+                new SecretKeySpec(key, "AES")
+            ).decode(encrypted).urn(),
+            Matchers.equalTo("urn:github:29835")
+        );
+    }
 
     /**
      * CcAES can encode and decode.
@@ -49,20 +133,7 @@ public final class CcAesTest {
         generator.init(length);
         final byte[] key = generator.generateKey().getEncoded();
         final String plain = "This is a test!!@@**";
-        final Codec codec = new CcAes(
-            new Codec() {
-                @Override
-                public Identity decode(final byte[] bytes) throws IOException {
-                    return new Identity.Simple(new String(bytes));
-                }
-                @Override
-                public byte[] encode(final Identity identity)
-                    throws IOException {
-                    return identity.urn().getBytes();
-                }
-            },
-            key
-        );
+        final Codec codec = new CcAes(new CcTest(), key);
         MatcherAssert.assertThat(
             codec.decode(codec.encode(new Identity.Simple(plain))).urn(),
             Matchers.equalTo(plain)
@@ -78,5 +149,64 @@ public final class CcAesTest {
         new CcAes(
             new CcPlain(), "0123456701234567"
         ).decode("broken input".getBytes());
+    }
+
+    /**
+     * Fake random with provided random result.
+     */
+    private static final class FkRandom extends SecureRandom {
+        /**
+         * Serial id.
+         */
+        private static final long serialVersionUID = 8646596235826414879L;
+        /**
+         * Ctor.
+         * @param fake Bytes
+         */
+        FkRandom(final byte[] fake) {
+            super(new CcAesTest.FkRandomSpi(fake), null);
+        }
+    }
+
+    /**
+     * Fake random SPI.
+     */
+    @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
+    private static final class FkRandomSpi extends SecureRandomSpi {
+        /**
+         * Serial id.
+         */
+        private static final long serialVersionUID = -5153681125995322457L;
+        /**
+         * Bytes.
+         */
+        private final byte[] fake;
+        /**
+         * Ctor.
+         * @param fake Bytes
+         */
+        FkRandomSpi(final byte[] fake) {
+            super();
+            this.fake = fake.clone();
+        }
+
+        @Override
+        public void engineSetSeed(final byte[] bytes) {
+        }
+
+        @Override
+        public void engineNextBytes(final byte[] bytes) {
+            if (bytes.length > this.fake.length) {
+                throw new UnsupportedOperationException(
+                    "Byte-array is too big"
+                );
+            }
+            System.arraycopy(this.fake, 0, bytes, 0, bytes.length);
+        }
+
+        @Override
+        public byte[] engineGenerateSeed(final int length) {
+            return new byte[length];
+        }
     }
 }

--- a/src/test/java/org/takes/facets/auth/codecs/CcSignedTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcSignedTest.java
@@ -1,0 +1,64 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.codecs;
+
+import java.io.IOException;
+import javax.crypto.spec.SecretKeySpec;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.takes.facets.auth.Identity;
+
+/**
+ * Test case for {@link CcSigned}.
+ * @author Kirill (g4s8.public@gmail.com)
+ * @version $Id$
+ * @since 1.11.1
+ * @checkstyle JavadocMethodCheck (500 lines)
+ * @checkstyle MagicNumber (500 line)
+ */
+public final class CcSignedTest {
+    @Test
+    public void signAndVerify() throws IOException {
+        final String urn = "urn:github:346236";
+        final String alg = "HmacSHA1";
+        final CcSigned target = new CcSigned(
+            new CcTest(),
+            alg,
+            new SecretKeySpec(
+                new byte[]{
+                    (byte) -80, (byte) -46, (byte) 7, (byte) -102,
+                    (byte) 106, (byte) -25, (byte) -61, (byte) 80,
+                    (byte) 112, (byte) 103, (byte) -47, (byte) -52,
+                    (byte) 0, (byte) 124, (byte) 86, (byte) 113,
+                },
+                alg
+            )
+        );
+        MatcherAssert.assertThat(
+            target.decode(target.encode(new Identity.Simple(urn))).urn(),
+            Matchers.equalTo(urn)
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/auth/codecs/CcTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcTest.java
@@ -1,0 +1,43 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.auth.codecs;
+
+import org.takes.facets.auth.Identity;
+
+/**
+ * Test codec.
+ * @author Kirill (g4s8.public@gmail.com)
+ * @version $Id$
+ * @since 1.11.1
+ */
+final class CcTest implements Codec {
+    @Override
+    public Identity decode(final byte[] bytes) {
+        return new Identity.Simple(new String(bytes));
+    }
+    @Override
+    public byte[] encode(final Identity identity) {
+        return identity.urn().getBytes();
+    }
+}


### PR DESCRIPTION
#821 

- `CcSigned` introduced to sign identity with `Mac`
- `CcAes`  - using random `IV` for each request