### PR TITLE
Bump qulice to 0.18.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@ SOFTWARE.
   <properties>
     <timestamp>${maven.build.timestamp}</timestamp>
     <jdk.version>1.8</jdk.version>
-    <qulice.version>0.17.5</qulice.version>
+    <qulice.version>0.18.5</qulice.version>
   </properties>
   <dependencies>
     <!--
@@ -386,13 +386,6 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <!--
-              @todo #837:30min Upgrade qulice to latest 0.17.x and if possible
-               to latest 0.18.x and fix all the issues it detects for the build
-               to pass. In 0.17.6, some changes impact a lot of file, while in
-               0.18 there should be less new issues. Don't forget about the IT
-               test ran by maven-invoker-plugin.
-            -->
             <version>${qulice.version}</version>
             <configuration>
               <excludes combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,14 @@ SOFTWARE.
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
+      <!--
+        @todo #880:30min Once Cactoos is updated to qulice >=0.18.5
+         remove all references to Files.newXXX static methods and
+         replace them with OO objects such as InputOf or OutputOf
+         depending on the need. See
+         https://github.com/yegor256/takes/pull/886#issuecomment-446030223
+         for details.
+       -->
       <version>0.38</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/takes/facets/auth/Identity.java
+++ b/src/main/java/org/takes/facets/auth/Identity.java
@@ -43,10 +43,12 @@ public interface Identity {
         public String toString() {
             return "anonymous";
         }
+
         @Override
         public String urn() {
             throw new UnsupportedOperationException("#urn()");
         }
+
         @Override
         public Map<String, String> properties() {
             throw new UnsupportedOperationException("#properties()");
@@ -73,10 +75,12 @@ public interface Identity {
          * URN.
          */
         private final String name;
+
         /**
          * Map of properties.
          */
         private final Map<String, String> props;
+
         /**
          * Ctor.
          * @param urn URN of the identity
@@ -84,6 +88,7 @@ public interface Identity {
         public Simple(final String urn) {
             this(urn, Collections.<String, String>emptyMap());
         }
+
         /**
          * Ctor.
          * @param urn URN of the identity
@@ -93,10 +98,12 @@ public interface Identity {
             this.name = urn;
             this.props = Collections.unmodifiableMap(map);
         }
+
         @Override
         public String urn() {
             return this.name;
         }
+
         @Override
         public Map<String, String> properties() {
             return Collections.unmodifiableMap(this.props);

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -157,6 +157,7 @@ public final class PsBasic implements Pass {
          * Should we authenticate a user?
          */
         private final boolean condition;
+
         /**
          * Ctor.
          * @param cond Condition
@@ -164,6 +165,7 @@ public final class PsBasic implements Pass {
         public Fake(final boolean cond) {
             this.condition = cond;
         }
+
         @Override
         public Opt<Identity> enter(final String usr, final String pwd) {
             final Opt<Identity> user;
@@ -204,14 +206,17 @@ public final class PsBasic implements Pass {
          * formatted.
          */
         private static final String KEY_FORMAT = "%s %s";
+
         /**
          * Encoding for URLEncode#encode.
          */
         private static final String ENCODING = "UTF-8";
+
         /**
          * Map from login/password pairs to URNs.
          */
         private final Map<String, String> usernames;
+
         /**
          * Public ctor.
          * @param users Strings with user's login, password and URN with
@@ -244,6 +249,7 @@ public final class PsBasic implements Pass {
             }
             return identity;
         }
+
         /**
          * Converts Strings with user's login, password and URN to Map.
          * @param users Strings with user's login, password and URN with
@@ -264,6 +270,7 @@ public final class PsBasic implements Pass {
             }
             return result;
         }
+
         /**
          * Returns an URN corresponding to a login-password pair.
          * @param user Login.
@@ -298,6 +305,7 @@ public final class PsBasic implements Pass {
             }
             return opt;
         }
+
         /**
          * Creates a key for
          *  {@link org.takes.facets.auth.PsBasic.Default#usernames} map.
@@ -316,6 +324,7 @@ public final class PsBasic implements Pass {
                 )
             );
         }
+
         /**
          * Checks if a unified user string is correctly formatted.
          * @param unified String with urlencoded user login, password and urn
@@ -334,6 +343,7 @@ public final class PsBasic implements Pass {
                 );
             }
         }
+
         /**
          * Counts spaces in a string.
          * @param txt Any string.

--- a/src/main/java/org/takes/facets/auth/PsByFlag.java
+++ b/src/main/java/org/takes/facets/auth/PsByFlag.java
@@ -140,6 +140,7 @@ public final class PsByFlag implements Pass {
          * Serialization marker.
          */
         private static final long serialVersionUID = 7362482770166663015L;
+
         /**
          * Ctor.
          * @param key Key
@@ -148,6 +149,7 @@ public final class PsByFlag implements Pass {
         public Pair(final String key, final Pass pass) {
             this(Pattern.compile(Pattern.quote(key)), pass);
         }
+
         /**
          * Ctor.
          * @param key Key

--- a/src/main/java/org/takes/facets/auth/PsToken.java
+++ b/src/main/java/org/takes/facets/auth/PsToken.java
@@ -134,7 +134,7 @@ public final class PsToken implements Pass {
             tocheck.put(jwtheader).put(".".getBytes()).put(jwtpayload);
             final byte[] checked = this.signature.sign(tocheck.array());
             if (Arrays.equals(jwtsign, checked)) {
-                try (final JsonReader rdr = Json.createReader(
+                try (JsonReader rdr = Json.createReader(
                     new StringReader(
                         new String(Base64.getDecoder().decode(jwtpayload))
                     )
@@ -164,7 +164,7 @@ public final class PsToken implements Pass {
         tosign.put(".".getBytes());
         tosign.put(jwtpayload);
         final byte[] sign = this.signature.sign(tosign.array());
-        try (final JsonReader reader = Json.createReader(res.body())) {
+        try (JsonReader reader = Json.createReader(res.body())) {
             final JsonObject target = Json.createObjectBuilder()
                 .add("response", reader.read())
                 .add(

--- a/src/main/java/org/takes/facets/auth/RsLogout.java
+++ b/src/main/java/org/takes/facets/auth/RsLogout.java
@@ -47,6 +47,7 @@ public final class RsLogout extends RsWrap {
     public RsLogout(final Response res) {
         this(res, PsCookie.class.getSimpleName());
     }
+
     /**
      * Ctor.
      * @param res Original response

--- a/src/main/java/org/takes/facets/auth/Token.java
+++ b/src/main/java/org/takes/facets/auth/Token.java
@@ -94,7 +94,7 @@ public interface Token {
         public byte[] encoded() throws IOException {
             return Base64.getEncoder().encode(this.joseo.toString().getBytes());
         }
-    };
+    }
 
     /**
      * JSON Web Token.
@@ -165,5 +165,5 @@ public interface Token {
         public byte[] encoded() throws IOException {
             return Base64.getEncoder().encode(this.jwto.toString().getBytes());
         }
-    };
+    }
 }

--- a/src/main/java/org/takes/facets/auth/codecs/CcAes.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcAes.java
@@ -71,6 +71,7 @@ public final class CcAes implements Codec {
      * The encryption key.
      */
     private final Key key;
+
     /**
      * Random.
      */
@@ -86,6 +87,7 @@ public final class CcAes implements Codec {
     public CcAes(final Codec codec, final String key) {
         this(codec, key.getBytes(Charset.defaultCharset()));
     }
+
     /**
      * Constructor for the class.
      *

--- a/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
@@ -86,9 +86,9 @@ public final class CcBase64 implements Codec {
      */
     private static byte[] checkIllegalCharacters(final byte[] bytes) {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        for (int pos = 0; pos < bytes.length; ++pos) {
-            if (BASE64CHARS.indexOf(bytes[pos]) < 0) {
-                out.write(bytes[pos]);
+        for (final byte byt: bytes) {
+            if (BASE64CHARS.indexOf(byt) < 0) {
+                out.write(byt);
             }
         }
         return out.toByteArray();

--- a/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
@@ -93,6 +93,7 @@ public final class CcSalted implements Codec {
      * @param text Salted text
      * @return Original text
      */
+    @SuppressWarnings("PMD.CyclomaticComplexity")
     private static byte[] unsalt(final byte[] text) {
         if (text.length == 0) {
             throw new DecodingException("empty input");

--- a/src/main/java/org/takes/facets/auth/codecs/CcSigned.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSigned.java
@@ -40,14 +40,17 @@ public final class CcSigned implements Codec {
      * Origin codec.
      */
     private final Codec cdc;
+
     /**
      * MAC algorithm.
      */
     private final String alg;
+
     /**
      * Secret key.
      */
     private final Key key;
+
     /**
      * Ctor.
      * @param origin Origin codec

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -143,7 +143,7 @@ public final class SiHmac implements Signature {
      *  for all unexpected exceptions
      */
     private byte[] encrypt(final byte[] bytes) throws IOException {
-        try (final Formatter formatter = new Formatter()) {
+        try (Formatter formatter = new Formatter()) {
             for (final byte byt : this.create().doFinal(bytes)) {
                 formatter.format("%02x", byt);
             }
@@ -165,13 +165,10 @@ public final class SiHmac implements Signature {
             final SecretKeySpec secret = new SecretKeySpec(
                 this.key, algo
             );
-            final Mac mac = Mac
-                .getInstance(algo);
+            final Mac mac = Mac.getInstance(algo);
             mac.init(secret);
             return mac;
-        } catch (final InvalidKeyException ex) {
-            throw new IOException(ex);
-        } catch (final NoSuchAlgorithmException ex) {
+        } catch (final NoSuchAlgorithmException | InvalidKeyException ex) {
             throw new IOException(ex);
         }
     }

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -59,12 +59,9 @@ public final class FbStatus extends FbWrap {
      * @since 0.16.10
      */
     public FbStatus(final int code) {
-        this(
-            new Filtered<>(
-                (value) -> code == value.intValue(), code
-            )
-        );
+        this(new Filtered<>(value -> code == value.intValue(), code));
     }
+
     /**
      * Ctor.
      * @param check HTTP status code predicate
@@ -92,6 +89,7 @@ public final class FbStatus extends FbWrap {
             }
         });
     }
+
     /**
      * Ctor.
      * @param code HTTP status code
@@ -127,9 +125,7 @@ public final class FbStatus extends FbWrap {
      */
     public FbStatus(final int code, final Fallback fallback) {
         this(
-            new Filtered<>(
-                (status) -> code == status.intValue(), code
-            ),
+            new Filtered<>(status -> code == status.intValue(), code),
             fallback
         );
     }
@@ -141,9 +137,7 @@ public final class FbStatus extends FbWrap {
      */
     public FbStatus(final int code, final Scalar<Fallback> fallback) {
         this(
-            new Filtered<>(
-                (status) -> code == status.intValue(), code
-            ),
+            new Filtered<>(status -> code == status.intValue(), code),
             fallback
         );
     }
@@ -164,6 +158,7 @@ public final class FbStatus extends FbWrap {
             }
         );
     }
+
     /**
      * Ctor.
      * @param check Check

--- a/src/main/java/org/takes/facets/fallback/RqFallback.java
+++ b/src/main/java/org/takes/facets/fallback/RqFallback.java
@@ -69,14 +69,17 @@ public interface RqFallback extends Request {
          * Original request.
          */
         private final Request request;
+
         /**
          * HTTP status code.
          */
         private final int status;
+
         /**
          * Throwable.
          */
         private final Throwable err;
+
         /**
          * Ctor.
          * @param code HTTP status code
@@ -84,6 +87,7 @@ public interface RqFallback extends Request {
         public Fake(final int code) {
             this(code, new HttpException(code));
         }
+
         /**
          * Ctor.
          * @param code HTTP status code
@@ -92,6 +96,7 @@ public interface RqFallback extends Request {
         public Fake(final int code, final Throwable error) {
             this(new RqFake(), code, error);
         }
+
         /**
          * Ctor.
          * @param req Request
@@ -103,18 +108,22 @@ public interface RqFallback extends Request {
             this.status = code;
             this.err = error;
         }
+
         @Override
         public int code() {
             return this.status;
         }
+
         @Override
         public Throwable throwable() {
             return this.err;
         }
+
         @Override
         public Iterable<String> head() throws IOException {
             return this.request.head();
         }
+
         @Override
         public InputStream body() throws IOException {
             return this.request.body();

--- a/src/main/java/org/takes/facets/fallback/TkFallback.java
+++ b/src/main/java/org/takes/facets/fallback/TkFallback.java
@@ -177,6 +177,7 @@ public final class TkFallback extends TkWrap {
                 }
                 return head;
             }
+
             @Override
             public InputStream body() throws IOException {
                 final long start = System.currentTimeMillis();

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -24,9 +24,9 @@
 package org.takes.facets.fork;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -213,8 +213,8 @@ public final class FkHitRefresh implements Fork {
          * @throws IOException If fails
          */
         public void touch() throws IOException {
-            try (final OutputStream out = new FileOutputStream(
-                this.touchedFile()
+            try (OutputStream out = Files.newOutputStream(
+                this.touchedFile().toPath()
             )) {
                 out.write('+');
             }

--- a/src/main/java/org/takes/facets/fork/RqRegex.java
+++ b/src/main/java/org/takes/facets/fork/RqRegex.java
@@ -63,10 +63,12 @@ public interface RqRegex extends Request {
          * Original request.
          */
         private final Request request;
+
         /**
          * Matcher.
          */
         private final Matcher mtr;
+
         /**
          * Ctor.
          * @param ptn Pattern
@@ -75,6 +77,7 @@ public interface RqRegex extends Request {
         public Fake(final String ptn, final CharSequence query) {
             this(new RqFake(), ptn, query);
         }
+
         /**
          * Ctor.
          * @param req Request
@@ -85,6 +88,7 @@ public interface RqRegex extends Request {
             final CharSequence query) {
             this(req, Pattern.compile(ptn).matcher(query));
         }
+
         /**
          * Ctor.
          * @param req Request
@@ -94,6 +98,7 @@ public interface RqRegex extends Request {
             this.request = req;
             this.mtr = matcher;
         }
+
         @Override
         public Matcher matcher() {
             if (!this.mtr.matches()) {
@@ -107,10 +112,12 @@ public interface RqRegex extends Request {
             }
             return this.mtr;
         }
+
         @Override
         public Iterable<String> head() throws IOException {
             return this.request.head();
         }
+
         @Override
         public InputStream body() throws IOException {
             return this.request.body();

--- a/src/main/java/org/takes/facets/fork/RsFork.java
+++ b/src/main/java/org/takes/facets/fork/RsFork.java
@@ -67,6 +67,7 @@ public final class RsFork extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return RsFork.pick(req, list).head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return RsFork.pick(req, list).body();

--- a/src/main/java/org/takes/facets/fork/TkMethods.java
+++ b/src/main/java/org/takes/facets/fork/TkMethods.java
@@ -45,7 +45,7 @@ public class TkMethods extends TkWrap {
      * @param take Original take
      * @param methods Methods the take should act
      */
-    public TkMethods(final Take take, final String ...methods) {
+    public TkMethods(final Take take, final String... methods) {
         super(
             new TkFork(
                 new FkMethods(Arrays.asList(methods), take),

--- a/src/main/java/org/takes/facets/fork/TkRegex.java
+++ b/src/main/java/org/takes/facets/fork/TkRegex.java
@@ -56,10 +56,12 @@ public interface TkRegex {
          * Original take, expecting {@link RqRegex}.
          */
         private final TkRegex origin;
+
         /**
          * Matcher.
          */
         private final Matcher matcher;
+
         /**
          * Ctor.
          * @param rgx Original destination
@@ -70,6 +72,7 @@ public interface TkRegex {
             final CharSequence query) {
             this(rgx, Pattern.compile(ptn).matcher(query));
         }
+
         /**
          * Ctor.
          * @param rgx Original destination
@@ -79,6 +82,7 @@ public interface TkRegex {
             this.origin = rgx;
             this.matcher = mtr;
         }
+
         @Override
         public Response act(final Request req) throws IOException {
             return this.origin.act(new RqRegex.Fake(req, this.matcher));

--- a/src/main/java/org/takes/facets/forward/TkForward.java
+++ b/src/main/java/org/takes/facets/forward/TkForward.java
@@ -79,10 +79,12 @@ public final class TkForward implements Take {
          * Original response.
          */
         private final Response origin;
+
         /**
          * Saved response.
          */
         private final List<Response> saved;
+
         /**
          * Ctor.
          * @param res Original response
@@ -91,14 +93,17 @@ public final class TkForward implements Take {
             this.origin = res;
             this.saved = new CopyOnWriteArrayList<>();
         }
+
         @Override
         public Iterable<String> head() throws IOException {
             return this.load().head();
         }
+
         @Override
         public InputStream body() throws IOException {
             return this.load().body();
         }
+
         /**
          * Load it.
          * @return Response

--- a/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/AbstractHmTextBody.java
@@ -94,7 +94,7 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
      * @return InputStream of body
      * @throws IOException If some problem inside
      */
-    protected abstract InputStream itemBody(final T item) throws IOException;
+    protected abstract InputStream itemBody(T item) throws IOException;
 
     /**
      * Text from item.
@@ -106,8 +106,8 @@ public abstract class AbstractHmTextBody<T> extends TypeSafeMatcher<T> {
     private String text(final T item) throws IOException {
         final String text;
         try (
-            final InputStream input = this.itemBody(item);
-            final ByteArrayOutputStream output = new ByteArrayOutputStream()
+            InputStream input = this.itemBody(item);
+            ByteArrayOutputStream output = new ByteArrayOutputStream()
         ) {
             // @checkstyle MagicNumberCheck (1 line)
             final byte[] buffer = new byte[1024];

--- a/src/main/java/org/takes/facets/hamcrest/HmBody.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmBody.java
@@ -115,9 +115,7 @@ public final class HmBody<T extends Body> extends TypeSafeMatcher<T> {
     public boolean matchesSafely(final T item) {
         boolean result = true;
         try (
-            final InputStream val = new BufferedInputStream(
-                HmBody.itemBody(item)
-            )
+            InputStream val = new BufferedInputStream(HmBody.itemBody(item))
         ) {
             int left = this.body.read();
             while (left != -1) {
@@ -157,7 +155,7 @@ public final class HmBody<T extends Body> extends TypeSafeMatcher<T> {
     @SuppressWarnings("PMD.AssignmentInOperand")
     private static byte[] asBytes(final InputStream input) throws IOException {
         input.reset();
-        try (final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             // @checkstyle MagicNumberCheck (1 line)
             final byte[] buffer = new byte[1024];
             int read;

--- a/src/main/java/org/takes/facets/ret/RsReturn.java
+++ b/src/main/java/org/takes/facets/ret/RsReturn.java
@@ -61,6 +61,7 @@ public final class RsReturn extends RsWrap {
         throws IOException {
         this(res, loc, RsReturn.class.getSimpleName());
     }
+
     /**
      * Ctor.
      * @param res Response to decorate

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -54,27 +54,28 @@ import org.takes.rs.RsWithStatus;
  * @checkstyle IndentationCheck (500 lines)
  */
 @EqualsAndHashCode
+@SuppressWarnings("PMD.DataClass")
 public final class BkBasic implements Back {
 
     /**
      * Local address header name.
      */
-     public static final String LOCALADDR =  "X-Takes-LocalAddress";
+    public static final String LOCALADDR =  "X-Takes-LocalAddress";
 
     /**
      * Local port header name.
      */
-     public static final String LOCALPORT = "X-Takes-LocalPort";
+    public static final String LOCALPORT = "X-Takes-LocalPort";
 
     /**
      * Remote address header name.
      */
-     public static final String REMOTEADDR = "X-Takes-RemoteAddress";
+    public static final String REMOTEADDR = "X-Takes-RemoteAddress";
 
     /**
      * Remote port header name.
      */
-     public static final String REMOTEPORT = "X-Takes-RemotePort";
+    public static final String REMOTEPORT = "X-Takes-RemotePort";
 
     /**
      * Take.
@@ -93,8 +94,8 @@ public final class BkBasic implements Back {
     @Override
     public void accept(final Socket socket) throws IOException {
         try (
-            final InputStream input = socket.getInputStream();
-            final BufferedOutputStream output = new BufferedOutputStream(
+            InputStream input = socket.getInputStream();
+            BufferedOutputStream output = new BufferedOutputStream(
                 socket.getOutputStream()
             )
         ) {

--- a/src/main/java/org/takes/http/BkTimeable.java
+++ b/src/main/java/org/takes/http/BkTimeable.java
@@ -44,10 +44,12 @@ public final class BkTimeable extends Thread implements Back {
      * Original back.
      */
     private final Back back;
+
     /**
      * Maximum latency in milliseconds.
      */
     private final long latency;
+
     /**
      * Threads storage.
      */

--- a/src/main/java/org/takes/http/BkWrap.java
+++ b/src/main/java/org/takes/http/BkWrap.java
@@ -37,6 +37,7 @@ public class BkWrap implements Back {
      * Original back.
      */
     private final Back origin;
+
     /**
      * Ctor.
      * @param back Original back

--- a/src/main/java/org/takes/http/Exit.java
+++ b/src/main/java/org/takes/http/Exit.java
@@ -57,10 +57,12 @@ public interface Exit {
          * Left.
          */
         private final Exit left;
+
         /**
          * Right.
          */
         private final Exit right;
+
         /**
          * Ctor.
          * @param lft Left
@@ -70,6 +72,7 @@ public interface Exit {
             this.left = lft;
             this.right = rht;
         }
+
         @Override
         public boolean ready() {
             return this.left.ready() || this.right.ready();
@@ -85,10 +88,12 @@ public interface Exit {
          * Left.
          */
         private final Exit left;
+
         /**
          * Right.
          */
         private final Exit right;
+
         /**
          * Ctor.
          * @param lft Left
@@ -98,6 +103,7 @@ public interface Exit {
             this.left = lft;
             this.right = rht;
         }
+
         @Override
         public boolean ready() {
             return this.left.ready() && this.right.ready();
@@ -113,6 +119,7 @@ public interface Exit {
          * Origin.
          */
         private final Exit origin;
+
         /**
          * Ctor.
          * @param exit Original
@@ -120,6 +127,7 @@ public interface Exit {
         public Not(final Exit exit) {
             this.origin = exit;
         }
+
         @Override
         public boolean ready() {
             return !this.origin.ready();

--- a/src/main/java/org/takes/http/FtCli.java
+++ b/src/main/java/org/takes/http/FtCli.java
@@ -182,6 +182,5 @@ public final class FtCli implements Front {
         public boolean ready() {
             return System.currentTimeMillis() - this.start > this.max;
         }
-    };
-
+    }
 }

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -24,12 +24,12 @@
 package org.takes.http;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
@@ -147,7 +147,7 @@ public final class MainRemote {
             TimeUnit.MILLISECONDS.sleep(1L);
         }
         final int port;
-        try (InputStream input = new FileInputStream(file)) {
+        try (InputStream input = Files.newInputStream(file.toPath())) {
             // @checkstyle MagicNumber (1 line)
             final byte[] buf = new byte[10];
             while (true) {

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -24,12 +24,11 @@
 package org.takes.http;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -96,7 +95,7 @@ final class Options {
             final File file = new File(port);
             if (file.exists()) {
                 try (Reader reader = new Utf8InputStreamReader(
-                    new FileInputStream(file)
+                    Files.newInputStream(file.toPath())
                     )
                 ) {
                     // @checkstyle MagicNumber (1 line)
@@ -109,9 +108,8 @@ final class Options {
             } else {
                 socket = new ServerSocket(0);
                 try (Writer writer = new Utf8OutputStreamWriter(
-                    new FileOutputStream(file)
-                    )
-                ) {
+                    Files.newOutputStream(file.toPath())
+                )) {
                     writer.append(Integer.toString(socket.getLocalPort()));
                 }
             }

--- a/src/main/java/org/takes/misc/Concat.java
+++ b/src/main/java/org/takes/misc/Concat.java
@@ -80,10 +80,12 @@ public final class Concat<T> implements Iterable<T> {
          * Internal reference for holding the first iterator from constructor.
          */
         private final Iterator<E> left;
+
         /**
          * Internal reference for holding the second iterator from constructor.
          */
         private final Iterator<E> right;
+
         /**
          * Ctor.
          * @param aitr The first iterable to traverse
@@ -93,10 +95,12 @@ public final class Concat<T> implements Iterable<T> {
             this.left = aitr;
             this.right = bitr;
         }
+
         @Override
         public boolean hasNext() {
             return this.left.hasNext() || this.right.hasNext();
         }
+
         @Override
         public E next() {
             final E object;
@@ -107,6 +111,7 @@ public final class Concat<T> implements Iterable<T> {
             }
             return object;
         }
+
         @Override
         public void remove() {
             throw new UnsupportedOperationException(

--- a/src/main/java/org/takes/misc/Opt.java
+++ b/src/main/java/org/takes/misc/Opt.java
@@ -59,6 +59,7 @@ public interface Opt<T> {
          * Origin.
          */
         private final T origin;
+
         /**
          * Ctor.
          * @param orgn Origin
@@ -66,10 +67,12 @@ public interface Opt<T> {
         public Single(final T orgn) {
             this.origin = orgn;
         }
+
         @Override
         public T get() {
             return this.origin;
         }
+
         @Override
         public boolean has() {
             return true;
@@ -90,6 +93,7 @@ public interface Opt<T> {
                 "there is nothing here, use has() first, to check"
             );
         }
+
         @Override
         public boolean has() {
             return false;

--- a/src/main/java/org/takes/misc/Sprintf.java
+++ b/src/main/java/org/takes/misc/Sprintf.java
@@ -67,7 +67,7 @@ public final class Sprintf implements CharSequence {
     @Override
     public String toString() {
         final StringBuilder out = new StringBuilder(0);
-        try (final Formatter fmt = new Formatter(out)) {
+        try (Formatter fmt = new Formatter(out)) {
             fmt.format(
                 this.pattern,
                 this.args.toArray(new Object[this.args.size()])

--- a/src/main/java/org/takes/rq/RqBuffered.java
+++ b/src/main/java/org/takes/rq/RqBuffered.java
@@ -50,6 +50,7 @@ public final class RqBuffered extends RqWrap {
                 public Iterable<String> head() throws IOException {
                     return req.head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return new BufferedInputStream(req.body());

--- a/src/main/java/org/takes/rq/RqChunk.java
+++ b/src/main/java/org/takes/rq/RqChunk.java
@@ -52,6 +52,7 @@ public final class RqChunk extends RqWrap {
                 public Iterable<String> head() throws IOException {
                     return req.head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return RqChunk.cap(req);

--- a/src/main/java/org/takes/rq/RqFake.java
+++ b/src/main/java/org/takes/rq/RqFake.java
@@ -116,6 +116,7 @@ public final class RqFake extends RqWrap {
                 public Iterable<String> head() {
                     return Collections.unmodifiableList(head);
                 }
+
                 @Override
                 public InputStream body() {
                     return body;

--- a/src/main/java/org/takes/rq/RqGreedy.java
+++ b/src/main/java/org/takes/rq/RqGreedy.java
@@ -63,6 +63,7 @@ public final class RqGreedy extends RqWrap {
             public Iterable<String> head() throws IOException {
                 return req.head();
             }
+
             @Override
             public InputStream body() {
                 return new ByteArrayInputStream(baos.toByteArray());

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -84,6 +84,7 @@ public interface RqHeaders extends Request {
         public Base(final Request req) {
             super(req);
         }
+
         @Override
         public List<String> header(final CharSequence key)
             throws IOException {
@@ -115,10 +116,12 @@ public interface RqHeaders extends Request {
             }
             return list;
         }
+
         @Override
         public Set<String> names() throws IOException {
             return this.map().keySet();
         }
+
         /**
          * Parse them all in a map.
          *
@@ -170,6 +173,7 @@ public interface RqHeaders extends Request {
          * Original.
          */
         private final RqHeaders origin;
+
         /**
          * Ctor.
          * @param req Original request
@@ -177,6 +181,7 @@ public interface RqHeaders extends Request {
         public Smart(final RqHeaders req) {
             this.origin = req;
         }
+
         /**
          * Ctor.
          * @param req Original request
@@ -184,23 +189,28 @@ public interface RqHeaders extends Request {
         public Smart(final Request req) {
             this(new RqHeaders.Base(req));
         }
+
         @Override
         public List<String> header(final CharSequence name)
             throws IOException {
             return this.origin.header(name);
         }
+
         @Override
         public Set<String> names() throws IOException {
             return this.origin.names();
         }
+
         @Override
         public Iterable<String> head() throws IOException {
             return this.origin.head();
         }
+
         @Override
         public InputStream body() throws IOException {
             return this.origin.body();
         }
+
         /**
          * Get single header or throw HTTP exception.
          * @param name Name of header
@@ -220,6 +230,7 @@ public interface RqHeaders extends Request {
             }
             return params.next();
         }
+
         /**
          * If header is present, returns the first header value.
          * If not, returns a default value.

--- a/src/main/java/org/takes/rq/RqHref.java
+++ b/src/main/java/org/takes/rq/RqHref.java
@@ -64,6 +64,7 @@ public interface RqHref extends Request {
         public Base(final Request req) {
             super(req);
         }
+
         @Override
         public Href href() throws IOException {
             final String uri = new RqRequestLine.Base(this).uri();
@@ -100,6 +101,7 @@ public interface RqHref extends Request {
          * Original.
          */
         private final RqHref origin;
+
         /**
          * Ctor.
          * @param req Original request
@@ -108,6 +110,7 @@ public interface RqHref extends Request {
         public Smart(final Request req) {
             this(new RqHref.Base(req));
         }
+
         /**
          * Ctor.
          * @param req Original request
@@ -115,18 +118,22 @@ public interface RqHref extends Request {
         public Smart(final RqHref req) {
             this.origin = req;
         }
+
         @Override
         public Href href() throws IOException {
             return this.origin.href();
         }
+
         @Override
         public Iterable<String> head() throws IOException {
             return this.origin.head();
         }
+
         @Override
         public InputStream body() throws IOException {
             return this.origin.body();
         }
+
         /**
          * Get self.
          * @return Self page, full URL
@@ -143,6 +150,7 @@ public interface RqHref extends Request {
                 )
             );
         }
+
         /**
          * Get param or throw HTTP exception.
          * @param name Name of query param
@@ -161,6 +169,7 @@ public interface RqHref extends Request {
             }
             return params.next();
         }
+
         /**
          * Get param or default.
          * @param name Name of query param

--- a/src/main/java/org/takes/rq/RqLengthAware.java
+++ b/src/main/java/org/takes/rq/RqLengthAware.java
@@ -63,6 +63,7 @@ public final class RqLengthAware extends RqWrap {
                 public Iterable<String> head() throws IOException {
                     return req.head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return RqLengthAware.cap(req);

--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -94,6 +94,7 @@ public final class RqLive extends RqWrap {
             public Iterable<String> head() {
                 return head;
             }
+
             @Override
             public InputStream body() {
                 return input;

--- a/src/main/java/org/takes/rq/RqOnce.java
+++ b/src/main/java/org/takes/rq/RqOnce.java
@@ -59,6 +59,7 @@ public final class RqOnce extends RqWrap {
             public Iterable<String> head() throws IOException {
                 return req.head();
             }
+
             @Override
             public InputStream body() throws IOException {
                 if (!seen.getAndSet(true)) {

--- a/src/main/java/org/takes/rq/RqSimple.java
+++ b/src/main/java/org/takes/rq/RqSimple.java
@@ -49,6 +49,7 @@ public class RqSimple extends RqWrap {
                 public Iterable<String> head() {
                     return head;
                 }
+
                 @Override
                 public InputStream body() {
                     return body;

--- a/src/main/java/org/takes/rq/RqWithBody.java
+++ b/src/main/java/org/takes/rq/RqWithBody.java
@@ -50,6 +50,7 @@ public final class RqWithBody extends RqWrap {
             public Iterable<String> head() throws IOException {
                 return req.head();
             }
+
             @Override
             public InputStream body() {
                 return new ByteArrayInputStream(

--- a/src/main/java/org/takes/rq/RqWithHeaders.java
+++ b/src/main/java/org/takes/rq/RqWithHeaders.java
@@ -70,6 +70,7 @@ public final class RqWithHeaders extends RqWrap {
                     }
                     return head;
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return req.body();

--- a/src/main/java/org/takes/rq/RqWithoutHeader.java
+++ b/src/main/java/org/takes/rq/RqWithoutHeader.java
@@ -55,11 +55,12 @@ public final class RqWithoutHeader extends RqWrap {
                         "%s:", new EnglishLowerCase(name.toString()).string()
                     );
                     return new Filtered<>(
-                        (header) -> !new EnglishLowerCase(header).string()
+                        header -> !new EnglishLowerCase(header).string()
                             .startsWith(prefix),
                         req.head()
                     );
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return req.body();

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -76,38 +76,46 @@ public final class RqMtBase implements RqMultipart {
      * The encoding used to create the request.
      */
     private static final Charset ENCODING = Charset.forName("UTF-8");
+
     /**
      * Pattern to get boundary from header.
      */
     private static final Pattern BOUNDARY = Pattern.compile(
         ".*[^a-z]boundary=([^;]+).*"
     );
+
     /**
      * Pattern to get name from header.
      */
     private static final Pattern NAME = Pattern.compile(
         ".*[^a-z]name=\"([^\"]+)\".*"
     );
+
     /**
      * Carriage return constant.
      */
     private static final String CRLF = "\r\n";
+
     /**
      * Map of params and values.
      */
     private final Map<String, List<Request>> map;
+
     /**
      * Internal buffer.
      */
     private final ByteBuffer buffer;
+
     /**
      * InputStream based on request body.
      */
     private final InputStream stream;
+
     /**
      * Original request.
      */
     private final Request origin;
+
     /**
      * Ctor.
      * @param req Original request
@@ -123,6 +131,7 @@ public final class RqMtBase implements RqMultipart {
         );
         this.map = this.requests(req);
     }
+
     @Override
     public Iterable<Request> part(final CharSequence name) {
         final List<Request> values = this.map
@@ -147,6 +156,7 @@ public final class RqMtBase implements RqMultipart {
         }
         return iter;
     }
+
     @Override
     public Iterable<String> names() {
         return this.map.keySet();
@@ -215,6 +225,7 @@ public final class RqMtBase implements RqMultipart {
         }
         return RqMtBase.asMap(requests);
     }
+
     /**
      * Make a request.
      *  Scans the origin request until the boundary reached. Caches
@@ -247,6 +258,7 @@ public final class RqMtBase implements RqMultipart {
         }
         return new RqTemp(file);
     }
+
     /**
      * Copy until boundary reached.
      * @param target Output file channel
@@ -293,6 +305,7 @@ public final class RqMtBase implements RqMultipart {
             target.write(btarget);
         }
     }
+
     /**
      * Convert a list of requests to a map.
      * @param reqs Requests

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -42,14 +42,17 @@ public final class RqMtFake implements RqMultipart {
      * Fake boundary constant.
      */
     private static final String BOUNDARY = "AaB02x";
+
     /**
      * Carriage return constant.
      */
     private static final String CRLF = "\r\n";
+
     /**
      * Fake multipart request.
      */
     private final RqMultipart fake;
+
     /**
      * Fake ctor.
      * @param req Fake request header holder
@@ -62,22 +65,27 @@ public final class RqMtFake implements RqMultipart {
             new RqMtFake.FakeMultipartRequest(req, dispositions)
         );
     }
+
     @Override
     public Iterable<Request> part(final CharSequence name) {
         return this.fake.part(name);
     }
+
     @Override
     public Iterable<String> names() {
         return this.fake.names();
     }
+
     @Override
     public Iterable<String> head() throws IOException {
         return this.fake.head();
     }
+
     @Override
     public InputStream body() throws IOException {
         return this.fake.body();
     }
+
     /**
      * Fake body creator.
      * @param parts Fake request body parts
@@ -123,10 +131,12 @@ public final class RqMtFake implements RqMultipart {
          * Request object. Holds a value for the header.
          */
         private final Request req;
+
         /**
          * Holding multiple request body parts.
          */
         private final String parts;
+
         /**
          * The Constructor for the class.
          * @param rqst The Request object
@@ -138,6 +148,7 @@ public final class RqMtFake implements RqMultipart {
             this.req = rqst;
             this.parts = RqMtFake.fakeBody(list).toString();
         }
+
         @Override
         public Iterable<String> head() throws IOException {
             return new RqWithHeaders(
@@ -149,6 +160,7 @@ public final class RqMtFake implements RqMultipart {
                 String.format("Content-Length: %s", this.parts.length())
             ).head();
         }
+
         @Override
         public InputStream body() {
             return new ByteArrayInputStream(

--- a/src/main/java/org/takes/rq/multipart/RqMtSmart.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtSmart.java
@@ -40,6 +40,7 @@ public final class RqMtSmart implements RqMultipart {
      * Original request.
      */
     private final RqMultipart origin;
+
     /**
      * Ctor.
      * @param req Original
@@ -48,6 +49,7 @@ public final class RqMtSmart implements RqMultipart {
     public RqMtSmart(final Request req) throws IOException {
         this(new RqMtBase(req));
     }
+
     /**
      * Ctor.
      * @param req Original
@@ -55,6 +57,7 @@ public final class RqMtSmart implements RqMultipart {
     public RqMtSmart(final RqMultipart req) {
         this.origin = req;
     }
+
     /**
      * Get single part.
      * @param name Name of the part to get
@@ -73,18 +76,22 @@ public final class RqMtSmart implements RqMultipart {
         }
         return parts.next();
     }
+
     @Override
     public Iterable<Request> part(final CharSequence name) {
         return this.origin.part(name);
     }
+
     @Override
     public Iterable<String> names() {
         return this.origin.names();
     }
+
     @Override
     public Iterable<String> head() throws IOException {
         return this.origin.head();
     }
+
     @Override
     public InputStream body() throws IOException {
         return this.origin.body();

--- a/src/main/java/org/takes/rq/multipart/RqTemp.java
+++ b/src/main/java/org/takes/rq/multipart/RqTemp.java
@@ -24,8 +24,8 @@
 package org.takes.rq.multipart;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import lombok.EqualsAndHashCode;
 import org.takes.rq.RqLive;
 import org.takes.rq.RqWithHeader;
@@ -52,7 +52,10 @@ final class RqTemp extends RqWrap {
         super(
             new RqWithHeader(
                 new RqLive(
-                    new TempInputStream(new FileInputStream(file), file)
+                    new TempInputStream(
+                        Files.newInputStream(file.toPath()),
+                        file
+                    )
                 ),
                 "Content-Length",
                 String.valueOf(file.length())

--- a/src/main/java/org/takes/rs/Body.java
+++ b/src/main/java/org/takes/rs/Body.java
@@ -25,7 +25,6 @@ package org.takes.rs;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -88,7 +87,7 @@ interface Body {
 
         @Override
         public int length() throws IOException {
-            try (final InputStream input = this.url.openStream()) {
+            try (InputStream input = this.url.openStream()) {
                 return input.available();
             }
         }
@@ -208,7 +207,7 @@ interface Body {
 
         @Override
         public InputStream input() throws IOException {
-            return new FileInputStream(this.file());
+            return Files.newInputStream(this.file().toPath());
         }
 
         @Override
@@ -240,7 +239,7 @@ interface Body {
             synchronized (this.file) {
                 if (!this.file.exists()) {
                     this.file.deleteOnExit();
-                    try (final InputStream content = this.body.input()) {
+                    try (InputStream content = this.body.input()) {
                         Files.copy(
                             content,
                             Paths.get(this.file.getAbsolutePath()),

--- a/src/main/java/org/takes/rs/RsBuffered.java
+++ b/src/main/java/org/takes/rs/RsBuffered.java
@@ -52,6 +52,7 @@ public final class RsBuffered extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return res.head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return new BufferedInputStream(res.body());

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -184,7 +184,7 @@ public final class RsPrint extends RsWrap implements Text {
     public void printBody(final OutputStream output) throws IOException {
         //@checkstyle MagicNumberCheck (1 line)
         final byte[] buf = new byte[4096];
-        try (final InputStream body = this.body()) {
+        try (InputStream body = this.body()) {
             while (true) {
                 final int bytes = body.read(buf);
                 if (bytes < 0) {

--- a/src/main/java/org/takes/rs/RsSimple.java
+++ b/src/main/java/org/takes/rs/RsSimple.java
@@ -65,6 +65,7 @@ public class RsSimple extends RsWrap {
                 public Iterable<String> head() {
                     return head;
                 }
+
                 @Override
                 public InputStream body() {
                     return body;

--- a/src/main/java/org/takes/rs/RsVelocity.java
+++ b/src/main/java/org/takes/rs/RsVelocity.java
@@ -115,6 +115,7 @@ public final class RsVelocity extends RsWrap {
         Object> params) {
         this(".", template, params);
     }
+
     /**
      * Ctor.
      * @param folder Template folder
@@ -140,6 +141,7 @@ public final class RsVelocity extends RsWrap {
                 public Iterable<String> head() {
                     return new RsEmpty().head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return RsVelocity.render(folder, template, params.get());
@@ -214,6 +216,7 @@ public final class RsVelocity extends RsWrap {
          * Serialization marker.
          */
         private static final long serialVersionUID = 7362489770169963015L;
+
         /**
          * Ctor.
          * @param key Key

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -145,6 +145,7 @@ public final class RsWithBody extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return RsWithBody.append(res, body.length());
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return body.input();

--- a/src/main/java/org/takes/rs/RsWithHeader.java
+++ b/src/main/java/org/takes/rs/RsWithHeader.java
@@ -107,6 +107,7 @@ public final class RsWithHeader extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return RsWithHeader.extend(res.head(), header.toString());
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return res.body();

--- a/src/main/java/org/takes/rs/RsWithHeaders.java
+++ b/src/main/java/org/takes/rs/RsWithHeaders.java
@@ -71,6 +71,7 @@ public final class RsWithHeaders extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return RsWithHeaders.extend(res, headers);
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return res.body();

--- a/src/main/java/org/takes/rs/RsWithStatus.java
+++ b/src/main/java/org/takes/rs/RsWithStatus.java
@@ -83,6 +83,7 @@ public final class RsWithStatus extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return RsWithStatus.head(res, code, rsn);
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return res.body();

--- a/src/main/java/org/takes/rs/RsWithoutHeader.java
+++ b/src/main/java/org/takes/rs/RsWithoutHeader.java
@@ -49,7 +49,6 @@ public final class RsWithoutHeader extends RsWrap {
      */
     public RsWithoutHeader(final Response res, final CharSequence name) {
         super(
-            // @checkstyle AnonInnerLengthCheck (50 lines)
             new Response() {
                 @Override
                 public Iterable<String> head() throws IOException {
@@ -57,13 +56,14 @@ public final class RsWithoutHeader extends RsWrap {
                         "%s:", new EnglishLowerCase(name.toString()).string()
                     );
                     return new Filtered<>(
-                        (header) -> {
+                        header -> {
                             return !new EnglishLowerCase(header).string()
                                 .startsWith(prefix);
                         },
                         res.head()
                     );
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return res.body();

--- a/src/main/java/org/takes/rs/RsXslt.java
+++ b/src/main/java/org/takes/rs/RsXslt.java
@@ -106,6 +106,7 @@ public final class RsXslt extends RsWrap {
                 public Iterable<String> head() throws IOException {
                     return rsp.head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return RsXslt.transform(rsp.body(), resolver);
@@ -193,6 +194,7 @@ public final class RsXslt extends RsWrap {
         }
         return baos.toByteArray();
     }
+
     /**
      * Retrieve a stylesheet from this XML (throws an exception if
      * no stylesheet is attached).

--- a/src/main/java/org/takes/rs/xe/RsXembly.java
+++ b/src/main/java/org/takes/rs/xe/RsXembly.java
@@ -122,6 +122,7 @@ public final class RsXembly extends RsWrap {
                         "text/xml"
                     ).head();
                 }
+
                 @Override
                 public InputStream body() throws IOException {
                     return RsXembly.render(dom, src);

--- a/src/main/java/org/takes/rs/xe/XeTransform.java
+++ b/src/main/java/org/takes/rs/xe/XeTransform.java
@@ -93,6 +93,7 @@ public final class XeTransform<T> implements Iterable<XeSource> {
             public boolean hasNext() {
                 return origin.hasNext();
             }
+
             @Override
             public XeSource next() {
                 try {
@@ -101,6 +102,7 @@ public final class XeTransform<T> implements Iterable<XeSource> {
                     throw new IllegalStateException(ex);
                 }
             }
+
             @Override
             public void remove() {
                 origin.remove();

--- a/src/main/java/org/takes/servlet/ResponseOf.java
+++ b/src/main/java/org/takes/servlet/ResponseOf.java
@@ -48,6 +48,7 @@ final class ResponseOf {
      * Buffer size.
      */
     private static final int BUFSIZE = 8192;
+
     /**
      * Http response first line head pattern.
      */
@@ -55,10 +56,12 @@ final class ResponseOf {
         "^HTTP/(?:1\\.1|2) (?<code>\\d+).*$",
         Pattern.CANON_EQ | Pattern.DOTALL | Pattern.CASE_INSENSITIVE
     );
+
     /**
      * Origin response.
      */
     private final Response rsp;
+
     /**
      * Ctor.
      * @param response Origin takes response
@@ -66,6 +69,7 @@ final class ResponseOf {
     ResponseOf(final Response response) {
         this.rsp = response;
     }
+
     /**
      * Apply to servlet response.
      * @param sresp Servlet response
@@ -80,8 +84,8 @@ final class ResponseOf {
                 ResponseOf.applyHeader(sresp, head.next());
             }
             try (
-                final InputStream body = this.rsp.body();
-                final OutputStream out = sresp.getOutputStream()
+                InputStream body = this.rsp.body();
+                OutputStream out = sresp.getOutputStream()
             ) {
                 final byte[] buff = new byte[ResponseOf.BUFSIZE];
                 // @checkstyle LineLengthCheck (1 line)

--- a/src/main/java/org/takes/servlet/RqFrom.java
+++ b/src/main/java/org/takes/servlet/RqFrom.java
@@ -42,6 +42,7 @@ final class RqFrom implements Request {
      * Servlet request.
      */
     private final HttpServletRequest sreq;
+
     /**
      * Ctor.
      * @param request Servlet request
@@ -94,6 +95,7 @@ final class RqFrom implements Request {
          * Servlet request.
          */
         private final HttpServletRequest req;
+
         /**
          * Ctor.
          * @param request Servlet request
@@ -129,10 +131,12 @@ final class RqFrom implements Request {
          * Default http port.
          */
         private static final int PORT_DEFAULT = 80;
+
         /**
          * Servlet request.
          */
         private final HttpServletRequest req;
+
         /**
          * Ctor.
          * @param request Servlet request.

--- a/src/main/java/org/takes/servlet/SrvTake.java
+++ b/src/main/java/org/takes/servlet/SrvTake.java
@@ -49,10 +49,12 @@ public final class SrvTake extends HttpServlet {
      * Id for serializable.
      */
     private static final long serialVersionUID = -8119918127398448635L;
+
     /**
      * Take, initialize in {@link #init()}.
      */
     private final AtomicReference<Take> tke;
+
     /**
      * Ctor.
      */
@@ -62,6 +64,7 @@ public final class SrvTake extends HttpServlet {
     }
 
     @Override
+    @SuppressWarnings("PMD.CyclomaticComplexity")
     public void init() throws ServletException {
         super.init();
         final String cname = this.getServletConfig()

--- a/src/main/java/org/takes/tk/TkFiles.java
+++ b/src/main/java/org/takes/tk/TkFiles.java
@@ -24,9 +24,9 @@
 package org.takes.tk;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.takes.HttpException;
@@ -89,7 +89,7 @@ public final class TkFiles extends TkWrap {
                             )
                         );
                     }
-                    return new RsWithBody(new FileInputStream(file));
+                    return new RsWithBody(Files.newInputStream(file.toPath()));
                 }
             }
         );

--- a/src/main/java/org/takes/tk/TkSlf4j.java
+++ b/src/main/java/org/takes/tk/TkSlf4j.java
@@ -90,34 +90,40 @@ public final class TkSlf4j implements Take {
         final Logger logger = LoggerFactory.getLogger(this.target);
         try {
             final Response rsp = this.origin.act(req);
-            logger.info(
-                "[{} {}] returned \"{}\" in {} ms",
-                new RqMethod.Base(req).method(),
-                new RqHref.Base(req).href(),
-                rsp.head().iterator().next(),
-                System.currentTimeMillis() - start
-            );
+            if (logger.isInfoEnabled()) {
+                logger.info(
+                    "[{} {}] returned \"{}\" in {} ms",
+                    new RqMethod.Base(req).method(),
+                    new RqHref.Base(req).href(),
+                    rsp.head().iterator().next(),
+                    System.currentTimeMillis() - start
+                );
+            }
             return rsp;
         } catch (final IOException ex) {
-            logger.info(
-                "[{} {}] thrown {}(\"{}\") in {} ms",
-                new RqMethod.Base(req).method(),
-                new RqHref.Base(req).href(),
-                ex.getClass().getCanonicalName(),
-                ex.getLocalizedMessage(),
-                System.currentTimeMillis() - start
-            );
+            if (logger.isInfoEnabled()) {
+                logger.info(
+                    "[{} {}] thrown {}(\"{}\") in {} ms",
+                    new RqMethod.Base(req).method(),
+                    new RqHref.Base(req).href(),
+                    ex.getClass().getCanonicalName(),
+                    ex.getLocalizedMessage(),
+                    System.currentTimeMillis() - start
+                );
+            }
             throw ex;
             // @checkstyle IllegalCatchCheck (1 line)
         } catch (final RuntimeException ex) {
-            logger.info(
-                "[{} {}] thrown runtime {}(\"{}\") in {} ms",
-                new RqMethod.Base(req).method(),
-                new RqHref.Base(req).href(),
-                ex.getClass().getCanonicalName(),
-                ex.getLocalizedMessage(),
-                System.currentTimeMillis() - start
-            );
+            if (logger.isInfoEnabled()) {
+                logger.info(
+                    "[{} {}] thrown runtime {}(\"{}\") in {} ms",
+                    new RqMethod.Base(req).method(),
+                    new RqHref.Base(req).href(),
+                    ex.getClass().getCanonicalName(),
+                    ex.getLocalizedMessage(),
+                    System.currentTimeMillis() - start
+                );
+            }
             throw ex;
         }
     }

--- a/src/main/java/org/takes/tk/TkSmartRedirect.java
+++ b/src/main/java/org/takes/tk/TkSmartRedirect.java
@@ -89,10 +89,12 @@ public final class TkSmartRedirect extends TkWrap {
          * Original request.
          */
         private final Request req;
+
         /**
          * Original location.
          */
         private final String origin;
+
         /**
          * Ctor.
          * @param req Original request.
@@ -102,6 +104,7 @@ public final class TkSmartRedirect extends TkWrap {
             this.req = req;
             this.origin = origin;
         }
+
         /**
          * Get location with composed params.
          * @return New location.

--- a/src/test/java/org/takes/facets/auth/codecs/CcAesTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcAesTest.java
@@ -157,6 +157,7 @@ public final class CcAesTest {
          * Serial id.
          */
         private static final long serialVersionUID = 8646596235826414879L;
+
         /**
          * Ctor.
          * @param fake Bytes
@@ -171,14 +172,17 @@ public final class CcAesTest {
      */
     @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
     private static final class FkRandomSpi extends SecureRandomSpi {
+
         /**
          * Serial id.
          */
         private static final long serialVersionUID = -5153681125995322457L;
+
         /**
          * Bytes.
          */
         private final byte[] fake;
+
         /**
          * Ctor.
          * @param fake Bytes

--- a/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcBase64Test.java
@@ -38,6 +38,7 @@ import org.takes.facets.auth.Identity;
  * @since 0.13
  */
 public final class CcBase64Test {
+
     /**
      * CcBase64 can encode.
      * @throws IOException If some problem inside
@@ -53,6 +54,7 @@ public final class CcBase64Test {
             Matchers.equalTo("dXJuJTNBdGVzdCUzQTM=")
         );
     }
+
     /**
      * CcBase64 can decode.
      * @throws IOException If some problem inside
@@ -67,6 +69,7 @@ public final class CcBase64Test {
             Matchers.equalTo("urn:test:test")
         );
     }
+
     /**
      * CcBase64 can encode and decode.
      * @throws IOException If some problem inside
@@ -89,6 +92,7 @@ public final class CcBase64Test {
             Matchers.equalTo(properties)
         );
     }
+
     /**
      * CcBase64 can encode empty byte array.
      * @throws IOException If some problem inside
@@ -104,6 +108,7 @@ public final class CcBase64Test {
             Matchers.equalTo("")
         );
     }
+
     /**
      * CcBase64 can decode non Base64 alphabet symbols.
      * @throws IOException If some problem inside
@@ -123,6 +128,7 @@ public final class CcBase64Test {
             );
         }
     }
+
     /**
      * Checks CcBase64 equals method.
      * @throws Exception If some problem inside

--- a/src/test/java/org/takes/facets/auth/codecs/CcGzipTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcGzipTest.java
@@ -24,8 +24,6 @@
 package org.takes.facets.auth.codecs;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -51,34 +49,15 @@ public final class CcGzipTest {
                     throws IOException {
                     return identity.urn().getBytes();
                 }
+
                 @Override
                 public Identity decode(final byte[] bytes) throws IOException {
-                    return new Identity() {
-                        @Override
-                        public String urn() {
-                            return new String(bytes);
-                        }
-                        @Override
-                        public Map<String, String> properties() {
-                            return new HashMap<String, String>();
-                        }
-                    };
+                    return new Identity.Simple(new String(bytes));
                 }
             }
         );
         final String urn = "test:gzip";
-        final byte[] encode = gzip.encode(
-            new Identity() {
-                @Override
-                public String urn() {
-                    return urn;
-                }
-                @Override
-                public Map<String, String> properties() {
-                    return new HashMap<String, String>();
-                }
-            }
-        );
+        final byte[] encode = gzip.encode(new Identity.Simple(urn));
         MatcherAssert.assertThat(
             gzip.decode(encode).urn(),
             Matchers.containsString(urn)

--- a/src/test/java/org/takes/facets/auth/codecs/CcTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcTest.java
@@ -34,6 +34,7 @@ final class CcTest implements Codec {
     public Identity decode(final byte[] bytes) {
         return new Identity.Simple(new String(bytes));
     }
+
     @Override
     public byte[] encode(final Identity identity) {
         return identity.urn().getBytes();

--- a/src/test/java/org/takes/facets/auth/codecs/CcXorTest.java
+++ b/src/test/java/org/takes/facets/auth/codecs/CcXorTest.java
@@ -49,6 +49,7 @@ public final class CcXorTest {
                 public byte[] encode(final Identity identity) {
                     return identity.urn().getBytes();
                 }
+
                 @Override
                 public Identity decode(final byte[] bytes) {
                     return new Identity.Simple(new String(bytes));

--- a/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
+++ b/src/test/java/org/takes/facets/auth/signatures/SiHmacTest.java
@@ -47,6 +47,7 @@ public final class SiHmacTest {
             Matchers.equalTo(SiHmac.HMAC256)
         );
     }
+
     /**
      * SiHmac can sign.
      * @throws IOException If some problem inside
@@ -64,6 +65,7 @@ public final class SiHmacTest {
             )
         );
     }
+
     /**
      * Checks SiHmac equals method.
      * @throws Exception If some problem inside

--- a/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsGoogleTest.java
@@ -59,62 +59,77 @@ public final class PsGoogleTest {
      * Image.
      */
     private static final String IMAGE = "image";
+
     /**
      * GET.
      */
     private static final String GET = "GET";
+
     /**
      * Name.
      */
     private static final String NAME = "name";
+
     /**
      * Picture.
      */
     private static final String PICTURE = "picture";
+
     /**
      * Url.
      */
     private static final String URL = "url";
+
     /**
      * Act head.
      */
     private static final String ACT_HEAD = "GET /plus/v1/people/me";
+
     /**
      * Regex pattern.
      */
     private static final String REGEX_PATTERN = "/plus/v1/people/me";
+
     /**
      * Code parameter.
      */
     private static final String CODE_PARAM = "?code=code";
+
     /**
      * Code.
      */
     private static final String CODE = "code";
+
     /**
      * Google token parameter.
      */
     private static final String GOOGLE_TOKEN = "GoogleToken";
+
     /**
      * Avatar google url.
      */
     private static final String AVATAR = "https://google.com/img/avatar.gif";
+
     /**
      * XPath access_token string.
      */
     private static final String ACCESS_TOKEN = "access_token";
+
     /**
      * Account url.
      */
     private static final String ACCOUNT = "http://localhost/account";
+
     /**
      * Key request parameter.
      */
     private static final String KEY = "key";
+
     /**
      * App request parameter.
      */
     private static final String APP = "app";
+
     /**
      * PsGoogle login.
      * @checkstyle MultipleStringLiteralsCheck (100 lines)
@@ -192,6 +207,7 @@ public final class PsGoogleTest {
             }
         );
     }
+
     /**
      * PsGoogle login with fail due a bad response from google.
      * @checkstyle MultipleStringLiteralsCheck (100 lines)
@@ -242,6 +258,7 @@ public final class PsGoogleTest {
             }
         );
     }
+
     /**
      * Test a google response without the displayName property.
      * @checkstyle MultipleStringLiteralsCheck (100 lines)
@@ -317,6 +334,7 @@ public final class PsGoogleTest {
             }
         );
     }
+
     /**
      * Build a token request fork.
      * @return Returns the token request
@@ -387,6 +405,7 @@ public final class PsGoogleTest {
             Matchers.equalTo(value)
         );
     }
+
     /**
      * Construct a error response with google json syntax for errors.
      * @return Json with error.

--- a/src/test/java/org/takes/facets/fallback/FbStatusTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbStatusTest.java
@@ -72,12 +72,12 @@ public final class FbStatusTest {
         MatcherAssert.assertThat(
             new RsPrint(
                 new FbStatus(
-                    new Filtered<Integer>(
-                        (status) -> {
+                    new Filtered<>(
+                        status -> {
                             return status == HttpURLConnection.HTTP_MOVED_PERM
                                 || status == HttpURLConnection.HTTP_MOVED_TEMP;
                         },
-                        new ListOf<Integer>(
+                        new ListOf<>(
                             HttpURLConnection.HTTP_MOVED_PERM,
                             HttpURLConnection.HTTP_MOVED_TEMP
                         )

--- a/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
+++ b/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
@@ -86,6 +86,7 @@ public final class TkFallbackTest {
                                 public Iterable<String> head() {
                                     throw new UnsupportedOperationException("");
                                 }
+
                                 @Override
                                 public InputStream body() {
                                     throw new IllegalArgumentException(

--- a/src/test/java/org/takes/facets/forward/TkForwardTest.java
+++ b/src/test/java/org/takes/facets/forward/TkForwardTest.java
@@ -75,6 +75,7 @@ public final class TkForwardTest {
                     public Iterable<String> head() {
                         return new RsEmpty().head();
                     }
+
                     @Override
                     public InputStream body() throws IOException {
                         throw new RsForward("/b");

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -140,6 +140,7 @@ public final class BkBasicTest {
                         public Iterable<String> head() throws IOException {
                             return Collections.singletonList("HTTP/1.1 200 OK");
                         }
+
                         @Override
                         public InputStream body() throws IOException {
                             return req.body();

--- a/src/test/java/org/takes/http/MainRemoteTest.java
+++ b/src/test/java/org/takes/http/MainRemoteTest.java
@@ -90,6 +90,7 @@ public final class MainRemoteTest {
         private DemoApp() {
             // it's a utility class
         }
+
         /**
          * Main entry point.
          * @param args Command line args
@@ -110,6 +111,7 @@ public final class MainRemoteTest {
         private DemoAppArgs() {
             // it's a utility class
         }
+
         /**
          * Main entry point.
          * @param args Command line args

--- a/src/test/java/org/takes/rq/ChunkedInputStreamTest.java
+++ b/src/test/java/org/takes/rq/ChunkedInputStreamTest.java
@@ -43,6 +43,7 @@ public final class ChunkedInputStreamTest {
      * Carriage return.
      */
     private static final String CRLF = "\r\n";
+
     /**
      * End of chunk byte.
      */

--- a/src/test/java/org/takes/rq/RqChunkTest.java
+++ b/src/test/java/org/takes/rq/RqChunkTest.java
@@ -42,10 +42,12 @@ public final class RqChunkTest {
      * Chunked message header.
      */
     private static final String CHUNKED_HEADER = "Transfer-Encoding: chunked";
+
     /**
      * Carriage return.
      */
     private static final String CRLF = "\r\n";
+
     /**
      * End of chunk byte.
      */

--- a/src/test/java/org/takes/rq/RqHeadersTest.java
+++ b/src/test/java/org/takes/rq/RqHeadersTest.java
@@ -99,6 +99,7 @@ public final class RqHeadersTest {
             Matchers.equalTo("www.takes.com")
         );
     }
+
     /**
      * RqHeaders.Smart can return a default header.
      * @throws IOException If some problem inside

--- a/src/test/java/org/takes/rq/TempInputStreamTest.java
+++ b/src/test/java/org/takes/rq/TempInputStreamTest.java
@@ -25,10 +25,9 @@ package org.takes.rq;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -46,14 +45,14 @@ public final class TempInputStreamTest {
     @Test
     public void deletesTempFile() throws IOException {
         final File file = File.createTempFile("tempfile", ".tmp");
-        final BufferedWriter out = new BufferedWriter(new FileWriter(file));
+        final BufferedWriter out = Files.newBufferedWriter(file.toPath());
         try {
             out.write("Temp file deletion test");
         } finally {
             out.close();
         }
         final InputStream body = new TempInputStream(
-            new FileInputStream(file), file
+            Files.newInputStream(file.toPath()), file
         );
         try {
             MatcherAssert.assertThat(

--- a/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
@@ -47,23 +47,28 @@ public final class RqMtBaseTest {
      * Body element.
      */
     private static final String BODY_ELEMENT = "--AaB01x";
+
     /**
      * Content type.
      */
     private static final String CONTENT_TYPE =
         "Content-Type: multipart/form-data; boundary=AaB01x";
+
     /**
      * Form data.
      */
     private static final String FORM_DATA = "form-data; name=\"%s\"";
+
     /**
      * Carriage return constant.
      */
     private static final String CRLF = "\r\n";
+
     /**
      * Content disposition.
      */
     private static final String DISPOSITION = "Content-Disposition";
+
     /**
      * Content disposition plus form data.
      */

--- a/src/test/java/org/takes/rq/multipart/RqMtFakeTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtFakeTest.java
@@ -24,10 +24,12 @@
 package org.takes.rq.multipart;
 
 import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.HashSet;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Test;
 import org.takes.rq.RqFake;
@@ -40,6 +42,7 @@ import org.takes.rq.RqWithHeaders;
 /**
  * Test case for {@link RqMtFake}.
  * @since 0.33
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
 public final class RqMtFakeTest {
@@ -48,10 +51,12 @@ public final class RqMtFakeTest {
      */
     private static final String FORM_DATA =
         "form-data; name=\"data\"; filename=\"%s\"";
+
     /**
      * Content disposition.
      */
     private static final String DISPOSITION = "Content-Disposition";
+
     /**
      * RqMtFake can throw exception on no name
      * at Content-Disposition header.
@@ -188,7 +193,6 @@ public final class RqMtFakeTest {
         final String exmessage =
             "An IOException was expected since the Stream is closed";
         final String name = "name";
-        final String closed = "Closed";
         final String content = "content";
         final RqMtBase multi = new RqMtBase(request);
         multi.part(name).iterator().next().body().read();
@@ -203,8 +207,8 @@ public final class RqMtFakeTest {
             Assert.fail(exmessage);
         } catch (final IOException ex) {
             MatcherAssert.assertThat(
-                ex.getMessage(),
-                Matchers.containsString(closed)
+                ex,
+                new IsInstanceOf(ClosedChannelException.class)
             );
         }
         MatcherAssert.assertThat(
@@ -216,8 +220,8 @@ public final class RqMtFakeTest {
             Assert.fail(exmessage);
         } catch (final IOException ex) {
             MatcherAssert.assertThat(
-                ex.getMessage(),
-                Matchers.containsString(closed)
+                ex,
+                new IsInstanceOf(ClosedChannelException.class)
             );
         }
     }

--- a/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
@@ -28,12 +28,11 @@ import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Arrays;
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.MatcherAssert;
@@ -63,30 +62,36 @@ public final class RqMtSmartTest {
      * Body element.
      */
     private static final String BODY_ELEMENT = "--zzz";
+
     /**
      * Content type.
      */
     private static final String CONTENT_TYPE =
         "Content-Type: multipart/form-data; boundary=zzz";
+
     /**
      * Carriage return constant.
      */
     private static final String CRLF = "\r\n";
+
     /**
      * Content disposition.
      */
     private static final String DISPOSITION = "Content-Disposition";
+
     /**
      * Content disposition plus form data.
      */
     private static final String CONTENT = String.format(
         "%s: %s", RqMtSmartTest.DISPOSITION, "form-data; name=\"%s\""
     );
+
     /**
      * Temp directory.
      */
     @Rule
     public final transient TemporaryFolder temp = new TemporaryFolder();
+
     /**
      * RqMtSmart can return correct part length.
      * @throws IOException If some problem inside
@@ -234,7 +239,7 @@ public final class RqMtSmartTest {
         final int length = 100000000;
         final String part = "test";
         final File file = this.temp.newFile("handlesRequestInTime.tmp");
-        final BufferedWriter bwr = new BufferedWriter(new FileWriter(file));
+        final BufferedWriter bwr = Files.newBufferedWriter(file.toPath());
         bwr.write(
             Joiner.on(RqMtSmartTest.CRLF).join(
                 RqMtSmartTest.BODY_ELEMENT,
@@ -259,7 +264,7 @@ public final class RqMtSmartTest {
                 RqMtSmartTest.CONTENT_TYPE,
                 String.format("Content-Length:%s", file.length())
             ),
-            new TempInputStream(new FileInputStream(file), file)
+            new TempInputStream(Files.newInputStream(file.toPath()), file)
         );
         final RqMtSmart smart = new RqMtSmart(
             new RqMtBase(req)
@@ -279,6 +284,7 @@ public final class RqMtSmartTest {
             smart.part(part).iterator().next().body().close();
         }
     }
+
     /**
      * RqMtSmart doesn't distort the content.
      * @throws IOException If some problem inside
@@ -288,7 +294,7 @@ public final class RqMtSmartTest {
         final int length = 1000000;
         final String part = "test1";
         final File file = this.temp.newFile("notDistortContent.tmp");
-        final BufferedWriter bwr = new BufferedWriter(new FileWriter(file));
+        final BufferedWriter bwr = Files.newBufferedWriter(file.toPath());
         final String head =
             Joiner.on(RqMtSmartTest.CRLF).join(
                 "--zzz1",
@@ -319,7 +325,7 @@ public final class RqMtSmartTest {
                 ),
                 "Content-Type: multipart/form-data; boundary=zzz1"
             ),
-            new TempInputStream(new FileInputStream(file), file)
+            new TempInputStream(Files.newInputStream(file.toPath()), file)
         );
         final InputStream stream = new RqMtSmart(
             new RqMtBase(req)

--- a/src/test/java/org/takes/rs/BodyTest.java
+++ b/src/test/java/org/takes/rs/BodyTest.java
@@ -140,10 +140,10 @@ public final class BodyTest {
         try {
             final byte[] bytes =
                 new Utf8String("URL returnsCorrectInput!").bytes();
-            try (final InputStream input = new ByteArrayInputStream(bytes)) {
+            try (InputStream input = new ByteArrayInputStream(bytes)) {
                 Files.copy(input, file, StandardCopyOption.REPLACE_EXISTING);
             }
-            try (final InputStream input =
+            try (InputStream input =
                 new Body.Url(file.toUri().toURL()).input()) {
                 MatcherAssert.assertThat(
                     ByteStreams.toByteArray(input),
@@ -165,7 +165,7 @@ public final class BodyTest {
         try {
             final byte[] bytes =
                 new Utf8String("URL returnsCorrectLength!").bytes();
-            try (final InputStream input = new ByteArrayInputStream(bytes)) {
+            try (InputStream input = new ByteArrayInputStream(bytes)) {
                 Files.copy(input, file, StandardCopyOption.REPLACE_EXISTING);
             }
             MatcherAssert.assertThat(

--- a/src/test/java/org/takes/tk/TkRedirectTest.java
+++ b/src/test/java/org/takes/tk/TkRedirectTest.java
@@ -43,6 +43,7 @@ public final class TkRedirectTest {
      * Constant variable for HTTP header testing.
      */
     private static final String LOCATION = "Location: %1$s";
+
     /**
      * New line constant.
      */

--- a/src/test/java/org/takes/tk/TkRetryTest.java
+++ b/src/test/java/org/takes/tk/TkRetryTest.java
@@ -83,7 +83,7 @@ public final class TkRetryTest {
         } catch (final IOException exception) {
             final long spent = System.nanoTime() - start;
             MatcherAssert.assertThat(
-                new Long(count * delay - Tv.HUNDRED) * Tv.MILLION,
+                Long.valueOf(count * delay - Tv.HUNDRED) * Tv.MILLION,
                 Matchers.lessThanOrEqualTo(spent)
             );
             throw exception;
@@ -112,7 +112,7 @@ public final class TkRetryTest {
         );
         final long spent = System.nanoTime() - start;
         MatcherAssert.assertThat(
-            new Long(delay - Tv.HUNDRED) * Tv.MILLION,
+            Long.valueOf(delay - Tv.HUNDRED) * Tv.MILLION,
             Matchers.lessThanOrEqualTo(spent)
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
For #880

I had to change a test (`RqMtFakeTest.closesAllParts`) because of the rule [AvoidFileStream](https://pmd.github.io/latest/pmd_rules_java_performance.html#avoidfilestream) that made me to use a different implementation for some stream and thus changed some of the exception thrown.

Apart from that, it is only cosmetics.