### PR TITLE
Start using Cactoos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.29</version>
+      <version>0.38</version>
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,12 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.llorllale</groupId>
+      <artifactId>cactoos-matchers</artifactId>
+      <version>0.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,12 @@ SOFTWARE.
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.8.0-alpha2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>

--- a/src/main/java/org/takes/misc/Utf8String.java
+++ b/src/main/java/org/takes/misc/Utf8String.java
@@ -28,6 +28,11 @@ import java.nio.charset.Charset;
 /**
  * String that uses UTF-8 encoding for all byte operations.
  * @since 0.33
+ * @todo #804:30min Make this implements Cactoos Bytes and Text
+ *  and make the places in Takes that use it be able to directly
+ *  take either a Bytes or a Text depending on the situation.
+ *  For example RsWithBody should take Bytes and Text in its constructors.
+ *  Also reimplement this class with BytesOf.
  */
 public final class Utf8String {
 

--- a/src/main/java/org/takes/rs/Body.java
+++ b/src/main/java/org/takes/rs/Body.java
@@ -38,6 +38,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  * The body of a response used by {@link RsWithBody}.
  *
  * @since 0.32
+ * @todo #804:30min Make Body extends Cactoos's Input and replace input method
+ *  with stream method. Once this is done, rewrite the tests (such as BodyTest)
+ *  so that they do not use guava but Cactoos objects and cactoos-matchers
+ *  InputHasContent. When there is no more need for the method input,
+ *  remove it.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 interface Body {

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -31,6 +31,7 @@ import java.io.Writer;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.Text;
 import org.takes.Response;
 import org.takes.misc.Utf8OutputStreamWriter;
 import org.takes.misc.Utf8String;
@@ -41,10 +42,19 @@ import org.takes.misc.Utf8String;
  * <p>The class is immutable and thread-safe.
  *
  * @since 0.1
+ * @todo #804:30min Continue removing Guava's code from tests, starting
+ *  with all the calls to Joiner by replacing them with Cactoos JoinedText
+ *  and the use of cactoos-matchers TextIs or TextHasContent coupled with this
+ *  class RsPrint as a Text as it was started in #804. When there is no more
+ *  use for the method print, remove it and extract printHead and printBody
+ *  in two different classes BodyPrint and HeadPrint both implementing Text
+ *  and start again replacing guava in tests in the same manner.
+ *  Create new todos until guava is removed and Takes is much more Cactoos
+ *  oriented as started with #804.
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class RsPrint extends RsWrap {
+public final class RsPrint extends RsWrap implements Text {
 
     /**
      * Pattern for first line.
@@ -77,6 +87,11 @@ public final class RsPrint extends RsWrap {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         this.print(baos);
         return new Utf8String(baos.toByteArray()).string();
+    }
+
+    @Override
+    public String asString() throws IOException {
+        return this.print();
     }
 
     /**

--- a/src/test/java/org/takes/facets/hamcrest/HmTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmTextBodyTest.java
@@ -95,7 +95,7 @@ public final class HmTextBodyTest {
 
         @Override
         public InputStream itemBody(final Text item) throws IOException {
-            return new InputStreamOf(item.asString());
+            return new InputStreamOf(item);
         }
     }
 }

--- a/src/test/java/org/takes/rs/RsTextTest.java
+++ b/src/test/java/org/takes/rs/RsTextTest.java
@@ -23,12 +23,13 @@
  */
 package org.takes.rs;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link RsText}.
@@ -44,9 +45,10 @@ public final class RsTextTest {
     public void makesPlainTextResponse() throws IOException {
         final String body = "hello, world!";
         MatcherAssert.assertThat(
-            new RsPrint(new RsBuffered(new RsText(body))).print(),
-            Matchers.equalTo(
-                Joiner.on("\r\n").join(
+            new RsPrint(new RsBuffered(new RsText(body))),
+            new TextIs(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     String.format("Content-Length: %s", body.length()),
                     "Content-Type: text/plain",

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -23,12 +23,12 @@
  */
 package org.takes.rs;
 
-import com.google.common.base.Joiner;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextIs;
 
 /**
  * Test case for {@link RsWithType}.
@@ -91,9 +91,10 @@ public final class RsWithTypeTest {
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     type
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(RsWithTypeTest.CONTENT_TYPE, type),
                     "",
@@ -119,9 +120,10 @@ public final class RsWithTypeTest {
                     ),
                     RsWithTypeTest.TYPE_HTML
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     "HTTP/1.1 500 Internal Error",
                     "Content-Length: 6",
                     "Content-Type: text/html",
@@ -143,9 +145,10 @@ public final class RsWithTypeTest {
                 new RsWithType.Html(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML)
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE,
@@ -162,9 +165,10 @@ public final class RsWithTypeTest {
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     StandardCharsets.ISO_8859_1
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
@@ -189,9 +193,10 @@ public final class RsWithTypeTest {
                 new RsWithType.Json(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML)
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE,
@@ -208,9 +213,10 @@ public final class RsWithTypeTest {
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     StandardCharsets.ISO_8859_1
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
@@ -235,9 +241,10 @@ public final class RsWithTypeTest {
                 new RsWithType.Xml(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML)
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE, RsWithTypeTest.TYPE_XML
@@ -253,9 +260,10 @@ public final class RsWithTypeTest {
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML),
                     StandardCharsets.ISO_8859_1
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
@@ -280,9 +288,10 @@ public final class RsWithTypeTest {
                 new RsWithType.Text(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML)
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE, RsWithTypeTest.TYPE_TEXT
@@ -298,9 +307,10 @@ public final class RsWithTypeTest {
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML),
                     StandardCharsets.ISO_8859_1
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
@@ -323,9 +333,10 @@ public final class RsWithTypeTest {
         MatcherAssert.assertThat(
             new RsPrint(
                 new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_TEXT)
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE,
@@ -352,9 +363,10 @@ public final class RsWithTypeTest {
                     RsWithTypeTest.TYPE_TEXT,
                     StandardCharsets.ISO_8859_1
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(RsWithTypeTest.CRLF).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    RsWithTypeTest.CRLF,
                     RsWithTypeTest.HTTP_OK,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,

--- a/src/test/java/org/takes/tk/TkHtmlTest.java
+++ b/src/test/java/org/takes/tk/TkHtmlTest.java
@@ -23,11 +23,12 @@
  */
 package org.takes.tk;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.TextIs;
 import org.takes.Take;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
@@ -46,9 +47,10 @@ public final class TkHtmlTest {
     public void createsTextResponse() throws IOException {
         final String body = "<html>hello, world!</html>";
         MatcherAssert.assertThat(
-            new RsPrint(new TkHtml(body).act(new RqFake())).print(),
-            Matchers.equalTo(
-                Joiner.on("\r\n").join(
+            new RsPrint(new TkHtml(body).act(new RqFake())),
+            new TextIs(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     String.format("Content-Length: %s", body.length()),
                     "Content-Type: text/html",
@@ -68,12 +70,12 @@ public final class TkHtmlTest {
         final String body = "<html>hello, dude!</html>";
         final Take take = new TkHtml(body);
         MatcherAssert.assertThat(
-            new RsPrint(take.act(new RqFake())).print(),
-            Matchers.containsString(body)
+            new RsPrint(take.act(new RqFake())),
+            new TextHasString(body)
         );
         MatcherAssert.assertThat(
-            new RsPrint(take.act(new RqFake())).print(),
-            Matchers.containsString(body)
+            new RsPrint(take.act(new RqFake())),
+            new TextHasString(body)
         );
     }
 

--- a/src/test/java/org/takes/tk/TkRedirectTest.java
+++ b/src/test/java/org/takes/tk/TkRedirectTest.java
@@ -23,12 +23,12 @@
  */
 package org.takes.tk;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextIs;
 import org.takes.facets.hamcrest.HmHeader;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
@@ -58,9 +58,10 @@ public final class TkRedirectTest {
         MatcherAssert.assertThat(
             new RsPrint(
                 new TkRedirect(url).act(new RqFake())
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(TkRedirectTest.NEWLINE).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    TkRedirectTest.NEWLINE,
                     "HTTP/1.1 303 See Other",
                     String.format(TkRedirectTest.LOCATION, url),
                     "",
@@ -82,9 +83,10 @@ public final class TkRedirectTest {
                 new TkRedirect(url, HttpURLConnection.HTTP_MOVED_TEMP).act(
                     new RqFake()
                 )
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on(TkRedirectTest.NEWLINE).join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    TkRedirectTest.NEWLINE,
                     "HTTP/1.1 302 Moved Temporarily",
                     String.format(TkRedirectTest.LOCATION, url),
                     "",

--- a/src/test/java/org/takes/tk/TkTextTest.java
+++ b/src/test/java/org/takes/tk/TkTextTest.java
@@ -23,11 +23,12 @@
  */
 package org.takes.tk;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextHasString;
+import org.llorllale.cactoos.matchers.TextIs;
 import org.takes.Take;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
@@ -46,9 +47,10 @@ public final class TkTextTest {
     public void createsTextResponse() throws IOException {
         final String body = "hello, world!";
         MatcherAssert.assertThat(
-            new RsPrint(new TkText(body).act(new RqFake())).print(),
-            Matchers.equalTo(
-                Joiner.on("\r\n").join(
+            new RsPrint(new TkText(body).act(new RqFake())),
+            new TextIs(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     String.format("Content-Length: %s", body.length()),
                     "Content-Type: text/plain",
@@ -68,12 +70,12 @@ public final class TkTextTest {
         final String body = "hello, dude!";
         final Take take = new TkText(body);
         MatcherAssert.assertThat(
-            new RsPrint(take.act(new RqFake())).print(),
-            Matchers.containsString(body)
+            new RsPrint(take.act(new RqFake())),
+            new TextHasString(body)
         );
         MatcherAssert.assertThat(
-            new RsPrint(take.act(new RqFake())).print(),
-            Matchers.containsString(body)
+            new RsPrint(take.act(new RqFake())),
+            new TextHasString(body)
         );
     }
 

--- a/src/test/java/org/takes/tk/TkWithHeadersTest.java
+++ b/src/test/java/org/takes/tk/TkWithHeadersTest.java
@@ -23,11 +23,11 @@
  */
 package org.takes.tk;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.TextIs;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsPrint;
 
@@ -52,9 +52,10 @@ public final class TkWithHeadersTest {
                     host,
                     type
                 ).act(new RqFake())
-            ).print(),
-            Matchers.equalTo(
-                Joiner.on("\r\n").join(
+            ),
+            new TextIs(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     host,
                     type,


### PR DESCRIPTION
Toward making Takes Cactoos-compliant for #804.

This is better reviewed commit by commit.

Basically I
1. Started removing uses of Guava as proposed by ARC (see https://github.com/yegor256/takes/issues/804#issuecomment-439715270) by:
   1. Used `JoinedText` and `cactoos-matchers` in tests
   2. Made `RsPrint` Cactoos-compliant to to be able to write those tests
   3. Added a `@todo` to continue this task and more towards Cactoos compliance
2. Added two `@todos` that also go into this direction and that were blockers for me to rewrite tests and remove Guava.

I'm sure more `@todo`s could have been written but I think that's a good start.