### PR TITLE
For #786: Correct HmRqHeader and HmRsHeader constructors

### DIFF
--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmHeader.java
@@ -41,6 +41,7 @@ import org.hamcrest.TypeSafeMatcher;
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @author I. Sokolov (happy.neko@gmail.com)
  * @author Andrey Eliseev (aeg.exper0@gmail.com)
+ * @author Paulo Lobo (pauloeduardolobo@gmail.com)
  * @version $Id$
  * @param <T> Item type. Should be able to return own headers
  * @since 0.31.2

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmHeader.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 
 /**
@@ -78,28 +77,6 @@ abstract class AbstractHmHeader<T> extends TypeSafeMatcher<T> {
         super();
         this.header = hdrm;
         this.value = vlm;
-    }
-
-    /**
-     * Ctor.
-     * @param hdr Header name
-     * @param vlm Value matcher
-     */
-    protected AbstractHmHeader(final String hdr,
-        final Matcher<Iterable<String>> vlm) {
-        this(Matchers.equalToIgnoringCase(hdr), vlm);
-    }
-
-    /**
-     * Ctor.
-     * @param hdr Header name
-     * @param val Header value
-     */
-    protected AbstractHmHeader(final String hdr, final String val) {
-        this(
-            Matchers.equalToIgnoringCase(hdr),
-            Matchers.hasItems(val)
-        );
     }
 
     @Override

--- a/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqHeader.java
@@ -25,6 +25,8 @@ package org.takes.facets.hamcrest;
 
 import java.io.IOException;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.text.IsEqualIgnoringCase;
 import org.takes.Request;
 
 /**
@@ -57,7 +59,7 @@ public final class HmRqHeader extends AbstractHmHeader<Request> {
      */
     public HmRqHeader(final String hdr,
         final Matcher<Iterable<String>> vlm) {
-        super(hdr, vlm);
+        super(new IsEqualIgnoringCase(hdr), vlm);
     }
 
     /**
@@ -66,7 +68,7 @@ public final class HmRqHeader extends AbstractHmHeader<Request> {
      * @param val Header value
      */
     public HmRqHeader(final String hdr, final String val) {
-        super(hdr, val);
+        this(hdr, Matchers.hasItems(val));
     }
 
     @Override

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -38,8 +38,9 @@ import org.takes.Response;
  * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
  * @author I. Sokolov (happy.neko@gmail.com)
  * @author Andrey Eliseev (aeg.exper0@gmail.com)
+ * @author Paulo Lobo (pauloeduardolobo@gmail.com)
  * @version $Id$
- * @since 0.23.3
+ * @since 2.0
  */
 public final class HmRsHeader extends AbstractHmHeader<Response> {
 

--- a/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsHeader.java
@@ -25,6 +25,8 @@ package org.takes.facets.hamcrest;
 
 import java.io.IOException;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.text.IsEqualIgnoringCase;
 import org.takes.Response;
 
 /**
@@ -58,7 +60,7 @@ public final class HmRsHeader extends AbstractHmHeader<Response> {
      */
     public HmRsHeader(final String hdr,
         final Matcher<Iterable<String>> vlm) {
-        super(hdr, vlm);
+        super(new IsEqualIgnoringCase(hdr), vlm);
     }
 
     /**
@@ -67,7 +69,7 @@ public final class HmRsHeader extends AbstractHmHeader<Response> {
      * @param val Header value
      */
     public HmRsHeader(final String hdr, final String val) {
-        super(hdr, val);
+        this(hdr, Matchers.hasItems(val));
     }
 
     @Override


### PR DESCRIPTION
For #786:
- Removed constructors from `AbstractHmHeader`
- Added constructors to `HmRqHeader` and `HmRsHeader`