### PR TITLE
#893 Make tests OO

### DIFF
--- a/src/test/java/org/takes/facets/auth/social/PsFacebookTest.java
+++ b/src/test/java/org/takes/facets/auth/social/PsFacebookTest.java
@@ -25,6 +25,7 @@ package org.takes.facets.auth.social;
 
 import com.jcabi.http.request.FakeRequest;
 import com.restfb.DefaultWebRequestor;
+
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -32,7 +33,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.text.RandomStringGenerator;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.takes.facets.auth.Identity;
 import org.takes.facets.auth.Pass;
@@ -93,7 +94,7 @@ public class PsFacebookTest {
                 )
             )
         );
-        MatcherAssert.assertThat(identity.has(), Matchers.is(true));
+        MatcherAssert.assertThat(identity.has(), new IsEqual<>(true));
         MatcherAssert.assertThat(
             identity.get().urn(),
             CoreMatchers.equalTo(String.format("urn:facebook:%s", identifier))

--- a/src/test/java/org/takes/facets/hamcrest/HmBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmBodyTest.java
@@ -26,9 +26,9 @@ package org.takes.facets.hamcrest;
 
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.Body;
 import org.takes.Request;
@@ -58,6 +58,11 @@ public final class HmBodyTest {
 
     /**
      * HmRqBody can test if values of bodies are different.
+     * @todo #893:30min Continue removing static class Matchers.
+     *  Use the classes PsFacebookTest.java, HmBodyTest.java,
+     *  HmRqTextBodyTest.java, HmRsStatusTest.java,
+     *  RsPreviousTest.java, TkPreviousTest.java,
+     *  RsReturnTest.java and RsPrintTest.java as an example.
      */
     @Test
     public void testsBodyValuesAreDifferent() {
@@ -66,7 +71,7 @@ public final class HmBodyTest {
                 Collections.<String>emptyList(),
                 "this"
             ),
-            Matchers.not(new HmBody<>("that"))
+            new IsNot<>(new HmBody<>("that"))
         );
     }
 
@@ -85,7 +90,7 @@ public final class HmBodyTest {
         matcher.describeMismatchSafely(request, description);
         MatcherAssert.assertThat(
             description.toString(),
-            Matchers.equalTo(
+            new IsEqual<>(
                 "body was: [111, 116, 104, 101, 114]"
             )
         );

--- a/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
@@ -25,7 +25,7 @@ package org.takes.facets.hamcrest;
 
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 
@@ -61,7 +61,7 @@ public final class HmRqTextBodyTest {
                 Collections.<String>emptyList(),
                 "some"
             ),
-            Matchers.not(new HmRqTextBody("other"))
+            new IsNot<>(new HmRqTextBody("other"))
         );
     }
 }

--- a/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
@@ -26,7 +26,7 @@ package org.takes.facets.hamcrest;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.tk.TkEmpty;
@@ -62,7 +62,7 @@ public final class HmRsStatusTest {
     public void testsStatusNotFound() throws IOException {
         MatcherAssert.assertThat(
             new TkHtml("<html><body/></html>").act(new RqFake()),
-            Matchers.not(
+            new IsNot<>(
                 new HmRsStatus(
                     HttpURLConnection.HTTP_NOT_FOUND
                 )

--- a/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
@@ -24,7 +24,7 @@
 package org.takes.facets.hamcrest;
 
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.rs.RsWithBody;
 
@@ -54,7 +54,7 @@ public final class HmRsTextBodyTest {
     public void testsBodyValueDoesNotContainsText() {
         MatcherAssert.assertThat(
             new RsWithBody("Some response"),
-            Matchers.not(new HmRsTextBody("expected something else"))
+            new IsNot<>(new HmRsTextBody("expected something else"))
         );
     }
 }

--- a/src/test/java/org/takes/facets/previous/TkPreviousTest.java
+++ b/src/test/java/org/takes/facets/previous/TkPreviousTest.java
@@ -25,7 +25,7 @@ package org.takes.facets.previous;
 
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.StringStartsWith;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithHeader;
@@ -54,7 +54,7 @@ public final class TkPreviousTest {
                     )
                 )
             ).print(),
-            Matchers.startsWith("HTTP/1.1 303 See Other")
+            new StringStartsWith("HTTP/1.1 303 See Other")
         );
     }
 

--- a/src/test/java/org/takes/facets/ret/RsReturnTest.java
+++ b/src/test/java/org/takes/facets/ret/RsReturnTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.takes.rs.RsEmpty;
 import org.takes.rs.RsPrint;
@@ -49,7 +49,7 @@ public final class RsReturnTest {
             new RsPrint(
                 new RsReturn(new RsEmpty(), destination)
             ).print(),
-            Matchers.containsString(
+            new StringContains(
                 String.format(
                     "Set-Cookie: RsReturn=%s;Path=/",
                     URLEncoder.encode(

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -30,7 +30,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.io.InputStreamOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
@@ -69,7 +68,7 @@ public final class RsPrintTest {
         }
         MatcherAssert.assertThat(
             output.haveFlushed(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -115,7 +114,7 @@ public final class RsPrintTest {
         }
         MatcherAssert.assertThat(
             writer.haveFlushed(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 


### PR DESCRIPTION
This PR is for the #893:

Hamcrest's Static Matchers have been changed to OO in some classes that will set an example for the others.