### PR TITLE
#882 Un-exclude findbugs from qulice checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,13 +417,6 @@ SOFTWARE.
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
-                <!--
-                  @todo #837:30min Un-exclude findbugs from qulice checks
-                   and fix the bugs it detects for the build to pass.
-                   Most of those are related to reliance on default encoding
-                   and synchronization problems. 
-                -->
-                <exclude>findbugs:.*</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/src/main/java/org/takes/facets/auth/Token.java
+++ b/src/main/java/org/takes/facets/auth/Token.java
@@ -24,6 +24,7 @@
 package org.takes.facets.auth;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -92,7 +93,9 @@ public interface Token {
 
         @Override
         public byte[] encoded() throws IOException {
-            return Base64.getEncoder().encode(this.joseo.toString().getBytes());
+            return Base64.getEncoder().encode(
+                this.joseo.toString().getBytes(Charset.defaultCharset())
+            );
         }
     }
 
@@ -163,7 +166,9 @@ public interface Token {
 
         @Override
         public byte[] encoded() throws IOException {
-            return Base64.getEncoder().encode(this.jwto.toString().getBytes());
+            return Base64.getEncoder().encode(
+                this.jwto.toString().getBytes(Charset.defaultCharset())
+            );
         }
     }
 }

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -147,7 +147,7 @@ public final class SiHmac implements Signature {
             for (final byte byt : this.create().doFinal(bytes)) {
                 formatter.format("%02x", byt);
             }
-            return formatter.toString().getBytes();
+            return formatter.toString().getBytes(Charset.defaultCharset());
         }
     }
 

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.EqualsAndHashCode;
 import org.takes.Request;
@@ -146,11 +147,6 @@ public final class FkHitRefresh implements Fork {
      */
     private static final class HitRefreshHandle {
         /**
-         * A flag File, which is not yet instantiated.
-         */
-        private static final File INEXISTENT_FLAG = new File("/inexistent");
-
-        /**
          * Directory to watch.
          */
         private final File dir;
@@ -159,7 +155,7 @@ public final class FkHitRefresh implements Fork {
          * Internal state. Flag file touched on every exec run.
          * Instantiated at first touch.
          */
-        private volatile File flag;
+        private final List<File> flag;
 
         /**
          * A lock for concurrent access to flag file.
@@ -186,7 +182,7 @@ public final class FkHitRefresh implements Fork {
             final ReentrantReadWriteLock lock) {
             this.dir = dir;
             this.lock = lock;
-            this.flag = HitRefreshHandle.INEXISTENT_FLAG;
+            this.flag = new CopyOnWriteArrayList<>();
         }
 
         /**
@@ -195,17 +191,15 @@ public final class FkHitRefresh implements Fork {
          * @throws IOException If fails
          */
         public File touchedFile() throws IOException {
-            this.lock.readLock().lock();
-            final boolean cold = this.flag == HitRefreshHandle.INEXISTENT_FLAG;
-            this.lock.readLock().unlock();
-            if (cold) {
+            if (this.flag.isEmpty()) {
                 this.lock.writeLock().lock();
-                this.flag = File.createTempFile("take", ".txt");
-                this.flag.deleteOnExit();
+                final File file = File.createTempFile("take", ".txt");
+                file.deleteOnExit();
+                this.flag.add(file);
                 this.lock.writeLock().unlock();
                 this.touch();
             }
-            return this.flag;
+            return this.flag.get(0);
         }
 
         /**
@@ -226,11 +220,8 @@ public final class FkHitRefresh implements Fork {
          * @throws IOException If fails
          */
         private boolean expired() throws IOException {
-            this.lock.readLock().lock();
-            final boolean cold = this.flag == HitRefreshHandle.INEXISTENT_FLAG;
-            this.lock.readLock().unlock();
-            boolean expired = false;
-            if (cold) {
+            final boolean expired;
+            if (this.flag.isEmpty()) {
                 expired = true;
             } else {
                 expired = this.directoryUpdated();
@@ -246,9 +237,13 @@ public final class FkHitRefresh implements Fork {
          *  in README.md file and must be eliminated.
          */
         private boolean directoryUpdated() {
-            this.lock.readLock().lock();
-            final long recent = this.flag.lastModified();
-            this.lock.readLock().unlock();
+            final long recent;
+            try {
+                this.lock.readLock().lock();
+                recent = this.flag.get(0).lastModified();
+            } finally {
+                this.lock.readLock().unlock();
+            }
             final File[] files = this.dir.listFiles();
             boolean expired = false;
             if (files != null) {

--- a/src/main/java/org/takes/facets/forward/RsForward.java
+++ b/src/main/java/org/takes/facets/forward/RsForward.java
@@ -25,6 +25,8 @@ package org.takes.facets.forward;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.net.HttpURLConnection;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -60,7 +62,7 @@ public class RsForward extends HttpException implements Response {
     /**
      * Original response.
      */
-    private final transient Response origin;
+    private final Response origin;
 
     /**
      * Ctor.
@@ -170,5 +172,28 @@ public class RsForward extends HttpException implements Response {
     @Override
     public final InputStream body() throws IOException {
         return this.origin.body();
+    }
+
+    /**
+     * Set default object to write serializated data.
+     * @param stream Stream to write
+     * @throws IOException if fails
+     */
+    private static void writeObject(
+        final ObjectOutputStream stream
+    ) throws IOException {
+        stream.defaultWriteObject();
+    }
+
+    /**
+     * Set default object to read serializated data.
+     * @param stream Stream to read
+     * @throws IOException if fails
+     * @throws ClassNotFoundException if class doesn't exists
+     */
+    private static void readObject(
+        final ObjectInputStream stream
+    ) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
     }
 }

--- a/src/main/java/org/takes/facets/forward/TkForward.java
+++ b/src/main/java/org/takes/facets/forward/TkForward.java
@@ -110,19 +110,17 @@ public final class TkForward implements Take {
          * @throws IOException If fails
          */
         private Response load() throws IOException {
-            synchronized (this.saved) {
-                if (this.saved.isEmpty()) {
-                    Iterable<String> head;
-                    InputStream body;
-                    try {
-                        head = this.origin.head();
-                        body = this.origin.body();
-                    } catch (final RsForward ex) {
-                        head = ex.head();
-                        body = ex.body();
-                    }
-                    this.saved.add(new RsSimple(head, body));
+            if (this.saved.isEmpty()) {
+                Iterable<String> head;
+                InputStream body;
+                try {
+                    head = this.origin.head();
+                    body = this.origin.body();
+                } catch (final RsForward ex) {
+                    head = ex.head();
+                    body = ex.body();
                 }
+                this.saved.add(new RsSimple(head, body));
             }
             return this.saved.get(0);
         }

--- a/src/main/java/org/takes/misc/Expires.java
+++ b/src/main/java/org/takes/misc/Expires.java
@@ -152,13 +152,10 @@ public interface Expires {
          */
         public Date(final String ptn, final Locale locale,
             final java.util.Date expires) {
-            this.format = new ThreadLocal<SimpleDateFormat>() {
-                @Override
-                protected SimpleDateFormat initialValue() {
-                    return new SimpleDateFormat(ptn, locale);
-                }
-            };
-            this.expires = expires;
+            this.format = ThreadLocal.withInitial(
+                () -> new SimpleDateFormat(ptn, locale)
+            );
+            this.expires = new java.util.Date(expires.getTime());
         }
 
         @Override

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -124,12 +124,10 @@ public final class RqFormBase extends RqWrap implements RqForm {
      * @throws IOException If something fails reading or parsing body
      */
     private Map<String, List<String>> map() throws IOException {
-        synchronized (this.saved) {
-            if (this.saved.isEmpty()) {
-                this.saved.add(this.freshMap());
-            }
-            return this.saved.get(0);
+        if (this.saved.isEmpty()) {
+            this.saved.add(this.freshMap());
         }
+        return this.saved.get(0);
     }
 
     /**

--- a/src/main/java/org/takes/rs/RsGzip.java
+++ b/src/main/java/org/takes/rs/RsGzip.java
@@ -80,19 +80,17 @@ public final class RsGzip implements Response {
      * @throws IOException If fails
      */
     private Response make() throws IOException {
-        synchronized (this.zipped) {
-            if (this.zipped.isEmpty()) {
-                this.zipped.add(
-                    new RsWithHeader(
-                        new RsWithBody(
-                            this.origin,
-                            RsGzip.gzip(this.origin.body())
-                        ),
-                        "Content-Encoding",
-                        "gzip"
-                    )
-                );
-            }
+        if (this.zipped.isEmpty()) {
+            this.zipped.add(
+                new RsWithHeader(
+                    new RsWithBody(
+                        this.origin,
+                        RsGzip.gzip(this.origin.body())
+                    ),
+                    "Content-Encoding",
+                    "gzip"
+                )
+            );
         }
         return this.zipped.get(0);
     }

--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -85,15 +85,13 @@ public final class RsPrettyJson implements Response {
      * @throws IOException If fails
      */
     private Response make() throws IOException {
-        synchronized (this.transformed) {
-            if (this.transformed.isEmpty()) {
-                this.transformed.add(
-                    new RsWithBody(
-                        this.origin,
-                        RsPrettyJson.transform(this.origin.body())
-                    )
-                );
-            }
+        if (this.transformed.isEmpty()) {
+            this.transformed.add(
+                new RsWithBody(
+                    this.origin,
+                    RsPrettyJson.transform(this.origin.body())
+                )
+            );
         }
         return this.transformed.get(0);
     }


### PR DESCRIPTION
#882 
- `Charset.defaultCharset()` as default encoding to strings
- Hard coded pathname fixed
- `RsForward` serialization fixed