### PR TITLE
Continue investigation for #800

### DIFF
--- a/src/test/java/org/takes/http/FtRemoteTest.java
+++ b/src/test/java/org/takes/http/FtRemoteTest.java
@@ -52,9 +52,10 @@ import org.takes.tk.TkFixed;
  * @version $Id$
  * @since 0.21
  *
- * @todo #730:30min Fix FtRemote for empty response body test case and
- *  unignore returnsAnEmptyResponseBody. After that the
- *  {@link org.takes.tk.TkSlf4jRemoteTest} should be fixed and relevant
+ * @todo #800:30min We can't assert if FtRemote returns an empty body because
+ *  some bug in jcabi-http (reported in
+ *  https://github.com/jcabi/jcabi-http/issues/177). After this bug is fixed,
+ *  the {@link org.takes.tk.TkSlf4jRemoteTest} should be fixed and relevant
  *  test case should be unignored.
  *
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)


### PR DESCRIPTION
This is for #800:
- after reading previous PR #855, I confirmed that it was indeed jcabi-http that had a problem.
- I've wrote down the result of this investigation in jcabi/jcabi-http#177
- I've added a `@todo` to record those results