### PR TITLE
#876 corrected test for PsFacebook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,13 @@ SOFTWARE.
       <version>2.6</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.4</version>
+    </dependency>
   </dependencies>
+  
   <build>
     <testResources>
       <testResource>
@@ -375,12 +381,6 @@ SOFTWARE.
                to pass. In 0.17.6, some changes impact a lot of file, while in
                0.18 there should be less new issues. Don't forget about the IT
                test ran by maven-invoker-plugin.
-              @todo #837:30min Finish the upgrade to qulice 0.17.5 by reviewing
-               all diamond usage: it was required until now to explicit the
-               type in generics but it is not needed anymore. For example in
-               BkTimetable line 65, new ConcurrentHashMap<Thread, Long>(1)
-               should be new ConcurrentHashMap<>(1). There are around 70
-               cases like that.
             -->
             <version>${qulice.version}</version>
             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,6 @@ SOFTWARE.
       <version>1.4</version>
     </dependency>
   </dependencies>
-  
   <build>
     <testResources>
       <testResource>

--- a/src/test/java/org/takes/facets/auth/social/PsFacebookTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsFacebookTest.java
@@ -26,9 +26,10 @@ package org.takes.facets.auth.social;
 import com.jcabi.http.request.FakeRequest;
 import com.restfb.DefaultWebRequestor;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.Map;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.text.RandomStringGenerator;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -52,15 +53,20 @@ public class PsFacebookTest {
     @Test
     public final void canLogin() throws Exception {
         final String identifier = RandomStringUtils.randomAlphanumeric(10);
+        final RandomStringGenerator generator =
+            new RandomStringGenerator.Builder()
+                .filteredBy(
+                    Character::isLetterOrDigit, Character::isIdeographic
+                ).build();
         final Pass pass = new PsFacebook(
             new FakeRequest(
                 200,
                 "HTTP OK",
-                Collections.<Map.Entry<String, String>>emptyList(),
+                Collections.emptyList(),
                 String.format(
                     "access_token=%s",
                     RandomStringUtils.randomAlphanumeric(10)
-                ).getBytes("utf-8")
+                ).getBytes(StandardCharsets.UTF_8)
             ),
             new DefaultWebRequestor() {
                 @Override
@@ -70,13 +76,13 @@ public class PsFacebookTest {
                         String.format(
                             "{\"id\":\"%s\",\"name\":\"%s\"}",
                             identifier,
-                            RandomStringUtils.random(10)
+                            generator.generate(10)
                         )
                     );
                 }
             },
-            RandomStringUtils.random(10),
-            RandomStringUtils.random(10)
+            generator.generate(10),
+            generator.generate(10)
         );
         final Opt<Identity> identity = pass.enter(
             new RqFake(


### PR DESCRIPTION
#876 
* corrected test for PsFacebook to generate correct unicode characters (and not control sequences - `random()` was generating those and that's why the test was sometimes failing)