### PR TITLE
TkMethods now returns 405 on unsupported method

### DIFF
--- a/src/main/java/org/takes/facets/fork/TkMethods.java
+++ b/src/main/java/org/takes/facets/fork/TkMethods.java
@@ -23,9 +23,12 @@
  */
 package org.takes.facets.fork;
 
+import java.net.HttpURLConnection;
 import java.util.Arrays;
 import lombok.ToString;
+import org.takes.HttpException;
 import org.takes.Take;
+import org.takes.tk.TkFailure;
 import org.takes.tk.TkWrap;
 
 /**
@@ -46,7 +49,16 @@ public class TkMethods extends TkWrap {
      */
     public TkMethods(final Take take, final String ...methods) {
         super(
-            new TkFork(new FkMethods(Arrays.asList(methods), take))
+            new TkFork(
+                new FkMethods(Arrays.asList(methods), take),
+                new FkFixed(
+                    new TkFailure(
+                        () -> new HttpException(
+                            HttpURLConnection.HTTP_BAD_METHOD
+                        )
+                    )
+                )
+            )
         );
     }
 }

--- a/src/test/java/org/takes/facets/fork/TkMethodsTest.java
+++ b/src/test/java/org/takes/facets/fork/TkMethodsTest.java
@@ -23,14 +23,19 @@
  */
 package org.takes.facets.fork;
 
+import com.jcabi.http.request.JdkRequest;
+import com.jcabi.http.response.RestResponse;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Take;
+import org.takes.http.FtRemote;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqMethod;
+import org.takes.tk.TkEmpty;
 
 /**
  * Test case for {@link TkMethods}.
@@ -60,6 +65,21 @@ public final class TkMethodsTest {
         IOException {
         new TkMethods(Mockito.mock(Take.class), RqMethod.POST).act(
             new RqFake(RqMethod.GET)
+        );
+    }
+
+    /**
+     * TkMethods can return 405 status when acting on unknown method.
+     * @throws IOException If any I/O error occurs
+     */
+    @Test
+    public void returnsMethodIsNotAllowedForUnsupportedMethods() throws
+        IOException {
+        new FtRemote(new TkMethods(new TkEmpty(), RqMethod.PUT)).exec(
+            url -> new JdkRequest(url)
+                .method(RqMethod.POST)
+                .fetch().as(RestResponse.class)
+                .assertStatus(HttpURLConnection.HTTP_BAD_METHOD)
         );
     }
 }


### PR DESCRIPTION
This is for #861.

Added a test and a fix.