### PR TITLE
#819: describe mismatch in AbstractHmTextBody

### DIFF
--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
@@ -55,11 +55,6 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
     private final Charset charset;
 
     /**
-     * Text from item for mismatch description.
-     */
-    private String itext;
-
-    /**
      * Ctor.
      * @param body Body matcher.
      * @param charset Charset of the text.
@@ -79,8 +74,7 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
     @Override
     protected final boolean matchesSafely(final T item) {
         try {
-            this.itext = this.text(item);
-            return this.body.matches(this.itext);
+            return this.body.matches(this.text(item));
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }
@@ -89,7 +83,11 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
     @Override
     protected final void describeMismatchSafely(final T item, final
         Description description) {
-        description.appendText("body was: ").appendText(this.itext);
+        try {
+            description.appendText("body was: ").appendText(this.text(item));
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     /**

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
@@ -41,12 +41,6 @@ import org.hamcrest.TypeSafeMatcher;
  * @version $Id$
  * @param <T> Item type. Should be able to return own body
  * @since 2.0
- *
- * @todo #794:30min Implement describeMismatchSafely and cover mismatch
- *  descriptions with relevant test cases. Update describeTo implementation
- *  to be more informative and add relevant test cases for that. Both  should
- *  show, what was expected, what was actually in the body and text description
- *  for clear understanding.
  */
 public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
 
@@ -59,6 +53,11 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
      * Charset of the text.
      */
     private final Charset charset;
+
+    /**
+     * Text from item for mismatch description.
+     */
+    private String itext;
 
     /**
      * Ctor.
@@ -74,16 +73,23 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
 
     @Override
     public final void describeTo(final Description description) {
-        description.appendDescriptionOf(this.body);
+        description.appendText("body: ").appendDescriptionOf(this.body);
     }
 
     @Override
     protected final boolean matchesSafely(final T item) {
         try {
-            return this.body.matches(this.text(item));
+            this.itext = this.text(item);
+            return this.body.matches(this.itext);
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }
+    }
+
+    @Override
+    protected final void describeMismatchSafely(final T item, final
+        Description description) {
+        description.appendText("body was: ").appendText(this.itext);
     }
 
     /**

--- a/src/test/java/org/takes/facets/hamcrest/HmTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmTextBodyTest.java
@@ -1,0 +1,103 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2018 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.cactoos.Text;
+import org.cactoos.io.InputStreamOf;
+import org.cactoos.text.TextOf;
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.StringDescription;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+
+/**
+ * Test case for {@link AbstractHmTextBody}.
+ *
+ * @author Alena Gerasimova (olena.gerasimova@gmail.com)
+ * @version $Id$
+ * @since 2.0
+ */
+public final class HmTextBodyTest {
+
+    /**
+     * Tests mismatch description.
+     */
+    @Test
+    public void describesMismatchCorrectly() {
+        final AbstractHmTextBody<Text> matcher = new HmTextBodyFake(
+            new IsEqual<>("courage"), Charset.defaultCharset()
+        );
+        final StringDescription description = new StringDescription();
+        final String body = "doubt";
+        final Text item = new TextOf(body);
+        matcher.matchesSafely(item);
+        matcher.describeMismatchSafely(item, description);
+        MatcherAssert.assertThat(
+            description.toString(),
+            new IsEqual<>(String.format("body was: %s", body))
+        );
+    }
+
+    /**
+     * Tests expected description.
+     */
+    @Test
+    public void describesExpectedCorrectly() {
+        final String expected = "red";
+        final AbstractHmTextBody<Text> matcher = new HmTextBodyFake(
+            new IsEqual<>(expected), Charset.defaultCharset()
+        );
+        final StringDescription description = new StringDescription();
+        matcher.describeTo(description);
+        MatcherAssert.assertThat(
+            description.toString(),
+            new IsEqual<>(String.format("body: \"%s\"", expected))
+        );
+    }
+
+    /**
+     * Fake child of {@link AbstractHmTextBody} for the test.
+     */
+    private final class HmTextBodyFake extends AbstractHmTextBody<Text> {
+
+        /**
+         * Ctor.
+         *
+         * @param body Body matcher.
+         * @param charset Charset of the text.
+         */
+        HmTextBodyFake(final Matcher<String> body, final Charset charset) {
+            super(body, charset);
+        }
+
+        @Override
+        public InputStream itemBody(final Text item) throws IOException {
+            return new InputStreamOf(item.asString());
+        }
+    }
+}


### PR DESCRIPTION
For #819 I've changed `AbstractHmTextBody` to properly describe mismatches, added corresponding test and removed `todo`.