### PR TITLE
For #877 removed junit-platform-surefire-provider 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,18 +399,6 @@ SOFTWARE.
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.3.1-M1</version>
-            <dependencies>
-              <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-surefire-provider</artifactId>
-                <version>1.3.1</version>
-              </dependency>
-              <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.3.1</version>
-              </dependency>
-            </dependencies>
             <configuration>
               <groups>org.takes.misc.PerformanceTests</groups>
             </configuration>


### PR DESCRIPTION
For #877 removed junit-platform-surefire-provider and redundant junit-jupter-engine from pom.xml.