### PR TITLE
For #725: Move header names from BkBasic to public constants

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -59,6 +59,26 @@ import org.takes.rs.RsWithStatus;
 public final class BkBasic implements Back {
 
     /**
+     * Local address header name.
+     */
+     public static final String LOCALADDR =  "X-Takes-LocalAddress";
+
+    /**
+     * Local port header name.
+     */
+     public static final String LOCALPORT = "X-Takes-LocalPort";
+
+    /**
+     * Remote address header name.
+     */
+     public static final String REMOTEADDR = "X-Takes-RemoteAddress";
+
+    /**
+     * Remote port header name.
+     */
+     public static final String REMOTEPORT = "X-Takes-RemotePort";
+
+    /**
      * Take.
      */
     private final Take take;
@@ -144,20 +164,23 @@ public final class BkBasic implements Back {
      * @param socket Socket
      * @return Request with custom headers
      */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     private static Request addSocketHeaders(final Request req,
         final Socket socket) {
         return new RqWithHeaders(
             req,
             String.format(
-                "X-Takes-LocalAddress: %s",
+                "%s: %s",
+                BkBasic.LOCALADDR,
                 socket.getLocalAddress().getHostAddress()
             ),
-            String.format("X-Takes-LocalPort: %d", socket.getLocalPort()),
+            String.format("%s: %d", BkBasic.LOCALPORT, socket.getLocalPort()),
             String.format(
-                "X-Takes-RemoteAddress: %s",
+                "%s: %s",
+                BkBasic.REMOTEADDR,
                 socket.getInetAddress().getHostAddress()
             ),
-            String.format("X-Takes-RemotePort: %d", socket.getPort())
+            String.format("%s: %d", BkBasic.REMOTEADDR, socket.getPort())
         );
     }
 }

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -58,9 +58,6 @@ import org.takes.tk.TkText;
  * @since 0.15.2
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
- * @todo #516:15min Move header names from BkBasic to public constants.
- *  Reusable header names will help in many situations. For example - in new
- *  integration tests.
  */
 @SuppressWarnings(
     {


### PR DESCRIPTION
For #725:
- Moved fields to public constants in `FkBasic`
- Removed todo in `FkBasicTest`