### PR TITLE
Upgrade to qulice 0.17.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@ SOFTWARE.
   <properties>
     <timestamp>${maven.build.timestamp}</timestamp>
     <jdk.version>1.8</jdk.version>
+    <qulice.version>0.17.5</qulice.version>
   </properties>
   <dependencies>
     <!--
@@ -368,12 +369,24 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.17.1</version>
+            <!--
+              @todo #837:30min Upgrade qulice to latest 0.17.x and if possible
+               to latest 0.18.x and fix all the issues it detects for the build
+               to pass. In 0.17.6, some changes impact a lot of file, while in
+               0.18 there should be less new issues. Don't forget about the it
+               test ran by maven-invoker-plugin.
+            -->
+            <version>${qulice.version}</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
+                <!--
+                  @todo #837:30min Un-exclude findbugs from qulice checks
+                   and fix the bugs it detects for the build to pass.
+                   Most of those are related to reliance on default encoding
+                   and synchronization problems. 
+                -->
                 <exclude>findbugs:.*</exclude>
-                <exclude>xml:/src/it/settings.xml</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -373,8 +373,14 @@ SOFTWARE.
               @todo #837:30min Upgrade qulice to latest 0.17.x and if possible
                to latest 0.18.x and fix all the issues it detects for the build
                to pass. In 0.17.6, some changes impact a lot of file, while in
-               0.18 there should be less new issues. Don't forget about the it
+               0.18 there should be less new issues. Don't forget about the IT
                test ran by maven-invoker-plugin.
+              @todo #837:30min Finish the upgrade to qulice 0.17.5 by reviewing
+               all diamond usage: it was required until now to explicit the
+               type in generics but it is not needed anymore. For example in
+               BkTimetable line 65, new ConcurrentHashMap<Thread, Long>(1)
+               should be new ConcurrentHashMap<>(1). There are around 70
+               cases like that.
             -->
             <version>${qulice.version}</version>
             <configuration>

--- a/src/it/file-manager/pom.xml
+++ b/src/it/file-manager/pom.xml
@@ -202,5 +202,17 @@ SOFTWARE.
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>qulice</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-maven-plugin</artifactId>
+            <version>@qulice.version@</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/App.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/App.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.tk.TkRedirect;
 /**
  * App.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/Item.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.xembly.Directives;
 /**
  * Item to show (a file or a dir).
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 final class Item implements XeSource {

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/Items.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/Items.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.xembly.Directives;
 /**
  * Items to show.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 final class Items implements XeSource {

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/RsPage.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/RsPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rs.xe.XeStylesheet;
 /**
  * Response with a page.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 final class RsPage implements Response {

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/TkDir.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/TkDir.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.facets.fork.TkRegex;
 /**
  * Directory take.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 final class TkDir implements TkRegex {

--- a/src/it/file-manager/src/main/java/org/takes/it/fm/package-info.java
+++ b/src/it/file-manager/src/main/java/org/takes/it/fm/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * File manager, integration test.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.it.fm;

--- a/src/it/file-manager/src/test/java/org/takes/it/fm/AppITCase.java
+++ b/src/it/file-manager/src/test/java/org/takes/it/fm/AppITCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link App}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 public final class AppITCase {

--- a/src/it/file-manager/src/test/java/org/takes/it/fm/AppTest.java
+++ b/src/it/file-manager/src/test/java/org/takes/it/fm/AppTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.http.FtRemote;
 
 /**
  * Test case for {@link org.takes.http.FtBasic}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class AppTest {

--- a/src/it/file-manager/src/test/java/org/takes/it/fm/package-info.java
+++ b/src/it/file-manager/src/test/java/org/takes/it/fm/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * File manager, integration test.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.it.fm;

--- a/src/main/java/org/takes/Body.java
+++ b/src/main/java/org/takes/Body.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ import java.io.InputStream;
 
 /**
  * Body abstraction for {@link Request} and {@link Response}.
- * @author Paulo Lobo (pauloeduardolobo@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public interface Body {

--- a/src/main/java/org/takes/Head.java
+++ b/src/main/java/org/takes/Head.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -27,8 +27,6 @@ import java.io.IOException;
 
 /**
  * Head abstraction for {@link Request} and {@link Response}.
- * @author Paulo Lobo (pauloeduardolobo@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public interface Head {

--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ import java.io.IOException;
 /**
  * HTTP-aware exception.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @SuppressWarnings("PMD.OnlyOneConstructorShouldDoInitialization")

--- a/src/main/java/org/takes/Request.java
+++ b/src/main/java/org/takes/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ package org.takes;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see org.takes.Response
  * @see org.takes.Take
  * @see org.takes.facets.fork.RqRegex

--- a/src/main/java/org/takes/Response.java
+++ b/src/main/java/org/takes/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -50,8 +50,6 @@ import java.io.InputStream;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see org.takes.Take
  * @see org.takes.rs.RsWithBody
  * @see org.takes.rs.RsWithHeader

--- a/src/main/java/org/takes/Scalar.java
+++ b/src/main/java/org/takes/Scalar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ import java.io.IOException;
 /**
  * Scalar that returns an object.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <T> Type of object
  * @see <a href="http://www.yegor256.com/2015/03/22/takes-java-web-framework.html">Java Web App Architecture In Takes Framework</a>
  * @since 1.4

--- a/src/main/java/org/takes/Take.java
+++ b/src/main/java/org/takes/Take.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -62,8 +62,6 @@ import java.io.IOException;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.yegor256.com/2015/03/22/takes-java-web-framework.html">Java Web App Architecture In Takes Framework</a>
  * @since 0.1
  * @checkstyle LineLengthCheck (1 lines)

--- a/src/main/java/org/takes/facets/auth/Identity.java
+++ b/src/main/java/org/takes/facets/auth/Identity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import java.util.Map;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Identity {

--- a/src/main/java/org/takes/facets/auth/Pass.java
+++ b/src/main/java/org/takes/facets/auth/Pass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Pass {

--- a/src/main/java/org/takes/facets/auth/PsAll.java
+++ b/src/main/java/org/takes/facets/auth/PsAll.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.misc.Opt;
 
 /**
  * A Pass which you can enter only if you can enter every Pass in a list.
- * @author Georgy Vlasov (wlasowegor@gmail.com)
- * @version $Id$
  * @since 0.22
  */
 public class PsAll implements Pass {

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -50,8 +50,6 @@ import org.takes.rs.RsWithHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id$
  * @since 0.20
  */
 @EqualsAndHashCode
@@ -135,8 +133,6 @@ public final class PsBasic implements Pass {
      * Entry interface that is used to check if the received information is
      * valid.
      *
-     * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id$
      * @since 0.20
      */
     public interface Entry {
@@ -154,8 +150,6 @@ public final class PsBasic implements Pass {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id$
      * @since 0.20
      */
     public static final class Fake implements PsBasic.Entry {
@@ -189,8 +183,6 @@ public final class PsBasic implements Pass {
     /**
      * Empty check.
      *
-     * @author Endrigo Antonini (teamed@endrigo.com.br)
-     * @version $Id$
      * @since 0.20
      */
     public static final class Empty implements PsBasic.Entry {
@@ -203,8 +195,6 @@ public final class PsBasic implements Pass {
     /**
      * Default entry.
      *
-     * @author Georgy Vlasov (wlasowegor@gmail.com)
-     * @version $Id$
      * @since 0.22
      */
     public static final class Default implements PsBasic.Entry {

--- a/src/main/java/org/takes/facets/auth/PsByFlag.java
+++ b/src/main/java/org/takes/facets/auth/PsByFlag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rq.RqHref;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsChain.java
+++ b/src/main/java/org/takes/facets/auth/PsChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsCookie.java
+++ b/src/main/java/org/takes/facets/auth/PsCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsEmpty.java
+++ b/src/main/java/org/takes/facets/auth/PsEmpty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsFake.java
+++ b/src/main/java/org/takes/facets/auth/PsFake.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsFixed.java
+++ b/src/main/java/org/takes/facets/auth/PsFixed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsLogout.java
+++ b/src/main/java/org/takes/facets/auth/PsLogout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/PsToken.java
+++ b/src/main/java/org/takes/facets/auth/PsToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -46,8 +46,6 @@ import org.takes.rs.RsJson;
  * <p>
  * The class is immutable and thread-safe.
  *
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.4
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle AvoidDuplicateLiterals (500 lines)
@@ -124,7 +122,7 @@ public final class PsToken implements Pass {
             }
         }
         final String dot = "\\.";
-        if (head.length() > 0) {
+        if (!head.isEmpty()) {
             final String jwt = head.split(" ", 2)[1].trim();
             final String[] parts = jwt.split(dot);
             final byte[] jwtheader = parts[0].getBytes();

--- a/src/main/java/org/takes/facets/auth/RqAuth.java
+++ b/src/main/java/org/takes/facets/auth/RqAuth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rq.RqWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/RqWithAuth.java
+++ b/src/main/java/org/takes/facets/auth/RqWithAuth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rq.RqWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.18
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/RsLogout.java
+++ b/src/main/java/org/takes/facets/auth/RsLogout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rs.RsWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/TkAuth.java
+++ b/src/main/java/org/takes/facets/auth/TkAuth.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rq.RqWithoutHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(of = { "origin", "pass", "header" })

--- a/src/main/java/org/takes/facets/auth/TkSecure.java
+++ b/src/main/java/org/takes/facets/auth/TkSecure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.facets.forward.RsForward;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(of = { "origin", "loc" })

--- a/src/main/java/org/takes/facets/auth/Token.java
+++ b/src/main/java/org/takes/facets/auth/Token.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import javax.json.JsonObject;
  * <p>
  * All implementations of this interface must be immutable and thread-safe.
  *
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.4
  */
 public interface Token {

--- a/src/main/java/org/takes/facets/auth/XeIdentity.java
+++ b/src/main/java/org/takes/facets/auth/XeIdentity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/XeLogoutLink.java
+++ b/src/main/java/org/takes/facets/auth/XeLogoutLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.xe.XeWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/codecs/CcAes.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcAes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -48,8 +48,6 @@ import org.takes.facets.auth.Identity;
  * <a href="https://crypto.stackexchange.com/a/205">before or after</a>
  * encryption.
  * <p>The class is immutable and thread-safe.
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @since 0.13.8
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,9 +35,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcCompact.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcCompact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcGzip.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcGzip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Aleksey Kurochka (eg04lt3r@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcHex.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcHex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcPlain.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcPlain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcSafe.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSafe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/CcSigned.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSigned.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * MAC codec which sign identity with provided algorithm and key.
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id$
  * @since 1.11.1
  */
 public final class CcSigned implements Codec {

--- a/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.facets.auth.Identity;
  * Decorator which check incoming and outgoing identities.
  *
  * <p>The class is immutable and thread-safe.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.11.2
  */
 public final class CcStrict implements Codec {

--- a/src/main/java/org/takes/facets/auth/codecs/CcXor.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcXor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/codecs/Codec.java
+++ b/src/main/java/org/takes/facets/auth/codecs/Codec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.facets.auth.Identity;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Codec {

--- a/src/main/java/org/takes/facets/auth/codecs/DecodingException.java
+++ b/src/main/java/org/takes/facets/auth/codecs/DecodingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -26,8 +26,6 @@ package org.takes.facets.auth.codecs;
 /**
  * Decoding exception.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 public final class DecodingException extends RuntimeException {

--- a/src/main/java/org/takes/facets/auth/codecs/package-info.java
+++ b/src/main/java/org/takes/facets/auth/codecs/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Codecs.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 package org.takes.facets.auth.codecs;

--- a/src/main/java/org/takes/facets/auth/package-info.java
+++ b/src/main/java/org/takes/facets/auth/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Auth.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.facets.auth;

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import lombok.EqualsAndHashCode;
  * <p>
  * The class is immutable and thread-safe.
  *
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.4
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/auth/signatures/Signature.java
+++ b/src/main/java/org/takes/facets/auth/signatures/Signature.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import java.io.IOException;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.4
  */
 public interface Signature {

--- a/src/main/java/org/takes/facets/auth/signatures/package-info.java
+++ b/src/main/java/org/takes/facets/auth/signatures/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Signatures.
  *
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.4
  */
 package org.takes.facets.auth.signatures;

--- a/src/main/java/org/takes/facets/auth/social/PsFacebook.java
+++ b/src/main/java/org/takes/facets/auth/social/PsFacebook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -53,8 +53,6 @@ import org.takes.rq.RqHref;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/main/java/org/takes/facets/auth/social/PsGithub.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGithub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -48,8 +48,6 @@ import org.takes.rq.RqHref;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.takes.rq.RqHref;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
+++ b/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.takes.rq.RqHref;
  * Linkedin OAuth landing/callback page.
  *
  * <p>The class is immutable and thread-safe.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.11.3
  */
 @EqualsAndHashCode(of = { "app", "key" })

--- a/src/main/java/org/takes/facets/auth/social/PsTwitter.java
+++ b/src/main/java/org/takes/facets/auth/social/PsTwitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Prasath Premkumar (popprem@gmail.com)
- * @version $Id$
  * @since 0.16
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/main/java/org/takes/facets/auth/social/XeFacebookLink.java
+++ b/src/main/java/org/takes/facets/auth/social/XeFacebookLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.xe.XeWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/social/XeGithubLink.java
+++ b/src/main/java/org/takes/facets/auth/social/XeGithubLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.xe.XeWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/social/XeGoogleLink.java
+++ b/src/main/java/org/takes/facets/auth/social/XeGoogleLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.xe.XeWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/auth/social/package-info.java
+++ b/src/main/java/org/takes/facets/auth/social/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Social authenticators.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 package org.takes.facets.auth.social;

--- a/src/main/java/org/takes/facets/cookies/RqCookies.java
+++ b/src/main/java/org/takes/facets/cookies/RqCookies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.rq.RqWrap;
  * HTTP cookies parsing.
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.14
  */
 public interface RqCookies extends Request {
@@ -63,8 +61,6 @@ public interface RqCookies extends Request {
      * Request decorator, for HTTP cookies parsing.
      *
      * <p>The class is immutable and thread-safe.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @version $Id$
      * @since 0.14
      */
     @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/cookies/RsWithCookie.java
+++ b/src/main/java/org/takes/facets/cookies/RsWithCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -54,8 +54,6 @@ import org.takes.rs.RsWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/cookies/TkJoinedCookies.java
+++ b/src/main/java/org/takes/facets/cookies/TkJoinedCookies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -45,8 +45,6 @@ import org.takes.tk.TkWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/cookies/package-info.java
+++ b/src/main/java/org/takes/facets/cookies/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Cookies.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 package org.takes.facets.cookies;

--- a/src/main/java/org/takes/facets/fallback/Fallback.java
+++ b/src/main/java/org/takes/facets/fallback/Fallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.misc.Opt;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see org.takes.facets.fallback.TkFallback
  * @since 0.1
  */

--- a/src/main/java/org/takes/facets/fallback/FbChain.java
+++ b/src/main/java/org/takes/facets/fallback/FbChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/fallback/FbEmpty.java
+++ b/src/main/java/org/takes/facets/fallback/FbEmpty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/fallback/FbFixed.java
+++ b/src/main/java/org/takes/facets/fallback/FbFixed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.tk.TkFixed;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/fallback/FbLog4j.java
+++ b/src/main/java/org/takes/facets/fallback/FbLog4j.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rq.RqMethod;
 
 /**
  * Fallback that logs all problems through Log4J.
- * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
- * @version $Id$
  * @since 0.25
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/fallback/FbSlf4j.java
+++ b/src/main/java/org/takes/facets/fallback/FbSlf4j.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.rq.RqMethod;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.25
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -42,9 +42,7 @@ import org.takes.tk.TkFixed;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)
@@ -83,7 +81,7 @@ public final class FbStatus extends FbWrap {
                         new RsWithBody(
                             res,
                             String.format(
-                                "%s: %s", WHITESPACE.split(
+                                "%s: %s", FbStatus.WHITESPACE.split(
                                     res.head().iterator().next(),
                                     2
                                 )[1], req.throwable().getLocalizedMessage()

--- a/src/main/java/org/takes/facets/fallback/FbWrap.java
+++ b/src/main/java/org/takes/facets/fallback/FbWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/fallback/RqFallback.java
+++ b/src/main/java/org/takes/facets/fallback/RqFallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rq.RqFake;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see TkFallback
  * @since 0.1
  */

--- a/src/main/java/org/takes/facets/fallback/TkFallback.java
+++ b/src/main/java/org/takes/facets/fallback/TkFallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -43,8 +43,6 @@ import org.takes.tk.TkWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle IllegalCatchCheck (500 lines)
  */

--- a/src/main/java/org/takes/facets/fallback/package-info.java
+++ b/src/main/java/org/takes/facets/fallback/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -48,8 +48,6 @@
  * through a series of fallbacks. The first of them who will return
  * some response will stop the chain.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.facets.fallback;

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -95,8 +95,6 @@ import org.takes.rs.RsWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/facets/flash/TkFlash.java
+++ b/src/main/java/org/takes/facets/flash/TkFlash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -55,8 +55,6 @@ import org.takes.facets.cookies.RsWithCookie;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(of = { "origin", "cookie" })

--- a/src/main/java/org/takes/facets/flash/XeFlash.java
+++ b/src/main/java/org/takes/facets/flash/XeFlash.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/flash/package-info.java
+++ b/src/main/java/org/takes/facets/flash/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -146,8 +146,6 @@
  * <p>Don't forget that the cookie you receive is not just a flash message,
  * but also other parameters, URL-encoded and separated by "slash".</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.facets.flash;

--- a/src/main/java/org/takes/facets/fork/FkAgent.java
+++ b/src/main/java/org/takes/facets/fork/FkAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rq.RqHeaders;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Valeriy Zhirnov (neonailol@gmail.com)
- * @version $Id$
  * @since 1.7.2
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/facets/fork/FkAnonymous.java
+++ b/src/main/java/org/takes/facets/fork/FkAnonymous.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -51,8 +51,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  * @see TkFork
  * @see TkRegex

--- a/src/main/java/org/takes/facets/fork/FkAuthenticated.java
+++ b/src/main/java/org/takes/facets/fork/FkAuthenticated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -51,8 +51,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  * @see TkFork
  * @see TkRegex

--- a/src/main/java/org/takes/facets/fork/FkChain.java
+++ b/src/main/java/org/takes/facets/fork/FkChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Opt;
 /**
  * A Fork chain. Routes to each given Fork in order, until one of them returns
  * a response or until none are left.
- * @author Carlos Gines (efrel.v2@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class FkChain implements Fork {

--- a/src/main/java/org/takes/facets/fork/FkContentType.java
+++ b/src/main/java/org/takes/facets/fork/FkContentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.tk.TkFixed;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  * @see RsFork
  */

--- a/src/main/java/org/takes/facets/fork/FkEncoding.java
+++ b/src/main/java/org/takes/facets/fork/FkEncoding.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -52,8 +52,6 @@ import org.takes.rq.RqHeaders;
  * in any case.
  *
  * <p>The class is immutable and thread-safe.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see org.takes.facets.fork.RsFork
  * @since 0.10
  */
@@ -94,7 +92,7 @@ public final class FkEncoding implements Fork {
             resp = new Opt.Single<Response>(this.origin);
         } else if (headers.hasNext()) {
             final Collection<String> items = Arrays.asList(
-                ENCODING_SEP.split(
+                FkEncoding.ENCODING_SEP.split(
                     new EnglishLowerCase(headers.next().trim())
                         .string()
                 )

--- a/src/main/java/org/takes/facets/fork/FkFixed.java
+++ b/src/main/java/org/takes/facets/fork/FkFixed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  * @see TkFork
  */

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -43,8 +43,6 @@ import org.takes.rq.RqHeaders;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  * @see TkFork
  */

--- a/src/main/java/org/takes/facets/fork/FkHost.java
+++ b/src/main/java/org/takes/facets/fork/FkHost.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -45,8 +45,6 @@ import org.takes.rq.RqHeaders;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see TkFork
  * @since 0.32
  */

--- a/src/main/java/org/takes/facets/fork/FkMethods.java
+++ b/src/main/java/org/takes/facets/fork/FkMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -48,8 +48,6 @@ import org.takes.tk.TkFixed;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  * @see TkFork
  */

--- a/src/main/java/org/takes/facets/fork/FkParams.java
+++ b/src/main/java/org/takes/facets/fork/FkParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rq.RqHref;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  * @see TkFork
  */

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -76,8 +76,6 @@ import org.takes.tk.TkText;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  * @see TkFork
  * @see TkRegex
@@ -220,8 +218,6 @@ public final class FkRegex implements Fork {
     /**
      * Request with a matcher inside.
      *
-     * @author Dali Freire (dalifreire@gmail.com)
-     * @version $Id$
      * @since 0.32.5
      */
     private static final class RqMatcher implements RqRegex {

--- a/src/main/java/org/takes/facets/fork/FkTypes.java
+++ b/src/main/java/org/takes/facets/fork/FkTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rq.RqHeaders;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  * @see RsFork
  */

--- a/src/main/java/org/takes/facets/fork/FkWrap.java
+++ b/src/main/java/org/takes/facets/fork/FkWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  * @see org.takes.facets.fork.RsFork
  */

--- a/src/main/java/org/takes/facets/fork/Fork.java
+++ b/src/main/java/org/takes/facets/fork/Fork.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.Opt;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public interface Fork {

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.misc.EnglishLowerCase;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  * @see org.takes.facets.fork.FkTypes
  */

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.misc.EnglishLowerCase;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  * @see org.takes.facets.fork.FkTypes
  */

--- a/src/main/java/org/takes/facets/fork/RqRegex.java
+++ b/src/main/java/org/takes/facets/fork/RqRegex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rq.RqFake;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see org.takes.facets.fork.FkRegex
  * @since 0.1
  */

--- a/src/main/java/org/takes/facets/fork/RsFork.java
+++ b/src/main/java/org/takes/facets/fork/RsFork.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.rs.RsWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/fork/TkConsumes.java
+++ b/src/main/java/org/takes/facets/fork/TkConsumes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.tk.TkWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/fork/TkFork.java
+++ b/src/main/java/org/takes/facets/fork/TkFork.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -56,8 +56,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  * @see org.takes.facets.fork.FkMethods
  * @see org.takes.facets.fork.FkRegex

--- a/src/main/java/org/takes/facets/fork/TkMethods.java
+++ b/src/main/java/org/takes/facets/fork/TkMethods.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.tk.TkWrap;
  * Take that acts on request with specified methods only.
  * <p>The class is immutable and thread-safe.
  *
- * @author Aleksey Popov (alopen@yandex.ru)
- * @version $Id$
  * @since 0.16.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/fork/TkProduces.java
+++ b/src/main/java/org/takes/facets/fork/TkProduces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.tk.TkWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
- * @version $Id$
  * @since 0.14
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/fork/TkRegex.java
+++ b/src/main/java/org/takes/facets/fork/TkRegex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Take;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public interface TkRegex {

--- a/src/main/java/org/takes/facets/fork/am/AgentMatch.java
+++ b/src/main/java/org/takes/facets/fork/am/AgentMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ package org.takes.facets.fork.am;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Valeriy Zhirnov (neonailol@gmail.com)
- * @version $Id$
  * @since 1.7.2
  */
 public interface AgentMatch {

--- a/src/main/java/org/takes/facets/fork/am/AmVersion.java
+++ b/src/main/java/org/takes/facets/fork/am/AmVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -26,8 +26,6 @@ package org.takes.facets.fork.am;
 /**
  * Matches specified version.
  *
- * @author Valeriy Zhirnov (neonailol@gmail.com)
- * @version $Id$
  * @since 1.7.2
  */
 public final class AmVersion implements AgentMatch {
@@ -79,8 +77,6 @@ public final class AmVersion implements AgentMatch {
     /**
      * Matches specified version when it greater than specified one.
      *
-     * @author Valeriy Zhirnov (neonailol@gmail.com)
-     * @version $Id$
      * @since 1.7.2
      */
     public static final class VmGreater implements VersionMatch {

--- a/src/main/java/org/takes/facets/fork/am/VersionMatch.java
+++ b/src/main/java/org/takes/facets/fork/am/VersionMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -26,8 +26,6 @@ package org.takes.facets.fork.am;
 /**
  * Version match.
  *
- * @author Valeriy Zhirnov (neonailol@gmail.com)
- * @version $Id$
  * @since 1.7.2
  */
 public interface VersionMatch {

--- a/src/main/java/org/takes/facets/fork/am/package-info.java
+++ b/src/main/java/org/takes/facets/fork/am/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Agent Matcher.
  *
- * @author Valeriy Zhirnov (neonailol@gmail.com)
- * @version $Id$
  * @since 1.7.2
  */
 package org.takes.facets.fork.am;

--- a/src/main/java/org/takes/facets/fork/package-info.java
+++ b/src/main/java/org/takes/facets/fork/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Fork.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 package org.takes.facets.fork;

--- a/src/main/java/org/takes/facets/forward/RsFailure.java
+++ b/src/main/java/org/takes/facets/forward/RsFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.facets.flash.RsFlash;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.18
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/forward/RsForward.java
+++ b/src/main/java/org/takes/facets/forward/RsForward.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rs.RsWithoutHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true, of = "origin")

--- a/src/main/java/org/takes/facets/forward/TkForward.java
+++ b/src/main/java/org/takes/facets/forward/TkForward.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.rs.RsSimple;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @see org.takes.facets.forward.TkForward
  */

--- a/src/main/java/org/takes/facets/forward/package-info.java
+++ b/src/main/java/org/takes/facets/forward/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -76,8 +76,6 @@
  * all exceptions of type {@link org.takes.facets.forward.RsForward} and
  * convert them to responses.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.facets.forward;

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
  * <p>This "matcher" tests given item body, assuming that it has text content.
  * <p>The class is immutable and thread-safe.
  *
- * @author Izbassar Tolegen (t.izbassar@gmail.com)
- * @version $Id$
  * @param <T> Item type. Should be able to return own body
  * @since 2.0
  */

--- a/src/main/java/org/takes/facets/hamcrest/HmBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.Body;
  *
  * <p>This "matcher" tests given item body</p>
  *
- * @author Tolegen Izbassar (t.izbassar@gmail.com)
- * @version $Id$
  * @param <T> Item type. Should be able to return own item
  * @since 2.0
  */

--- a/src/main/java/org/takes/facets/hamcrest/HmHeader.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,11 +40,6 @@ import org.takes.Head;
  * <p>This "matcher" tests given item headers.
  * <p>The class is immutable and thread-safe.
  *
- * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
- * @author I. Sokolov (happy.neko@gmail.com)
- * @author Andrey Eliseev (aeg.exper0@gmail.com)
- * @author Paulo Lobo (pauloeduardolobo@gmail.com)
- * @version $Id$
  * @param <T> Item type. Should be able to return own headers
  * @since 0.31.2
  */

--- a/src/main/java/org/takes/facets/hamcrest/HmRqTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqTextBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.Request;
  * assuming that it has text content.</p>
  * <p>The class is immutable and thread-safe.
  *
- * @author Izbassar Tolegen (t.izbassar@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class HmRqTextBody extends AbstractHmTextBody<Request> {

--- a/src/main/java/org/takes/facets/hamcrest/HmRsStatus.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,9 +35,6 @@ import org.takes.Response;
  * <p>This "matcher" tests given response status code.
  * <p>The class is immutable and thread-safe.
  *
- * @author Erim Erturk (erimerturk@gmail.com)
- * @author Andrey Eliseev (aeg.exper0@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class HmRsStatus extends FeatureMatcher<Response, Integer> {

--- a/src/main/java/org/takes/facets/hamcrest/HmRsTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsTextBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.Response;
  * assuming that it has text content.</p>
  * <p>The class is immutable and thread-safe.
  *
- * @author Izbassar Tolegen (t.izbassar@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class HmRsTextBody extends AbstractHmTextBody<Response> {

--- a/src/main/java/org/takes/facets/hamcrest/package-info.java
+++ b/src/main/java/org/takes/facets/hamcrest/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@
  *   }
  * }</pre>
  *
- * @author Erim Erturk (erimerturk@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 package org.takes.facets.hamcrest;

--- a/src/main/java/org/takes/facets/previous/RsPrevious.java
+++ b/src/main/java/org/takes/facets/previous/RsPrevious.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsWrap;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.10
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/previous/TkPrevious.java
+++ b/src/main/java/org/takes/facets/previous/TkPrevious.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.rs.RsRedirect;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.10
  */
 @ToString

--- a/src/main/java/org/takes/facets/previous/package-info.java
+++ b/src/main/java/org/takes/facets/previous/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -43,8 +43,6 @@
  * <p>Then, you decorate your application with
  * {@link org.takes.facets.previous.TkPrevious} and that's it.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 package org.takes.facets.previous;

--- a/src/main/java/org/takes/facets/ret/RsReturn.java
+++ b/src/main/java/org/takes/facets/ret/RsReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.RsWrap;
 /**
  * Response decorator which sets cookie with return location.
  *
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.20
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/facets/ret/TkReturn.java
+++ b/src/main/java/org/takes/facets/ret/TkReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rs.RsRedirect;
  * is set, sends redirect response to stored location.
  * Otherwise delegates to original Take.
  *
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.20
  */
 @ToString(of = { "origin", "cookie" })

--- a/src/main/java/org/takes/facets/ret/package-info.java
+++ b/src/main/java/org/takes/facets/ret/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Returns.
  *
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.20
  */
 package org.takes.facets.ret;

--- a/src/main/java/org/takes/http/Back.java
+++ b/src/main/java/org/takes/http/Back.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import java.net.Socket;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Back {

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -49,8 +49,6 @@ import org.takes.rs.RsWithStatus;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle IndentationCheck (500 lines)

--- a/src/main/java/org/takes/http/BkParallel.java
+++ b/src/main/java/org/takes/http/BkParallel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import lombok.EqualsAndHashCode;
  * <p>
  * The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/http/BkSafe.java
+++ b/src/main/java/org/takes/http/BkSafe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/http/BkTimeable.java
+++ b/src/main/java/org/takes/http/BkTimeable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import lombok.EqualsAndHashCode;
  * Back decorator with maximum lifetime.
  *
  * <p>The class is immutable and thread-safe.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.14.2
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/http/BkWrap.java
+++ b/src/main/java/org/takes/http/BkWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import lombok.EqualsAndHashCode;
 
 /**
  * Back Wrap.
- * @author Hamdi Douss (douss.hamdi@gmail.com)
- * @version $Id$
  * @since 0.28
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/http/Exit.java
+++ b/src/main/java/org/takes/http/Exit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ package org.takes.http;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Exit {

--- a/src/main/java/org/takes/http/Front.java
+++ b/src/main/java/org/takes/http/Front.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import java.io.IOException;
  *
  * <p>All implementations of this interface must be thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface Front {

--- a/src/main/java/org/takes/http/FtBasic.java
+++ b/src/main/java/org/takes/http/FtBasic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Take;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/http/FtCli.java
+++ b/src/main/java/org/takes/http/FtCli.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -52,8 +52,6 @@ import org.takes.rq.RqWithHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
  */
@@ -156,8 +154,6 @@ public final class FtCli implements Front {
     /**
      * Lifetime exceeded exit.
      *
-     * @author Dali Freire (dalifreire@gmail.com)
-     * @version $Id$
      * @since 0.32.5
      */
     private static final class Lifetime implements Exit {

--- a/src/main/java/org/takes/http/FtRemote.java
+++ b/src/main/java/org/takes/http/FtRemote.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.Take;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/main/java/org/takes/http/FtSecure.java
+++ b/src/main/java/org/takes/http/FtSecure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.Take;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Dragan Bozanovic (bozanovicdr@gmail.com)
- * @version $Id$
  * @since 0.25
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.23
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
@@ -177,8 +175,6 @@ public final class MainRemote {
     /**
      * Runnable main method.
      *
-     * @author Dali Freire (dalifreire@gmail.com)
-     * @version $Id$
      * @since 0.32.5
      */
     private static final class MainMethod implements Runnable {

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -44,8 +44,6 @@ import org.takes.misc.Utf8OutputStreamWriter;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/http/package-info.java
+++ b/src/main/java/org/takes/http/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * HTTP server.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.http;

--- a/src/main/java/org/takes/misc/Concat.java
+++ b/src/main/java/org/takes/misc/Concat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import java.util.Iterator;
  * Concatenating iterables. It produces an iterable collection combining A and
  * B, with order of the elements in A first.
  *
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @param <T> Type of items
  * @since 0.15.2
  */

--- a/src/main/java/org/takes/misc/EnglishLowerCase.java
+++ b/src/main/java/org/takes/misc/EnglishLowerCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -27,8 +27,6 @@ import java.util.Locale;
 
 /**
  * English lower case string representation.
- * @author Dali Freire (dalifreire@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class EnglishLowerCase {

--- a/src/main/java/org/takes/misc/EntryImpl.java
+++ b/src/main/java/org/takes/misc/EntryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import java.util.Map;
  * An immutable and thread-safe implementation of
  * {@link Map.Entry} interface.
  *
- * @author Dragan Bozanovic (bozanovicdr@gmail.com)
- * @version $Id$
  * @param <K> Key type
  * @param <V> Value type
  * @since 0.27

--- a/src/main/java/org/takes/misc/Expires.java
+++ b/src/main/java/org/takes/misc/Expires.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import java.util.TimeZone;
 /**
  * Expiration date in GMT.
  *
- * @author Paulo Lobo (pauloeduardolobo@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public interface Expires {
@@ -102,8 +100,6 @@ public interface Expires {
     /**
      * Expiration date in GMT.
      *
-     * @author Izbassar Tolegen (t.izbassar@gmail.com)
-     * @version $Id$
      * @since 2.0
      */
     final class Date implements Expires {

--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import java.util.regex.Pattern;
  * HTTP URI/HREF.
  *
  * <p>The class is immutable and thread-safe.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.7
  */
 @SuppressWarnings

--- a/src/main/java/org/takes/misc/Opt.java
+++ b/src/main/java/org/takes/misc/Opt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import lombok.EqualsAndHashCode;
  * Replacement a nullable T reference with a non-null value.
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @param <T> Type of item
  * @since 0.14
  */
@@ -52,8 +50,6 @@ public interface Opt<T> {
      * Holder for a single element only.
      *
      * <p>The class is immutable and thread-safe.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @version $Id$
      * @since 0.14
      * @param <T> Type of item
      */
@@ -84,8 +80,6 @@ public interface Opt<T> {
      * Empty instance.
      *
      * <p>The class is immutable and thread-safe.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @version $Id$
      * @param <T> Type of item
      * @since 0.14
      */

--- a/src/main/java/org/takes/misc/Sprintf.java
+++ b/src/main/java/org/takes/misc/Sprintf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import java.util.Formatter;
 /**
  * Sprintf in a class.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class Sprintf implements CharSequence {

--- a/src/main/java/org/takes/misc/Transform.java
+++ b/src/main/java/org/takes/misc/Transform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ import java.util.Iterator;
 /**
  * Transform elements in an iterable (in type T) into others (in type K).
  *
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @param <T> Type of item
  * @param <K> Type of key
  * @since 0.15.2

--- a/src/main/java/org/takes/misc/TransformAction.java
+++ b/src/main/java/org/takes/misc/TransformAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -26,8 +26,6 @@ package org.takes.misc;
 /**
  * Action for {@link Transform} to perform actual transformation.
  *
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @param <T> Type of item
  * @param <K> Type of key
  * @since 0.15.2

--- a/src/main/java/org/takes/misc/Utf8InputStreamReader.java
+++ b/src/main/java/org/takes/misc/Utf8InputStreamReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * InputStreamReader that uses UTF-8 encoding for all operations.
- * @author Dali Freire (dalifreire@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public class Utf8InputStreamReader extends InputStreamReader {

--- a/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
+++ b/src/main/java/org/takes/misc/Utf8OutputStreamWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * OutputStreamWriter that uses UTF-8 encoding for all operations.
- * @author Dali Freire (dalifreire@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public class Utf8OutputStreamWriter extends OutputStreamWriter {

--- a/src/main/java/org/takes/misc/Utf8PrintStream.java
+++ b/src/main/java/org/takes/misc/Utf8PrintStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * PrintStream that uses UTF-8 encoding for all operations.
- * @author Dali Freire (dalifreire@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public class Utf8PrintStream extends PrintStream {

--- a/src/main/java/org/takes/misc/Utf8String.java
+++ b/src/main/java/org/takes/misc/Utf8String.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -27,8 +27,6 @@ import java.nio.charset.Charset;
 
 /**
  * String that uses UTF-8 encoding for all byte operations.
- * @author Maksimenko Vladimir (xupypr@xupypr.com)
- * @version $Id$
  * @since 0.33
  */
 public final class Utf8String {

--- a/src/main/java/org/takes/misc/VerboseIterable.java
+++ b/src/main/java/org/takes/misc/VerboseIterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ import java.util.Iterator;
 /**
  * Verbose iterable.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <T> Type of item
  * @since 0.10
  */

--- a/src/main/java/org/takes/misc/VerboseIterator.java
+++ b/src/main/java/org/takes/misc/VerboseIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import java.util.NoSuchElementException;
 /**
  * Verbose iterator.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @param <T> Type of item
  * @since 0.10
  */

--- a/src/main/java/org/takes/misc/VerboseList.java
+++ b/src/main/java/org/takes/misc/VerboseList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import java.util.ListIterator;
 /**
  * Verbose List that wraps OutOfBoundsException with custom message.
  *
- * @author I. Sokolov (happy.neko@gmail.com)
- * @version $Id$
  * @param <T> Type of item
  * @since 0.31.1
  */

--- a/src/main/java/org/takes/misc/package-info.java
+++ b/src/main/java/org/takes/misc/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Miscellaneous classes.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 package org.takes.misc;

--- a/src/main/java/org/takes/package-info.java
+++ b/src/main/java/org/takes/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@
  * working with the framework, check out our introduction page in Github:
  * <a href="https://github.com/yegor256/take">README</a>.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @see <a href="http://www.takes.org">project site www.takes.org</a>
  * @see <a href="https://github.com/yegor256/take">Github project</a>

--- a/src/main/java/org/takes/rq/CapInputStream.java
+++ b/src/main/java/org/takes/rq/CapInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import java.io.InputStream;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 final class CapInputStream extends InputStream {

--- a/src/main/java/org/takes/rq/ChunkedInputStream.java
+++ b/src/main/java/org/takes/rq/ChunkedInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import java.nio.charset.Charset;
 /**
  * Input stream from chunked coded http request body.
  *
- * @author Maksimenko Vladimir (xupypr@xupypr.com)
- * @version $Id$
  * @since 0.31.2
  * @checkstyle LineLengthCheck (1 lines)
  * @link <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6.1">Chunked Transfer Coding</a>

--- a/src/main/java/org/takes/rq/RqBuffered.java
+++ b/src/main/java/org/takes/rq/RqBuffered.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqChunk.java
+++ b/src/main/java/org/takes/rq/RqChunk.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Hamdi Douss (douss.hamdi@gmail.com)
- * @version $Id$
  * @since 0.15
  * @see org.takes.rq.RqPrint
  */

--- a/src/main/java/org/takes/rq/RqFake.java
+++ b/src/main/java/org/takes/rq/RqFake.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqForm.java
+++ b/src/main/java/org/takes/rq/RqForm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @see <a href="http://www.w3.org/TR/html401/interact/forms.html">
  *     Forms in HTML</a>
  * @see org.takes.rq.RqGreedy

--- a/src/main/java/org/takes/rq/RqGreedy.java
+++ b/src/main/java/org/takes/rq/RqGreedy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -45,8 +45,6 @@ import org.takes.misc.VerboseList;
  * <p>All implementations of this interface must be immutable and
  * thread-safe.</p>
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @SuppressWarnings("PMD.TooManyMethods")
@@ -74,8 +72,6 @@ public interface RqHeaders extends Request {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Yury Lauresh (lavresh@gmail.com)
-     * @version $Id$
      * @since 0.13.8
      */
     @EqualsAndHashCode(callSuper = true)
@@ -166,7 +162,6 @@ public interface RqHeaders extends Request {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Yegor Bugayenko (yegor256@gmail.com)
      * @since 0.16
      */
     @EqualsAndHashCode

--- a/src/main/java/org/takes/rq/RqHref.java
+++ b/src/main/java/org/takes/rq/RqHref.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.misc.Href;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public interface RqHref extends Request {
@@ -55,8 +53,6 @@ public interface RqHref extends Request {
      * Request decorator, for HTTP URI query parsing.
      *
      * <p>The class is immutable and thread-safe.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @version $Id$
      * @since 0.13.1
      */
     @EqualsAndHashCode(callSuper = true)
@@ -96,7 +92,6 @@ public interface RqHref extends Request {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Yegor Bugayenko (yegor256@gmail.com)
      * @since 0.14
      */
     @EqualsAndHashCode

--- a/src/main/java/org/takes/rq/RqLengthAware.java
+++ b/src/main/java/org/takes/rq/RqLengthAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -45,8 +45,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.15
  * @see org.takes.rq.RqMultipart
  * @see org.takes.rq.RqPrint

--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqMethod.java
+++ b/src/main/java/org/takes/rq/RqMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.Request;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13.7
  */
 public interface RqMethod extends Request {
@@ -97,8 +95,6 @@ public interface RqMethod extends Request {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @version $Id$
      * @since 0.13.7
      */
     @EqualsAndHashCode(callSuper = true)
@@ -123,7 +119,7 @@ public interface RqMethod extends Request {
         public String method() throws IOException {
             final String method = new RqRequestLine.Base(this)
                 .method();
-            if (SEPARATORS.matcher(method).find()) {
+            if (Base.SEPARATORS.matcher(method).find()) {
                 throw new IOException(
                     String.format("Invalid HTTP method: %s", method)
                 );

--- a/src/main/java/org/takes/rq/RqMultipart.java
+++ b/src/main/java/org/takes/rq/RqMultipart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.takes.Request;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public interface RqMultipart extends Request {

--- a/src/main/java/org/takes/rq/RqOnce.java
+++ b/src/main/java/org/takes/rq/RqOnce.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.36
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqPrint.java
+++ b/src/main/java/org/takes/rq/RqPrint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqRequestLine.java
+++ b/src/main/java/org/takes/rq/RqRequestLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.Request;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Vladimir Maksimenko (xupypr@xupypr.com)
- * @version $Id$
  * @since 0.29.1
  */
 @SuppressWarnings("PMD.TooManyMethods")
@@ -75,8 +73,6 @@ public interface RqRequestLine extends Request {
      * Request decorator for Request-Line header validation
      *
      * <p>The class is immutable and thread-safe.
-     * @author Vladimir Maksimenko (xupypr@xupypr.com)
-     * @version $Id$
      * @since 1.0
      */
     @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqSimple.java
+++ b/src/main/java/org/takes/rq/RqSimple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqWithBody.java
+++ b/src/main/java/org/takes/rq/RqWithBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Utf8String;
  * Request with body.
  *
  * <p>The class is immutable and thread-safe.
- * @author Erim Erturk (erimerturk@gmail.com)
- * @version $Id$
  * @since 0.22
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqWithDefaultHeader.java
+++ b/src/main/java/org/takes/rq/RqWithDefaultHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -28,8 +28,6 @@ import org.takes.Request;
 
 /**
  * Request with default header.
- * @author Andrey Eliseev (aeg.exper0@gmail.com)
- * @version $Id$
  * @since 0.31
  */
 public final class RqWithDefaultHeader extends RqWrap {

--- a/src/main/java/org/takes/rq/RqWithHeader.java
+++ b/src/main/java/org/takes/rq/RqWithHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqWithHeaders.java
+++ b/src/main/java/org/takes/rq/RqWithHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqWithoutHeader.java
+++ b/src/main/java/org/takes/rq/RqWithoutHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.misc.EnglishLowerCase;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rq/RqWrap.java
+++ b/src/main/java/org/takes/rq/RqWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Request;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/rq/TempInputStream.java
+++ b/src/main/java/org/takes/rq/TempInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import java.nio.file.Paths;
 /**
  * Input stream wrapper that removes associated File instance on close.
  *
- * @author Andrey Eliseev (aeg.exper0@gmail.com)
- * @version $Id$
  * @since 0.31
  */
 public final class TempInputStream extends InputStream {

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -46,8 +46,6 @@ import org.takes.rq.RqWrap;
 
 /**
  * Base implementation of {@link RqForm}.
- * @author Aleksey Popov (alopen@yandex.ru)
- * @version $Id$
  * @since 0.33
  */
 @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")

--- a/src/main/java/org/takes/rq/form/RqFormFake.java
+++ b/src/main/java/org/takes/rq/form/RqFormFake.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rq.RqWithBody;
 
 /**
  * RqFormFake accepts parameters in the constructor.
- * @author Erim Erturk (erimerturk@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqFormFake implements RqForm {

--- a/src/main/java/org/takes/rq/form/RqFormSmart.java
+++ b/src/main/java/org/takes/rq/form/RqFormSmart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rq.RqForm;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/rq/form/package-info.java
+++ b/src/main/java/org/takes/rq/form/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -78,8 +78,6 @@
  * new RqFormSmart(base).single("alpha")
  * }
  * </pre>
- * @author Rui Castro (rui.castro@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 package org.takes.rq.form;

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -64,8 +64,6 @@ import org.takes.rq.RqMultipart;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.33
  * @see <a href="http://www.w3.org/TR/html401/interact/forms.html">
  *  Forms in HTML</a>

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rq.RqWithHeaders;
 
 /**
  * Fake decorator.
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqMtFake implements RqMultipart {

--- a/src/main/java/org/takes/rq/multipart/RqMtSmart.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtSmart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rq.RqMultipart;
 
 /**
  * Smart decorator.
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqMtSmart implements RqMultipart {

--- a/src/main/java/org/takes/rq/multipart/RqTemp.java
+++ b/src/main/java/org/takes/rq/multipart/RqTemp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rq.TempInputStream;
 /**
  * Request with a temporary file as body. The temporary file will be deleted
  * automatically when the body of the request will be closed.
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  * @see org.takes.rq.RqLive
  * @see org.takes.rq.TempInputStream

--- a/src/main/java/org/takes/rq/multipart/package-info.java
+++ b/src/main/java/org/takes/rq/multipart/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Implementations of the interface {@link org.takes.rq.RqMultipart}.
  *
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 package org.takes.rq.multipart;

--- a/src/main/java/org/takes/rq/package-info.java
+++ b/src/main/java/org/takes/rq/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Requests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.rq;

--- a/src/main/java/org/takes/rs/Body.java
+++ b/src/main/java/org/takes/rs/Body.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * The body of a response used by {@link RsWithBody}.
  *
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.32
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/main/java/org/takes/rs/RsBuffered.java
+++ b/src/main/java/org/takes/rs/RsBuffered.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsEmpty.java
+++ b/src/main/java/org/takes/rs/RsEmpty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString

--- a/src/main/java/org/takes/rs/RsFluent.java
+++ b/src/main/java/org/takes/rs/RsFluent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsGzip.java
+++ b/src/main/java/org/takes/rs/RsGzip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @ToString(of = "origin")

--- a/src/main/java/org/takes/rs/RsHtml.java
+++ b/src/main/java/org/takes/rs/RsHtml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsJson.java
+++ b/src/main/java/org/takes/rs/RsJson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -44,8 +44,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 @ToString(of = "origin")

--- a/src/main/java/org/takes/rs/RsPrettyXml.java
+++ b/src/main/java/org/takes/rs/RsPrettyXml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -50,8 +50,6 @@ import org.xml.sax.XMLReader;
  * Response with properly indented XML body.
  *
  * <p>The class is immutable and thread-safe.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 @ToString(of = "origin")

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsRedirect.java
+++ b/src/main/java/org/takes/rs/RsRedirect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsSimple.java
+++ b/src/main/java/org/takes/rs/RsSimple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsText.java
+++ b/src/main/java/org/takes/rs/RsText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsVelocity.java
+++ b/src/main/java/org/takes/rs/RsVelocity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -63,8 +63,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -42,8 +42,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.1
  */

--- a/src/main/java/org/takes/rs/RsWithHeader.java
+++ b/src/main/java/org/takes/rs/RsWithHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -52,8 +52,6 @@ import org.takes.misc.Concat;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsWithStatus.java
+++ b/src/main/java/org/takes/rs/RsWithStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.misc.Concat;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Opt;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)
@@ -130,8 +128,6 @@ public final class RsWithType extends RsWrap {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Eléna Ihde-Simon (elena.ihde-simon@posteo.de)
-     * @version $Id$
      * @since 0.30
      */
     public static final class Html extends RsWrap {
@@ -175,8 +171,6 @@ public final class RsWithType extends RsWrap {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Eléna Ihde-Simon (elena.ihde-simon@posteo.de)
-     * @version $Id$
      * @since 0.30
      */
     public static final class Json extends RsWrap {
@@ -220,8 +214,6 @@ public final class RsWithType extends RsWrap {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Eléna Ihde-Simon (elena.ihde-simon@posteo.de)
-     * @version $Id$
      * @since 0.30
      */
     public static final class Xml extends RsWrap {
@@ -265,8 +257,6 @@ public final class RsWithType extends RsWrap {
      *
      * <p>The class is immutable and thread-safe.
      *
-     * @author Eléna Ihde-Simon (elena.ihde-simon@posteo.de)
-     * @version $Id$
      * @since 0.30
      */
     public static final class Text extends RsWrap {

--- a/src/main/java/org/takes/rs/RsWithoutHeader.java
+++ b/src/main/java/org/takes/rs/RsWithoutHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.misc.EnglishLowerCase;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/rs/RsWrap.java
+++ b/src/main/java/org/takes/rs/RsWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.Response;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(of = "origin")

--- a/src/main/java/org/takes/rs/RsXslt.java
+++ b/src/main/java/org/takes/rs/RsXslt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -78,8 +78,6 @@ import org.takes.misc.Utf8String;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @see org.takes.rs.xe.RsXembly

--- a/src/main/java/org/takes/rs/package-info.java
+++ b/src/main/java/org/takes/rs/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Responses.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.rs;

--- a/src/main/java/org/takes/rs/xe/RsXembly.java
+++ b/src/main/java/org/takes/rs/xe/RsXembly.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -55,8 +55,6 @@ import org.xembly.Xembler;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/main/java/org/takes/rs/xe/XeAppend.java
+++ b/src/main/java/org/takes/rs/xe/XeAppend.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeChain.java
+++ b/src/main/java/org/takes/rs/xe/XeChain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeDate.java
+++ b/src/main/java/org/takes/rs/xe/XeDate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -54,8 +54,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeDirectives.java
+++ b/src/main/java/org/takes/rs/xe/XeDirectives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.xembly.SyntaxException;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/rs/xe/XeLifetime.java
+++ b/src/main/java/org/takes/rs/xe/XeLifetime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.7
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeLink.java
+++ b/src/main/java/org/takes/rs/xe/XeLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeLinkHome.java
+++ b/src/main/java/org/takes/rs/xe/XeLinkHome.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.xembly.Directive;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeLinkSelf.java
+++ b/src/main/java/org/takes/rs/xe/XeLinkSelf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.xembly.Directive;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeLocalhost.java
+++ b/src/main/java/org/takes/rs/xe/XeLocalhost.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -51,8 +51,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeMemory.java
+++ b/src/main/java/org/takes/rs/xe/XeMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -51,8 +51,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.2
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeMillis.java
+++ b/src/main/java/org/takes/rs/xe/XeMillis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -53,8 +53,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/rs/xe/XeSla.java
+++ b/src/main/java/org/takes/rs/xe/XeSla.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -50,8 +50,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeSource.java
+++ b/src/main/java/org/takes/rs/xe/XeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.xembly.Directive;
  *
  * <p>All implementations of this interface must be immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public interface XeSource {

--- a/src/main/java/org/takes/rs/xe/XeStylesheet.java
+++ b/src/main/java/org/takes/rs/xe/XeStylesheet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.xembly.Directives;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle LineLengthCheck (2 lines)
  * @see <a href="http://www.yegor256.com/2014/06/25/xml-and-xslt-in-browser.html">XML+XSLT in a Browser</a>

--- a/src/main/java/org/takes/rs/xe/XeTransform.java
+++ b/src/main/java/org/takes/rs/xe/XeTransform.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -59,8 +59,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @param <T> Type of item
  */

--- a/src/main/java/org/takes/rs/xe/XeWhen.java
+++ b/src/main/java/org/takes/rs/xe/XeWhen.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.xembly.Directive;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/takes/rs/xe/XeWrap.java
+++ b/src/main/java/org/takes/rs/xe/XeWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.xembly.Directive;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 @EqualsAndHashCode

--- a/src/main/java/org/takes/rs/xe/package-info.java
+++ b/src/main/java/org/takes/rs/xe/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Xembly responses.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.rs.xe;

--- a/src/main/java/org/takes/servlet/ResponseOf.java
+++ b/src/main/java/org/takes/servlet/ResponseOf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.Response;
 /**
  * Takes response as servlet response.
  *
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id $
  * @since 2.0
  * @todo #682:30min Servlet request and response adapters are not unit-tested.
  *  There should be tests for reading headers and body from servlet request

--- a/src/main/java/org/takes/servlet/RqFrom.java
+++ b/src/main/java/org/takes/servlet/RqFrom.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Request;
 /**
  * Request from {@link HttpServletRequest}.
  *
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id $
  * @since 2.0
  */
 final class RqFrom implements Request {

--- a/src/main/java/org/takes/servlet/SrvTake.java
+++ b/src/main/java/org/takes/servlet/SrvTake.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.Take;
 /**
  * Servlet for take.
  *
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id $
  * @since 2.0
  * @todo #682:30min Continue to integrate with Servlet API,
  *  see https://github.com/yegor256/takes/pull/836 discussion for details.

--- a/src/main/java/org/takes/servlet/package-info.java
+++ b/src/main/java/org/takes/servlet/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Servlet (javax) integration.
  *
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id $
  * @since 2.0
  */
 package org.takes.servlet;

--- a/src/main/java/org/takes/tk/TkClasspath.java
+++ b/src/main/java/org/takes/tk/TkClasspath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -54,8 +54,6 @@ import org.takes.rs.RsWithBody;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.takes.rs.RsWithStatus;
  * following <a href="http://www.w3.org/TR/cors/">link</a> or even on the <a
  * href="https://tools.ietf.org/html/rfc6454">RFC-6454</a> specification.
  *
- * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id$
  * @since 0.20
  */
 @ToString(of = { "origin", "allowed" })

--- a/src/main/java/org/takes/tk/TkEmpty.java
+++ b/src/main/java/org/takes/tk/TkEmpty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.RsEmpty;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString

--- a/src/main/java/org/takes/tk/TkFailure.java
+++ b/src/main/java/org/takes/tk/TkFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.Take;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkFiles.java
+++ b/src/main/java/org/takes/tk/TkFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -55,8 +55,6 @@ import org.takes.rs.RsWithBody;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkFixed.java
+++ b/src/main/java/org/takes/tk/TkFixed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.rs.RsText;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkGreedy.java
+++ b/src/main/java/org/takes/tk/TkGreedy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rq.RqGreedy;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkGzip.java
+++ b/src/main/java/org/takes/tk/TkGzip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsGzip;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkHtml.java
+++ b/src/main/java/org/takes/tk/TkHtml.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -42,8 +42,6 @@ import org.takes.rs.RsHtml;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkMeasured.java
+++ b/src/main/java/org/takes/tk/TkMeasured.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.RsWithHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkOnce.java
+++ b/src/main/java/org/takes/tk/TkOnce.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rq.RqGreedy;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.26
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkProxy.java
+++ b/src/main/java/org/takes/tk/TkProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -49,8 +49,6 @@ import org.takes.rs.RsWithStatus;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Dragan Bozanovic (bozanovicdr@gmail.com)
- * @version $Id$
  * @since 0.25
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/main/java/org/takes/tk/TkReadAlways.java
+++ b/src/main/java/org/takes/tk/TkReadAlways.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Take;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Dan Baleanu (dan.baleanu@gmail.com)
- * @version $Id$
  * @since 0.30
  */
 @ToString(of = {"origin"})

--- a/src/main/java/org/takes/tk/TkRedirect.java
+++ b/src/main/java/org/takes/tk/TkRedirect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.RsRedirect;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkRetry.java
+++ b/src/main/java/org/takes/tk/TkRetry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.misc.TransformAction;
  * Decorator TkRetry, which will not fail immediately on IOException, but
  * will retry a few times.
  *
- * @author Hamdi Douss (douss.hamdi@gmail.com)
- * @version $Id$
  * @since 0.28.3
  */
 public final class TkRetry implements Take {

--- a/src/main/java/org/takes/tk/TkSlf4j.java
+++ b/src/main/java/org/takes/tk/TkSlf4j.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,9 +40,6 @@ import org.takes.rq.RqMethod;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11.2
  */
 @ToString(of = { "origin", "target" })

--- a/src/main/java/org/takes/tk/TkSmartRedirect.java
+++ b/src/main/java/org/takes/tk/TkSmartRedirect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.rs.RsRedirect;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.9
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkSslOnly.java
+++ b/src/main/java/org/takes/tk/TkSslOnly.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsRedirect;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.9
  */
 @ToString

--- a/src/main/java/org/takes/tk/TkText.java
+++ b/src/main/java/org/takes/tk/TkText.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -42,8 +42,6 @@ import org.takes.rs.RsText;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkVerbose.java
+++ b/src/main/java/org/takes/tk/TkVerbose.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rq.RqMethod;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkVersioned.java
+++ b/src/main/java/org/takes/tk/TkVersioned.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsWithHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkWithCookie.java
+++ b/src/main/java/org/takes/tk/TkWithCookie.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.facets.cookies.RsWithCookie;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkWithHeader.java
+++ b/src/main/java/org/takes/tk/TkWithHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.rs.RsWithHeader;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkWithHeaders.java
+++ b/src/main/java/org/takes/tk/TkWithHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rs.RsWithHeaders;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkWithType.java
+++ b/src/main/java/org/takes/tk/TkWithType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.rs.RsWithType;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @ToString(callSuper = true)

--- a/src/main/java/org/takes/tk/TkWrap.java
+++ b/src/main/java/org/takes/tk/TkWrap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Take;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 @ToString(of = "origin")

--- a/src/main/java/org/takes/tk/package-info.java
+++ b/src/main/java/org/takes/tk/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Take.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.tk;

--- a/src/test/java/org/takes/facets/auth/IdentityTest.java
+++ b/src/test/java/org/takes/facets/auth/IdentityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link Identity}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  */
 public final class IdentityTest {

--- a/src/test/java/org/takes/facets/auth/PsAllTest.java
+++ b/src/test/java/org/takes/facets/auth/PsAllTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rs.RsEmpty;
 
 /**
  * Test of {@link PsAll}.
- * @author Georgy Vlasov (wlasowegor@gmail.com)
- * @version $Id$
  * @since 0.22
  */
 public final class PsAllTest {

--- a/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Unit tests for {@link org.takes.facets.auth.PsBasic.Default}.
- * @author Georgy Vlasov (wlasowegor@gmail.com)
- * @version $Id$
  * @since 0.22
  */
 public final class PsBasicDefaultTest {

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -44,8 +44,6 @@ import org.takes.tk.TkText;
 
 /**
  * Test of {@link PsBasic}.
- * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id$
  * @since 0.20
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/auth/PsByFlagTest.java
+++ b/src/test/java/org/takes/facets/auth/PsByFlagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.rs.RsWithType;
 
 /**
  * Test case for {@link PsByFlag}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class PsByFlagTest {

--- a/src/test/java/org/takes/facets/auth/PsChainTest.java
+++ b/src/test/java/org/takes/facets/auth/PsChainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.rs.RsEmpty;
 
 /**
  * Test case for {@link PsChain}.
- * @author Aleksey Kurochka (eg04lt3r@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 public final class PsChainTest {

--- a/src/test/java/org/takes/facets/auth/PsCookieTest.java
+++ b/src/test/java/org/takes/facets/auth/PsCookieTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link PsCookie}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class PsCookieTest {

--- a/src/test/java/org/takes/facets/auth/RqAuthTest.java
+++ b/src/test/java/org/takes/facets/auth/RqAuthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rq.RqWithHeader;
 
 /**
  * Test case for {@link RqAuth}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.9.12
  */
 public class RqAuthTest {

--- a/src/test/java/org/takes/facets/auth/TkAuthTest.java
+++ b/src/test/java/org/takes/facets/auth/TkAuthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.tk.TkText;
 
 /**
  * Test case for {@link TkAuth}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/auth/TkSecureTest.java
+++ b/src/test/java/org/takes/facets/auth/TkSecureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsEmpty;
 
 /**
  * Test case for {@link TkSecure}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 public final class TkSecureTest {

--- a/src/test/java/org/takes/facets/auth/TokenTest.java
+++ b/src/test/java/org/takes/facets/auth/TokenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.facets.auth.Token.Jwt;
 
 /**
  * Test case for {@link Token}.
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.5
  */
 public final class TokenTest {

--- a/src/test/java/org/takes/facets/auth/XeIdentityTest.java
+++ b/src/test/java/org/takes/facets/auth/XeIdentityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link org.takes.facets.auth.social.XeGithubLink}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class XeIdentityTest {

--- a/src/test/java/org/takes/facets/auth/XeLogoutLinkTest.java
+++ b/src/test/java/org/takes/facets/auth/XeLogoutLinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link XeLogoutLink}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  */
 public final class XeLogoutLinkTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcAesTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcAesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcAes}.
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @since 0.13.8
  * @checkstyle MagicNumber (500 line)
  */

--- a/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcBase64}.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class CcBase64Test {

--- a/src/test/java/org/takes/facets/auth/codecs/CcCompactTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcCompactTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcCompact}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 public final class CcCompactTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcGzipTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcGzipTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.facets.auth.Identity;
 /**
  * Test case for {@link CcGzip}.
  *
- * @author Aleksey Kurochka (eg04lt3r@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 public final class CcGzipTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcHexTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcHexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcHex}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class CcHexTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcPlainTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcPlainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcPlain}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class CcPlainTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcSaltedTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcSaltedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcSalted}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 public final class CcSaltedTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcSignedTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcSignedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcSigned}.
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id$
  * @since 1.11.1
  * @checkstyle JavadocMethodCheck (500 lines)
  * @checkstyle MagicNumber (500 line)

--- a/src/test/java/org/takes/facets/auth/codecs/CcStrictTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcStrictTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcStrict}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.11.2
  */
 public final class CcStrictTest {

--- a/src/test/java/org/takes/facets/auth/codecs/CcTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -27,8 +27,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test codec.
- * @author Kirill (g4s8.public@gmail.com)
- * @version $Id$
  * @since 1.11.1
  */
 final class CcTest implements Codec {

--- a/src/test/java/org/takes/facets/auth/codecs/CcXorTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcXorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.facets.auth.Identity;
 
 /**
  * Test case for {@link CcXor}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.13.7
  */
 public final class CcXorTest {

--- a/src/test/java/org/takes/facets/auth/codecs/package-info.java
+++ b/src/test/java/org/takes/facets/auth/codecs/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Codecs, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 package org.takes.facets.auth.codecs;

--- a/src/test/java/org/takes/facets/auth/package-info.java
+++ b/src/test/java/org/takes/facets/auth/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Auth, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.facets.auth;

--- a/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
+++ b/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link SiHmac}.
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.3
  */
 public final class SiHmacTest {

--- a/src/test/java/org/takes/facets/auth/signatures/package-info.java
+++ b/src/test/java/org/takes/facets/auth/signatures/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Signatures, tests.
  *
- * @author Sven Windisch (sven.windisch@gmail.com)
- * @version $Id$
  * @since 1.3
  */
 package org.takes.facets.auth.signatures;

--- a/src/test/java/org/takes/facets/auth/social/PsFacebookTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsFacebookTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link PsFacebook}.
- * @author Aleksey Popov (alopen@yandex.ru)
- * @version $Id$
  * @since 0.15
  * @checkstyle MagicNumberCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/auth/social/PsGithubTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGithubTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -50,8 +50,6 @@ import org.xembly.Directives;
 
 /**
  * Test case for {@link org.takes.rq.RqMethod}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.15.2
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -49,8 +49,6 @@ import org.takes.rs.RsJson;
  * Test case for {@link PsGoogle}.
  *
  * <p>The class is immutable and thread-safe.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.16.3
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsLinkedinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -48,8 +48,6 @@ import org.takes.rs.RsJson;
 
 /**
  * Test case for {@link PsLinkedin}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 public final class PsLinkedinTest {
@@ -90,9 +88,6 @@ public final class PsLinkedinTest {
 
     /**
      * Take that returns JSON with the authorization token.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @author Rui Castro (rui.castro@gmail.com)
-     * @version $Id$
      * @since 1.1
      */
     private final class TokenTake implements Take {
@@ -164,9 +159,6 @@ public final class PsLinkedinTest {
 
     /**
      * Take that returns JSON with test user data.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @author Rui Castro (rui.castro@gmail.com)
-     * @version $Id$
      * @since 1.1
      */
     private final class PeopleTake implements Take {
@@ -229,9 +221,6 @@ public final class PsLinkedinTest {
 
     /**
      * Script to test Linkedin authorization.
-     * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
-     * @author Rui Castro (rui.castro@gmail.com)
-     * @version $Id$
      * @since 1.1
      */
     private final class LinkedinScript implements FtRemote.Script {

--- a/src/test/java/org/takes/facets/auth/social/PsTwitterTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsTwitterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,9 +40,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link PsTwitter}.
- * @author Prasath Premkumar (popprem@gmail.com)
- * @author Adam Siemion (adam.siemion@lemonsoftware.pl)
- * @version $Id$
  * @since 1.0
  * @checkstyle MagicNumberCheck (500 lines)
  * @checkstyle MultipleStringLiteralsCheck (500 lines)

--- a/src/test/java/org/takes/facets/auth/social/XeFacebookLinkTest.java
+++ b/src/test/java/org/takes/facets/auth/social/XeFacebookLinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link XeFacebookLink}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 public final class XeFacebookLinkTest {

--- a/src/test/java/org/takes/facets/auth/social/XeGithubLinkTest.java
+++ b/src/test/java/org/takes/facets/auth/social/XeGithubLinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link XeGithubLink}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class XeGithubLinkTest {

--- a/src/test/java/org/takes/facets/auth/social/XeGoogleLinkTest.java
+++ b/src/test/java/org/takes/facets/auth/social/XeGoogleLinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.xe.XeAppend;
 
 /**
  * Test case for {@link XeGoogleLink}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class XeGoogleLinkTest {

--- a/src/test/java/org/takes/facets/auth/social/package-info.java
+++ b/src/test/java/org/takes/facets/auth/social/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Social authenticators, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.5
  */
 package org.takes.facets.auth.social;

--- a/src/test/java/org/takes/facets/cookies/RqCookiesTest.java
+++ b/src/test/java/org/takes/facets/cookies/RqCookiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rq.RqFake;
 /**
  * Test case for {@link RqCookies.Base}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class RqCookiesTest {

--- a/src/test/java/org/takes/facets/cookies/RsWithCookieTest.java
+++ b/src/test/java/org/takes/facets/cookies/RsWithCookieTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link RsWithCookie}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9.6
  */
 public final class RsWithCookieTest {

--- a/src/test/java/org/takes/facets/cookies/TkJoinedCookiesTest.java
+++ b/src/test/java/org/takes/facets/cookies/TkJoinedCookiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.tk.TkFixed;
 /**
  * Test case for {@link TkJoinedCookies}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 public final class TkJoinedCookiesTest {

--- a/src/test/java/org/takes/facets/cookies/package-info.java
+++ b/src/test/java/org/takes/facets/cookies/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Cookies, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11
  */
 package org.takes.facets.cookies;

--- a/src/test/java/org/takes/facets/fallback/FbChainTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbChainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link FbChain}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class FbChainTest {

--- a/src/test/java/org/takes/facets/fallback/FbLog4jTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbLog4jTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FbSlf4j}.
- * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
- * @version $Id$
  * @since 0.25
  */
 public final class FbLog4jTest {

--- a/src/test/java/org/takes/facets/fallback/FbSlf4jTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbSlf4jTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FbSlf4j}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.25
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/fallback/FbStatusTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbStatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.tk.TkFixed;
 
 /**
  * Test case for {@link FbStatus}.
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.16.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
+++ b/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.tk.TkFailure;
 
 /**
  * Test case for {@link TkFallback}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.9.6
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/fallback/package-info.java
+++ b/src/test/java/org/takes/facets/fallback/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Fallback, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.facets.fallback;

--- a/src/test/java/org/takes/facets/flash/RsFlashTest.java
+++ b/src/test/java/org/takes/facets/flash/RsFlashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link RsFlash}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9.6
  */
 public final class RsFlashTest {

--- a/src/test/java/org/takes/facets/flash/TkFlashTest.java
+++ b/src/test/java/org/takes/facets/flash/TkFlashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link TkFlash}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class TkFlashTest {

--- a/src/test/java/org/takes/facets/flash/XeFlashTest.java
+++ b/src/test/java/org/takes/facets/flash/XeFlashTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -45,8 +45,6 @@ import org.takes.rs.xe.XeStylesheet;
 
 /**
  * Test case for {@link XeFlash}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/flash/package-info.java
+++ b/src/test/java/org/takes/facets/flash/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Flash, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 package org.takes.facets.flash;

--- a/src/test/java/org/takes/facets/fork/FkAgentTest.java
+++ b/src/test/java/org/takes/facets/fork/FkAgentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkAgent}.
- * @author Valeriy Zhirnov (neonailol@gmail.com)
- * @version $Id$
  * @since 1.7.2
  * @checkstyle JavadocMethodCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/fork/FkAnonymousTest.java
+++ b/src/test/java/org/takes/facets/fork/FkAnonymousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkAnonymous}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class FkAnonymousTest {

--- a/src/test/java/org/takes/facets/fork/FkAuthenticatedTest.java
+++ b/src/test/java/org/takes/facets/fork/FkAuthenticatedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkAuthenticated}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class FkAuthenticatedTest {

--- a/src/test/java/org/takes/facets/fork/FkChainTest.java
+++ b/src/test/java/org/takes/facets/fork/FkChainTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link FkChain}.
- * @author Carlos Gines (efrel.v2@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class FkChainTest {

--- a/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/FkContentTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsEmpty;
 
 /**
  * Test case for {@link FkContentType}.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/fork/FkEncodingTest.java
+++ b/src/test/java/org/takes/facets/fork/FkEncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsEmpty;
 
 /**
  * Test case for {@link FkEncoding}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class FkEncodingTest {

--- a/src/test/java/org/takes/facets/fork/FkHitRefreshTest.java
+++ b/src/test/java/org/takes/facets/fork/FkHitRefreshTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkHitRefresh}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class FkHitRefreshTest {

--- a/src/test/java/org/takes/facets/fork/FkHostTest.java
+++ b/src/test/java/org/takes/facets/fork/FkHostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkHost}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.32
  */
 public final class FkHostTest {

--- a/src/test/java/org/takes/facets/fork/FkMethodsTest.java
+++ b/src/test/java/org/takes/facets/fork/FkMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkMethods}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class FkMethodsTest {

--- a/src/test/java/org/takes/facets/fork/FkParamsTest.java
+++ b/src/test/java/org/takes/facets/fork/FkParamsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkParams}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class FkParamsTest {

--- a/src/test/java/org/takes/facets/fork/FkRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/FkRegexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkRegex}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class FkRegexTest {

--- a/src/test/java/org/takes/facets/fork/FkTypesTest.java
+++ b/src/test/java/org/takes/facets/fork/FkTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link FkTypes}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class FkTypesTest {

--- a/src/test/java/org/takes/facets/fork/MediaTypeTest.java
+++ b/src/test/java/org/takes/facets/fork/MediaTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link MediaType}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  */
 public final class MediaTypeTest {

--- a/src/test/java/org/takes/facets/fork/MediaTypesTest.java
+++ b/src/test/java/org/takes/facets/fork/MediaTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link MediaTypes}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  */
 public final class MediaTypesTest {

--- a/src/test/java/org/takes/facets/fork/RqRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/RqRegexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqRegex}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class RqRegexTest {

--- a/src/test/java/org/takes/facets/fork/RsForkTest.java
+++ b/src/test/java/org/takes/facets/fork/RsForkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link RsFork}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.6
  */
 public final class RsForkTest {

--- a/src/test/java/org/takes/facets/fork/TkConsumesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkConsumesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -42,8 +42,6 @@ import org.takes.tk.TkFixed;
 
 /**
  * Test case for {@link TkConsumes}.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/test/java/org/takes/facets/fork/TkForkTest.java
+++ b/src/test/java/org/takes/facets/fork/TkForkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkFork}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class TkForkTest {

--- a/src/test/java/org/takes/facets/fork/TkMethodsTest.java
+++ b/src/test/java/org/takes/facets/fork/TkMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link TkMethods}.
- * @author Aleksey Popov (alopen@yandex.ru)
- * @version $Id$
  * @since 0.17
  */
 public final class TkMethodsTest {

--- a/src/test/java/org/takes/facets/fork/TkProducesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkProducesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.tk.TkFixed;
 
 /**
  * Test case for {@link TkProduces}.
- * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
- * @version $Id$
  * @since 0.14
  */
 public final class TkProducesTest {

--- a/src/test/java/org/takes/facets/fork/package-info.java
+++ b/src/test/java/org/takes/facets/fork/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Fork, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 package org.takes.facets.fork;

--- a/src/test/java/org/takes/facets/forward/RsForwardTest.java
+++ b/src/test/java/org/takes/facets/forward/RsForwardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.facets.flash.RsFlash;
 
 /**
  * Test case for {@link RsForward}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  */
 public final class RsForwardTest {

--- a/src/test/java/org/takes/facets/forward/TkForwardTest.java
+++ b/src/test/java/org/takes/facets/forward/TkForwardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkForward}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  */
 public final class TkForwardTest {

--- a/src/test/java/org/takes/facets/forward/package-info.java
+++ b/src/test/java/org/takes/facets/forward/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Forward, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  */
 package org.takes.facets.forward;

--- a/src/test/java/org/takes/facets/hamcrest/HmBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rq.RqFake;
 /**
  * Test case for {@link HmBody}.
  *
- * @author Tolegen Izbassar (t.izbassar@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class HmBodyTest {

--- a/src/test/java/org/takes/facets/hamcrest/HmHeaderTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,9 +35,6 @@ import org.takes.rq.RqWithHeaders;
 
 /**
  * Test case for {@link org.takes.facets.hamcrest.HmHeader}.
- * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
- * @author Paulo Lobo (pauloeduardolobo@gmail.com)
- * @version $Id$
  * @since 0.23.3
  */
 public final class HmHeaderTest {

--- a/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.rq.RqFake;
 /**
  * Test case for {@link HmRqTextBody}.
  *
- * @author Izbassar Tolegen (t.izbassar@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class HmRqTextBodyTest {

--- a/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.tk.TkHtml;
 
 /**
  * Test case for {@link HmRsStatus}.
- * @author Erim Erturk (erimerturk@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class HmRsStatusTest {

--- a/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.rs.RsWithBody;
 /**
  * Test case for {@link HmRsTextBody}.
  *
- * @author Izbassar Tolegen (t.izbassar@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class HmRsTextBodyTest {

--- a/src/test/java/org/takes/facets/hamcrest/HmTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmTextBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.junit.Test;
 /**
  * Test case for {@link AbstractHmTextBody}.
  *
- * @author Alena Gerasimova (olena.gerasimova@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class HmTextBodyTest {

--- a/src/test/java/org/takes/facets/hamcrest/package-info.java
+++ b/src/test/java/org/takes/facets/hamcrest/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Matcher, tests.
  *
- * @author Erim Erturk (erimerturk@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 package org.takes.facets.hamcrest;

--- a/src/test/java/org/takes/facets/previous/RsPreviousTest.java
+++ b/src/test/java/org/takes/facets/previous/RsPreviousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link RsPrevious}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  */
 public final class RsPreviousTest {

--- a/src/test/java/org/takes/facets/previous/TkPreviousTest.java
+++ b/src/test/java/org/takes/facets/previous/TkPreviousTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.tk.TkText;
 
 /**
  * Test case for {@link TkPrevious}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.2
  */
 public final class TkPreviousTest {

--- a/src/test/java/org/takes/facets/previous/package-info.java
+++ b/src/test/java/org/takes/facets/previous/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Previous, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 package org.takes.facets.previous;

--- a/src/test/java/org/takes/facets/ret/RsReturnTest.java
+++ b/src/test/java/org/takes/facets/ret/RsReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link RsReturn}.
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.20
  */
 public final class RsReturnTest {

--- a/src/test/java/org/takes/facets/ret/TkReturnTest.java
+++ b/src/test/java/org/takes/facets/ret/TkReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link TkReturn}.
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.20
  */
 public final class TkReturnTest {

--- a/src/test/java/org/takes/facets/ret/package-info.java
+++ b/src/test/java/org/takes/facets/ret/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Return, tests.
  *
- * @author Ivan Inozemtsev (ivan.inozemtsev@gmail.com)
- * @version $Id$
  * @since 0.20
  */
 package org.takes.facets.ret;

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -53,8 +53,6 @@ import org.takes.tk.TkText;
 /**
  * Test case for {@link BkBasic}.
  *
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.15.2
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MultipleStringLiteralsCheck (500 lines)

--- a/src/test/java/org/takes/http/BkParallelTest.java
+++ b/src/test/java/org/takes/http/BkParallelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.tk.TkEmpty;
 /**
  * Test case for {@link BkParallel}.
  *
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @since 0.15.2
  */

--- a/src/test/java/org/takes/http/BkTimeableTest.java
+++ b/src/test/java/org/takes/http/BkTimeableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -43,8 +43,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link BkTimeable}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.14.2
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/http/FtBasicTest.java
+++ b/src/test/java/org/takes/http/FtBasicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -58,8 +58,6 @@ import org.takes.tk.TkText;
 
 /**
  * Test case for {@link FtBasic}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/http/FtCliTest.java
+++ b/src/test/java/org/takes/http/FtCliTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.facets.fork.TkFork;
 
 /**
  * Test case for {@link FtCli}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/http/FtRemoteTest.java
+++ b/src/test/java/org/takes/http/FtRemoteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -48,8 +48,6 @@ import org.takes.tk.TkFixed;
 
 /**
  * Test case for {@link FtRemote}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.21
  *
  * @todo #800:30min We can't assert if FtRemote returns an empty body because

--- a/src/test/java/org/takes/http/FtSecureTest.java
+++ b/src/test/java/org/takes/http/FtSecureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.takes.tk.TkFixed;
 
 /**
  * Test case for {@link FtSecure}.
- * @author Dragan Bozanovic (bozanovicdr@gmail.com)
- * @version $Id$
  * @since 0.25
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/http/MainRemoteTest.java
+++ b/src/test/java/org/takes/http/MainRemoteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.tk.TkFixed;
 
 /**
  * Test case for {@link MainRemote}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.23
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/http/MkSocket.java
+++ b/src/test/java/org/takes/http/MkSocket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import java.net.Socket;
 /**
  * Socket mock for reuse.
  *
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.32
  */
 public final class MkSocket  extends Socket {

--- a/src/test/java/org/takes/http/OptionsTest.java
+++ b/src/test/java/org/takes/http/OptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link OptionsTest}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class OptionsTest {

--- a/src/test/java/org/takes/http/package-info.java
+++ b/src/test/java/org/takes/http/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * HTTP server, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.http;

--- a/src/test/java/org/takes/misc/ConcatTest.java
+++ b/src/test/java/org/takes/misc/ConcatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 /**
  * Test case for {@link Concat}.
  *
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @since 0.15.2
  */
 public final class ConcatTest {

--- a/src/test/java/org/takes/misc/ExpiresTest.java
+++ b/src/test/java/org/takes/misc/ExpiresTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Tests of {@link Expires} interface and direct implementations.
- * @author Paulo Lobo (pauloeduardolobo@gmail.com)
- * @version $Id$
  * @since 2.0
  */
 public final class ExpiresTest {

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link Href}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.7
  */
 public final class HrefTest {

--- a/src/test/java/org/takes/misc/PerformanceTests.java
+++ b/src/test/java/org/takes/misc/PerformanceTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@ package org.takes.misc;
 
 /**
  * Marker interface for performance tests.
- * @author Mesut Ozen (mesutozen36@gmail.com)
- * @version $Id$
  * @since 0.24
  */
 public interface PerformanceTests {

--- a/src/test/java/org/takes/misc/StateAwareInputStream.java
+++ b/src/test/java/org/takes/misc/StateAwareInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * InputStream decorator that knows if it was closed or not.
  *
- * @author I. Sokolov (happy.neko@gmail.com)
- * @version $Id$
  * @since 0.31
  */
 public final class StateAwareInputStream extends InputStream {

--- a/src/test/java/org/takes/misc/TransformTest.java
+++ b/src/test/java/org/takes/misc/TransformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 /**
  * Test case for {@link Transform}.
  *
- * @author Jason Wong (super132j@yahoo.com)
- * @version $Id$
  * @since 0.15.2
  */
 public final class TransformTest {

--- a/src/test/java/org/takes/misc/Utf8StringTest.java
+++ b/src/test/java/org/takes/misc/Utf8StringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link Utf8String}.
- * @author Maksimenko Vladimir (xupypr@xupypr.com)
- * @version $Id$
  * @since 0.33
  */
 public final class Utf8StringTest {

--- a/src/test/java/org/takes/misc/VerboseIterableTest.java
+++ b/src/test/java/org/takes/misc/VerboseIterableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Tests for {@link VerboseIterable}.
- * @author Marcus Sanchez (sanchez.marcus@gmail.com)
- * @version $Id$
  * @since 0.15.1
  */
 public class VerboseIterableTest {

--- a/src/test/java/org/takes/misc/VerboseIteratorTest.java
+++ b/src/test/java/org/takes/misc/VerboseIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Tests for {@link VerboseIterator}.
- * @author Marcus Sanchez (sanchez.marcus@gmail.com)
- * @version $Id$
  * @since 0.15.1
  */
 public class VerboseIteratorTest {

--- a/src/test/java/org/takes/misc/VerboseListTest.java
+++ b/src/test/java/org/takes/misc/VerboseListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 /**
  * Tests for {@link VerboseList}.
  *
- * @author I. Sokolov (happy.neko@gmail.com)
- * @version $Id$
  * @since 0.32
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/test/java/org/takes/misc/package-info.java
+++ b/src/test/java/org/takes/misc/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Miscellaneous classes, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 package org.takes.misc;

--- a/src/test/java/org/takes/package-info.java
+++ b/src/test/java/org/takes/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Take Framework, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes;

--- a/src/test/java/org/takes/rq/CapInputStreamTest.java
+++ b/src/test/java/org/takes/rq/CapInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.mockito.Mockito;
 /**
  * Test case for {@link CapInputStream}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 public final class CapInputStreamTest {

--- a/src/test/java/org/takes/rq/ChunkedInputStreamTest.java
+++ b/src/test/java/org/takes/rq/ChunkedInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.junit.Test;
 /**
  * Test case for {@link ChunkedInputStream}.
  *
- * @author Maksimenko Vladimir (xupypr@xupypr.com)
- * @version $Id$
  * @since 0.31.2
  */
 public final class ChunkedInputStreamTest {

--- a/src/test/java/org/takes/rq/RqChunkTest.java
+++ b/src/test/java/org/takes/rq/RqChunkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.junit.Test;
 /**
  * Test case for {@link RqChunk}.
  *
- * @author Hamdi Douss (douss.hamdi@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RqChunkTest {

--- a/src/test/java/org/takes/rq/RqFakeTest.java
+++ b/src/test/java/org/takes/rq/RqFakeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Request;
 
 /**
  * Test case for {@link RqFake}.
- * @author Dragan Bozanovic (bozanovicdr@gmail.com)
- * @version $Id$
  * @since 0.24
  */
 public final class RqFakeTest {

--- a/src/test/java/org/takes/rq/RqGreedyTest.java
+++ b/src/test/java/org/takes/rq/RqGreedyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Request;
 
 /**
  * Test case for {@link RqGreedy}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.16
  */
 public final class RqGreedyTest {

--- a/src/test/java/org/takes/rq/RqHeadersTest.java
+++ b/src/test/java/org/takes/rq/RqHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqHeaders}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RqHeadersTest {

--- a/src/test/java/org/takes/rq/RqHrefTest.java
+++ b/src/test/java/org/takes/rq/RqHrefTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.HttpException;
 
 /**
  * Test case for {@link RqHref.Base}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/org/takes/rq/RqLengthAwareTest.java
+++ b/src/test/java/org/takes/rq/RqLengthAwareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 /**
  * Test case for {@link RqLengthAware}.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RqLengthAwareTest {

--- a/src/test/java/org/takes/rq/RqLiveTest.java
+++ b/src/test/java/org/takes/rq/RqLiveTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Request;
 
 /**
  * Test case for {@link RqLive}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class RqLiveTest {

--- a/src/test/java/org/takes/rq/RqMethodTest.java
+++ b/src/test/java/org/takes/rq/RqMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link org.takes.rq.RqMethod}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.9.1
  */
 public final class RqMethodTest {

--- a/src/test/java/org/takes/rq/RqOnceTest.java
+++ b/src/test/java/org/takes/rq/RqOnceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.Request;
 
 /**
  * Test case for {@link RqOnce}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.26
  */
 public final class RqOnceTest {

--- a/src/test/java/org/takes/rq/RqPrintTest.java
+++ b/src/test/java/org/takes/rq/RqPrintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqPrint}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RqPrintTest {

--- a/src/test/java/org/takes/rq/RqRequestLineTest.java
+++ b/src/test/java/org/takes/rq/RqRequestLineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.HttpException;
 
 /**
  * Test case for {@link RqRequestLine.Base}.
- * @author Vladimir Maksimenko (xupypr@xupypr.com)
- * @version $Id$
  * @since 0.29.1
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/test/java/org/takes/rq/RqSocketTest.java
+++ b/src/test/java/org/takes/rq/RqSocketTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.HttpException;
 
 /**
  * Test case for {@link RqSocket}.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle MagicNumberCheck (500 lines)

--- a/src/test/java/org/takes/rq/RqWithBodyTest.java
+++ b/src/test/java/org/takes/rq/RqWithBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -29,8 +29,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqWithBody}.
- * @author Erim Erturk (erimerturk@gmail.com)
- * @version $Id$
  * @since 0.22
  */
 public final class RqWithBodyTest {

--- a/src/test/java/org/takes/rq/RqWithDefaultHeaderTest.java
+++ b/src/test/java/org/takes/rq/RqWithDefaultHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqWithDefaultHeader}.
- * @author Andrey Eliseev (aeg.exper0@gmail.com)
- * @version $Id$
  * @since 0.31
  */
 public final class RqWithDefaultHeaderTest {

--- a/src/test/java/org/takes/rq/RqWithHeaderTest.java
+++ b/src/test/java/org/takes/rq/RqWithHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqWithHeader}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class RqWithHeaderTest {

--- a/src/test/java/org/takes/rq/RqWithHeadersTest.java
+++ b/src/test/java/org/takes/rq/RqWithHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqWithHeaders}.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/test/java/org/takes/rq/RqWithoutHeaderTest.java
+++ b/src/test/java/org/takes/rq/RqWithoutHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RqWithoutHeader}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class RqWithoutHeaderTest {

--- a/src/test/java/org/takes/rq/TempInputStreamTest.java
+++ b/src/test/java/org/takes/rq/TempInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link TempInputStream}.
- * @author Andrey Eliseev (aeg.exper@gmail.com)
- * @version $Id$
  * @since 0.31
  */
 public final class TempInputStreamTest {

--- a/src/test/java/org/takes/rq/form/RqFormBaseTest.java
+++ b/src/test/java/org/takes/rq/form/RqFormBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,9 +34,6 @@ import org.takes.rq.RqForm;
 
 /**
  * Test case for {@link RqFormBase}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @author Rui Castro (rui.castro@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqFormBaseTest {

--- a/src/test/java/org/takes/rq/form/RqFormFakeTest.java
+++ b/src/test/java/org/takes/rq/form/RqFormFakeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,9 +34,6 @@ import org.takes.rq.RqForm;
 
 /**
  * Test case for {@link RqFormFake}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @author Rui Castro (rui.castro@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqFormFakeTest {

--- a/src/test/java/org/takes/rq/form/RqFormSmartTest.java
+++ b/src/test/java/org/takes/rq/form/RqFormSmartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,9 +32,6 @@ import org.takes.rq.RqForm;
 
 /**
  * Test case for {@link RqFormSmart}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @author Rui Castro (rui.castro@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqFormSmartTest {

--- a/src/test/java/org/takes/rq/form/package-info.java
+++ b/src/test/java/org/takes/rq/form/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -24,8 +24,6 @@
 
 /**
  * Form tests.
- * @author Rui Castro (rui.castro@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 package org.takes.rq.form;

--- a/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rq.RqWithHeaders;
 
 /**
  * Test case for {@link RqMtBase}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.33
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle LineLengthCheck (1 lines)

--- a/src/test/java/org/takes/rq/multipart/RqMtFakeTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtFakeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.rq.RqWithHeaders;
 
 /**
  * Test case for {@link RqMtFake}.
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */

--- a/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -54,8 +54,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link RqMtSmart}.
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)

--- a/src/test/java/org/takes/rq/multipart/RqTempTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqTempTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.misc.Utf8String;
 
 /**
  * Test case for {@link RqTemp}.
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 public final class RqTempTest {

--- a/src/test/java/org/takes/rq/multipart/package-info.java
+++ b/src/test/java/org/takes/rq/multipart/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Multipart tests.
  *
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.33
  */
 package org.takes.rq.multipart;

--- a/src/test/java/org/takes/rq/package-info.java
+++ b/src/test/java/org/takes/rq/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Requests, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.rq;

--- a/src/test/java/org/takes/rs/BodyTest.java
+++ b/src/test/java/org/takes/rs/BodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.misc.Utf8String;
 /**
  * Test case for {@link Body}.
  *
- * @author Nicolas Filotto (nicolas.filotto@gmail.com)
- * @version $Id$
  * @since 0.32
  */
 public final class BodyTest {

--- a/src/test/java/org/takes/rs/RsGzipTest.java
+++ b/src/test/java/org/takes/rs/RsGzipTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -39,8 +39,6 @@ import org.takes.Response;
 
 /**
  * Test case for {@link RsGzip}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/rs/RsJsonTest.java
+++ b/src/test/java/org/takes/rs/RsJsonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsJson}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsJsonTest {

--- a/src/test/java/org/takes/rs/RsPrettyJsonTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyJsonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsPrettyJson}.
- * @author Eugene Kondrashev (eugene.kondrashev@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 public final class RsPrettyJsonTest {

--- a/src/test/java/org/takes/rs/RsPrettyXmlTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsPrettyXml}.
- * @author Igor Khvostenkov (ikhvostenkov@gmail.com)
- * @version $Id$
  * @since 1.0
  */
 public final class RsPrettyXmlTest {

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsPrint}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  */
 public final class RsPrintTest {
@@ -95,8 +93,6 @@ public final class RsPrintTest {
     /**
      * Writer that throws IOException on method write.
      *
-     * @author Victor Noel (victor.noel@crazydwarves.org)
-     * @version $Id$
      * @since 2.0
      */
     private static final class FailWriter extends Writer {
@@ -147,8 +143,6 @@ public final class RsPrintTest {
     /**
      * FailOutputStream that throws IOException on method write.
      *
-     * @author Izbassar Tolegen (t.izbassar@gmail.com)
-     * @version $Id$
      * @since 2.0
      */
     private static final class FailOutputStream extends OutputStream {

--- a/src/test/java/org/takes/rs/RsRedirectTest.java
+++ b/src/test/java/org/takes/rs/RsRedirectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,8 +30,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsRedirect}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.12
  */
 public final class RsRedirectTest {

--- a/src/test/java/org/takes/rs/RsTextTest.java
+++ b/src/test/java/org/takes/rs/RsTextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsText}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsTextTest {

--- a/src/test/java/org/takes/rs/RsVelocityTest.java
+++ b/src/test/java/org/takes/rs/RsVelocityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.misc.StateAwareInputStream;
 
 /**
  * Test case for {@link RsVelocity}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsVelocityTest {

--- a/src/test/java/org/takes/rs/RsWithHeaderTest.java
+++ b/src/test/java/org/takes/rs/RsWithHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsWithHeader}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsWithHeaderTest {

--- a/src/test/java/org/takes/rs/RsWithHeadersTest.java
+++ b/src/test/java/org/takes/rs/RsWithHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsWithHeaders}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsWithHeadersTest {

--- a/src/test/java/org/takes/rs/RsWithStatusTest.java
+++ b/src/test/java/org/takes/rs/RsWithStatusTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.Response;
  * Test case for {@link RsWithStatus}.
  *
  * <p>The class is immutable and thread-safe.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.16.9
  */
 public final class RsWithStatusTest {

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsWithType}.
- * @author Yohann Ferreira (yohann.ferreira@orange.fr)
- * @version $Id$
  * @since 0.16.9
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/rs/RsWithoutHeaderTest.java
+++ b/src/test/java/org/takes/rs/RsWithoutHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RsWithoutHeader}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.9
  */
 public final class RsWithoutHeaderTest {

--- a/src/test/java/org/takes/rs/RsXsltTest.java
+++ b/src/test/java/org/takes/rs/RsXsltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -41,8 +41,6 @@ import org.takes.misc.StateAwareInputStream;
 
 /**
  * Test case for {@link RsXslt}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsXsltTest {

--- a/src/test/java/org/takes/rs/package-info.java
+++ b/src/test/java/org/takes/rs/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Responses, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.rs;

--- a/src/test/java/org/takes/rs/xe/RsXemblyTest.java
+++ b/src/test/java/org/takes/rs/xe/RsXemblyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.xembly.Directives;
 
 /**
  * Test case for {@link RsXembly}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class RsXemblyTest {

--- a/src/test/java/org/takes/rs/xe/XeAppendTest.java
+++ b/src/test/java/org/takes/rs/xe/XeAppendTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XeAppend}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class XeAppendTest {

--- a/src/test/java/org/takes/rs/xe/XeDateTest.java
+++ b/src/test/java/org/takes/rs/xe/XeDateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XeDate}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 public final class XeDateTest {

--- a/src/test/java/org/takes/rs/xe/XeLifetimeTest.java
+++ b/src/test/java/org/takes/rs/xe/XeLifetimeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XeLifetime}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.7
  */
 public final class XeLifetimeTest {

--- a/src/test/java/org/takes/rs/xe/XeLinkHomeTest.java
+++ b/src/test/java/org/takes/rs/xe/XeLinkHomeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link XeLinkHome}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class XeLinkHomeTest {

--- a/src/test/java/org/takes/rs/xe/XeLinkSelfTest.java
+++ b/src/test/java/org/takes/rs/xe/XeLinkSelfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link XeLinkSelf}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class XeLinkSelfTest {

--- a/src/test/java/org/takes/rs/xe/XeLinkTest.java
+++ b/src/test/java/org/takes/rs/xe/XeLinkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XeLink}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 public final class XeLinkTest {

--- a/src/test/java/org/takes/rs/xe/XeLocalhostTest.java
+++ b/src/test/java/org/takes/rs/xe/XeLocalhostTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XeLocalhost}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 public final class XeLocalhostTest {

--- a/src/test/java/org/takes/rs/xe/XeMemoryTest.java
+++ b/src/test/java/org/takes/rs/xe/XeMemoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsXslt;
 
 /**
  * Test case for {@link XeMemory}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.2
  */
 public final class XeMemoryTest {

--- a/src/test/java/org/takes/rs/xe/XeMillisTest.java
+++ b/src/test/java/org/takes/rs/xe/XeMillisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsXslt;
 
 /**
  * Test case for {@link XeSla}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.4
  */
 public final class XeMillisTest {

--- a/src/test/java/org/takes/rs/xe/XeSlaTest.java
+++ b/src/test/java/org/takes/rs/xe/XeSlaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsXslt;
 
 /**
  * Test case for {@link XeSla}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.3
  */
 public final class XeSlaTest {

--- a/src/test/java/org/takes/rs/xe/XeTransformTest.java
+++ b/src/test/java/org/takes/rs/xe/XeTransformTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.xembly.Directives;
 
 /**
  * Test case for {@link XeTransform}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class XeTransformTest {

--- a/src/test/java/org/takes/rs/xe/XeWhenTest.java
+++ b/src/test/java/org/takes/rs/xe/XeWhenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.Scalar;
 
 /**
  * Test case for {@link XeWhen}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.13
  */
 public final class XeWhenTest {

--- a/src/test/java/org/takes/rs/xe/package-info.java
+++ b/src/test/java/org/takes/rs/xe/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Xembly responses, tests.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.rs.xe;

--- a/src/test/java/org/takes/tk/TkClasspathTest.java
+++ b/src/test/java/org/takes/tk/TkClasspathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkClasspath}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 public final class TkClasspathTest {

--- a/src/test/java/org/takes/tk/TkCorsTest.java
+++ b/src/test/java/org/takes/tk/TkCorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link TkCors}.
- * @author Endrigo Antonini (teamed@endrigo.com.br)
- * @version $Id$
  * @since 0.20
  */
 public final class TkCorsTest {

--- a/src/test/java/org/takes/tk/TkFilesTest.java
+++ b/src/test/java/org/takes/tk/TkFilesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,8 +37,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkFiles}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.8
  */
 public final class TkFilesTest {

--- a/src/test/java/org/takes/tk/TkGzipTest.java
+++ b/src/test/java/org/takes/tk/TkGzipTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkGzip}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.17
  */
 public final class TkGzipTest {

--- a/src/test/java/org/takes/tk/TkHtmlTest.java
+++ b/src/test/java/org/takes/tk/TkHtmlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkHtml}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class TkHtmlTest {

--- a/src/test/java/org/takes/tk/TkMeasuredTest.java
+++ b/src/test/java/org/takes/tk/TkMeasuredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkMeasured}.
- * @author Dmitry Molotchko (dima.molotchko@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class TkMeasuredTest {

--- a/src/test/java/org/takes/tk/TkProxyTest.java
+++ b/src/test/java/org/takes/tk/TkProxyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -47,8 +47,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link TkProxy}.
- * @author Dragan Bozanovic (bozanovicdr@gmail.com)
- * @version $Id$
  * @since 0.25
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */

--- a/src/test/java/org/takes/tk/TkReadAlwaysTest.java
+++ b/src/test/java/org/takes/tk/TkReadAlwaysTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link TkReadAlways}.
- * @author Dan Baleanu (dan.baleanu@gmail.com)
- * @version $Id$
  * @since 0.30
  */
 public final class TkReadAlwaysTest {

--- a/src/test/java/org/takes/tk/TkRedirectTest.java
+++ b/src/test/java/org/takes/tk/TkRedirectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -35,8 +35,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkRedirect}.
- * @author Dmitry Molotchko (dima.molotchko@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/org/takes/tk/TkRetryTest.java
+++ b/src/test/java/org/takes/tk/TkRetryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -40,8 +40,6 @@ import org.takes.rs.RsText;
 /**
  * TkRetry can retry till success or retry count is reached.
  *
- * @author Hamdi Douss (douss.hamdi@gmail.com)
- * @version $Id$
  * @since 0.28.3
  */
 public final class TkRetryTest {

--- a/src/test/java/org/takes/tk/TkSlf4jRemoteTest.java
+++ b/src/test/java/org/takes/tk/TkSlf4jRemoteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -37,9 +37,6 @@ import org.takes.http.FtRemote;
 /**
  * Test case for {@link TkSlf4j} when used in conjunction
  * with {@link FtRemote} and {@link TkEmpty}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11.2
  */
 public final class TkSlf4jRemoteTest {

--- a/src/test/java/org/takes/tk/TkSlf4jTest.java
+++ b/src/test/java/org/takes/tk/TkSlf4jTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -30,9 +30,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link TkSlf4j}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.11.2
  */
 public final class TkSlf4jTest {

--- a/src/test/java/org/takes/tk/TkSmartRedirectTest.java
+++ b/src/test/java/org/takes/tk/TkSmartRedirectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -31,8 +31,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link TkSmartRedirect}.
- * @author Dmitry Molotchko (dima.molotchko@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/src/test/java/org/takes/tk/TkSslOnlyTest.java
+++ b/src/test/java/org/takes/tk/TkSslOnlyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -38,8 +38,6 @@ import org.takes.rs.RsText;
 
 /**
  * Test case for {@link TkSslOnly}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 1.9
  */
 public final class TkSslOnlyTest {

--- a/src/test/java/org/takes/tk/TkTextTest.java
+++ b/src/test/java/org/takes/tk/TkTextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -34,8 +34,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkText}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class TkTextTest {

--- a/src/test/java/org/takes/tk/TkVerboseTest.java
+++ b/src/test/java/org/takes/tk/TkVerboseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -36,8 +36,6 @@ import org.takes.rq.RqFake;
 
 /**
  * Test case for {@link TkVerbose}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.10
  */
 public final class TkVerboseTest {

--- a/src/test/java/org/takes/tk/TkVersionedTest.java
+++ b/src/test/java/org/takes/tk/TkVersionedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -32,8 +32,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link TkVersioned}.
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.4
  */
 public final class TkVersionedTest {

--- a/src/test/java/org/takes/tk/TkWithHeadersTest.java
+++ b/src/test/java/org/takes/tk/TkWithHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -33,8 +33,6 @@ import org.takes.rs.RsPrint;
 
 /**
  * Test case for {@link org.takes.tk.TkWithHeaders}.
- * @author Dmitry Zaytsev (dmitry.zaytsev@gmail.com)
- * @version $Id$
  * @since 0.9.1
  */
 public final class TkWithHeadersTest {

--- a/src/test/java/org/takes/tk/package-info.java
+++ b/src/test/java/org/takes/tk/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2014-2018 Yegor Bugayenko
@@ -25,8 +25,6 @@
 /**
  * Take, testss.
  *
- * @author Yegor Bugayenko (yegor256@gmail.com)
- * @version $Id$
  * @since 0.1
  */
 package org.takes.tk;


### PR DESCRIPTION
This is for #837 
- it was originally for 0.17.3, and I fixed as much things as I could and added todos for going toward latest 0.17.6 and also toward 0.18.x
- I used grep and sed to do the fixes on a large scale:
  - changed headers with `grep -r -l "^ \* The MIT License" * | xargs sed -i '1 s/\/\*\*/\/*/'`
  - remove `@author` and `@version` with `find . -name "*.java" -exec sed -i '/@author/d'`