### PR TITLE
RsPrint close stream

### DIFF
--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -28,8 +28,11 @@ import lombok.ToString;
 import org.takes.Response;
 import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.misc.Utf8String;
-
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Writer;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -23,17 +23,14 @@
  */
 package org.takes.rs;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
-import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.Response;
 import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.misc.Utf8String;
+
+import java.io.*;
+import java.util.regex.Pattern;
 
 /**
  * Response decorator that can print an entire response in HTTP format.
@@ -158,10 +155,9 @@ public final class RsPrint extends RsWrap {
      * @throws IOException If fails
      */
     public void printBody(final OutputStream output) throws IOException {
-        final InputStream body = this.body();
         //@checkstyle MagicNumberCheck (1 line)
         final byte[] buf = new byte[4096];
-        try {
+        try (final InputStream body = this.body()) {
             while (true) {
                 final int bytes = body.read(buf);
                 if (bytes < 0) {

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -29,7 +29,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -100,8 +99,13 @@ public final class RsPrintTest {
         );
     }
 
+    /**
+     * RsPrint test that Response body stream is closed
+     * after printing it to an output strea,
+     * @throws IOException If some problem inside
+     */
     @Test
-    public void testStreamIsCLoses() throws IOException {
+    public void assetStreamIsClosed() throws IOException {
         final AtomicBoolean closed = new AtomicBoolean(false);
         new RsPrint(new RsWithBody(new ByteArrayInputStream("test body...".getBytes()) {
             @Override
@@ -109,7 +113,7 @@ public final class RsPrintTest {
                 closed.set(true);
                 super.close();
             }
-        })).print(new ByteArrayOutputStream());
+        })).print();
         MatcherAssert.assertThat(closed.get(), Matchers.is(true));
     }
 

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -23,15 +23,12 @@
  */
 package org.takes.rs;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Test case for {@link RsPrint}.
@@ -97,24 +94,6 @@ public final class RsPrintTest {
             output.haveFlushed(),
             Matchers.is(true)
         );
-    }
-
-    /**
-     * RsPrint test that Response body stream is closed
-     * after printing it to an output strea,
-     * @throws IOException If some problem inside
-     */
-    @Test
-    public void assetStreamIsClosed() throws IOException {
-        final AtomicBoolean closed = new AtomicBoolean(false);
-        new RsPrint(new RsWithBody(new ByteArrayInputStream("test body...".getBytes()) {
-            @Override
-            public void close() throws IOException {
-                closed.set(true);
-                super.close();
-            }
-        })).print();
-        MatcherAssert.assertThat(closed.get(), Matchers.is(true));
     }
 
     /**

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -23,12 +23,16 @@
  */
 package org.takes.rs;
 
-import java.io.IOException;
-import java.io.OutputStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Test case for {@link RsPrint}.
@@ -94,6 +98,19 @@ public final class RsPrintTest {
             output.haveFlushed(),
             Matchers.is(true)
         );
+    }
+
+    @Test
+    public void testStreamIsCLoses() throws IOException {
+        final AtomicBoolean closed = new AtomicBoolean(false);
+        new RsPrint(new RsWithBody(new ByteArrayInputStream("test body...".getBytes()) {
+            @Override
+            public void close() throws IOException {
+                closed.set(true);
+                super.close();
+            }
+        })).print(new ByteArrayOutputStream());
+        MatcherAssert.assertThat(closed.get(), Matchers.is(true));
     }
 
     /**


### PR DESCRIPTION
Fixed #838 . RsPrint should close stream after printing it to an OutputStream.