### PR TITLE
#893 Removed the static Matchers from some classes

### DIFF
--- a/src/test/java/org/takes/facets/auth/IdentityTest.java
+++ b/src/test/java/org/takes/facets/auth/IdentityTest.java
@@ -25,7 +25,7 @@ package org.takes.facets.auth;
 
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -42,7 +42,7 @@ public final class IdentityTest {
     public void equalsToItself() throws IOException {
         MatcherAssert.assertThat(
             Identity.ANONYMOUS,
-            Matchers.equalTo(Identity.ANONYMOUS)
+            new IsEqual<>(Identity.ANONYMOUS)
         );
     }
 

--- a/src/test/java/org/takes/facets/auth/PsAllTest.java
+++ b/src/test/java/org/takes/facets/auth/PsAllTest.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.takes.Response;
 import org.takes.rq.RqFake;
@@ -51,7 +51,7 @@ public final class PsAllTest {
                 new ArrayList<Pass>(0),
                 0
             ).enter(new RqFake()).has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -66,7 +66,7 @@ public final class PsAllTest {
                 Collections.singletonList(new PsFake(true)),
                 -1
             ).enter(new RqFake()).has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -84,7 +84,7 @@ public final class PsAllTest {
                 ),
                 2
             ).enter(new RqFake()).has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -99,7 +99,7 @@ public final class PsAllTest {
                 Collections.singletonList(new PsFake(true)),
                 0
             ).enter(new RqFake()).has(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -114,7 +114,7 @@ public final class PsAllTest {
                 Collections.singletonList(new PsFake(false)),
                 0
             ).enter(new RqFake()).has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -139,7 +139,7 @@ public final class PsAllTest {
                 ),
                 Tv.THREE
             ).enter(request).get().urn(),
-            Matchers.equalTo(resulting.enter(request).get().urn())
+            new IsEqual<>(resulting.enter(request).get().urn())
         );
     }
 
@@ -159,7 +159,7 @@ public final class PsAllTest {
                 ),
                 1
             ).enter(new RqFake()).has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -179,7 +179,7 @@ public final class PsAllTest {
                 ),
                 1
             ).exit(response, exiting.enter(new RqFake()).get()),
-            Matchers.equalTo(response)
+            new IsEqual<>(response)
         );
     }
 }

--- a/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
@@ -25,7 +25,7 @@ package org.takes.facets.auth;
 
 import java.net.URLEncoder;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 /**
@@ -53,7 +53,7 @@ public final class PsBasicDefaultTest {
             )
                 .get()
                 .urn(),
-            Matchers.equalTo("urn:foo:robert")
+                new IsEqual<>("urn:foo:robert")
         );
     }
 
@@ -75,7 +75,7 @@ public final class PsBasicDefaultTest {
                     "hey you"
             )
                 .has(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
         MatcherAssert.assertThat(
             new PsBasic.Default(
@@ -88,7 +88,7 @@ public final class PsBasicDefaultTest {
                     "hey me"
             )
                 .has(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -109,7 +109,7 @@ public final class PsBasicDefaultTest {
                     "qwer"
             )
                 .has(),
-            Matchers.is(true)
+            new IsEqual<>(true)
         );
     }
 
@@ -135,7 +135,7 @@ public final class PsBasicDefaultTest {
             )
                 .get()
                 .urn(),
-            Matchers.is(urn)
+            new IsEqual<>(urn)
         );
     }
 
@@ -154,7 +154,7 @@ public final class PsBasicDefaultTest {
             )
                 .enter("charlie", "wrongpassword")
                 .has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 
@@ -173,7 +173,7 @@ public final class PsBasicDefaultTest {
             )
                 .enter("mike", "anything")
                 .has(),
-            Matchers.is(false)
+            new IsEqual<>(false)
         );
     }
 }

--- a/src/test/java/org/takes/facets/auth/PsChainTest.java
+++ b/src/test/java/org/takes/facets/auth/PsChainTest.java
@@ -25,7 +25,8 @@ package org.takes.facets.auth;
 
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringContains;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsEmpty;
@@ -47,7 +48,7 @@ public final class PsChainTest {
                 new PsLogout(),
                 new PsFake(true)
             ).enter(new RqFake()).get(),
-            Matchers.is(Identity.ANONYMOUS)
+            new IsEqual<>(Identity.ANONYMOUS)
         );
     }
 
@@ -62,7 +63,7 @@ public final class PsChainTest {
                 new PsFake(true)
             ).exit(new RsEmpty(), Identity.ANONYMOUS)
                 .head().iterator().next(),
-            Matchers.containsString("HTTP/1.1 200 O")
+            new StringContains("HTTP/1.1 200 O")
         );
     }
 }

--- a/src/test/java/org/takes/facets/hamcrest/HmBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmBodyTest.java
@@ -26,9 +26,9 @@ package org.takes.facets.hamcrest;
 
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.StringDescription;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.Body;
 import org.takes.Request;
@@ -66,7 +66,7 @@ public final class HmBodyTest {
                 Collections.<String>emptyList(),
                 "this"
             ),
-            Matchers.not(new HmBody<>("that"))
+            new IsNot<>(new HmBody<>("that"))
         );
     }
 
@@ -85,7 +85,7 @@ public final class HmBodyTest {
         matcher.describeMismatchSafely(request, description);
         MatcherAssert.assertThat(
             description.toString(),
-            Matchers.equalTo(
+            new IsEqual<>(
                 "body was: [111, 116, 104, 101, 114]"
             )
         );
@@ -93,6 +93,10 @@ public final class HmBodyTest {
 
     /**
      * HmBody can describe in readable way.
+     * @todo #893:30min Continue removing static class Matchers. Use the
+     *  classes IdentityTest.java, PsAllTest.java, PsBasicDefaultTest.java,
+     *  PsChainTest.java, HmBodyTest.java, HmRqTextBodyTest.java,
+     *  HmRsStatusTest.java, and HmRsTextBodyTest.java as an example.
      */
     @Test
     public void describeToInReadableWay() {

--- a/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqTextBodyTest.java
@@ -25,7 +25,7 @@ package org.takes.facets.hamcrest;
 
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 
@@ -61,7 +61,7 @@ public final class HmRqTextBodyTest {
                 Collections.<String>emptyList(),
                 "some"
             ),
-            Matchers.not(new HmRqTextBody("other"))
+            new IsNot<>(new HmRqTextBody("other"))
         );
     }
 }

--- a/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
@@ -26,7 +26,7 @@ package org.takes.facets.hamcrest;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.rq.RqFake;
 import org.takes.tk.TkEmpty;
@@ -62,7 +62,7 @@ public final class HmRsStatusTest {
     public void testsStatusNotFound() throws IOException {
         MatcherAssert.assertThat(
             new TkHtml("<html><body/></html>").act(new RqFake()),
-            Matchers.not(
+            new IsNot<>(
                 new HmRsStatus(
                     HttpURLConnection.HTTP_NOT_FOUND
                 )

--- a/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsTextBodyTest.java
@@ -24,7 +24,7 @@
 package org.takes.facets.hamcrest;
 
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 import org.takes.rs.RsWithBody;
 
@@ -54,7 +54,7 @@ public final class HmRsTextBodyTest {
     public void testsBodyValueDoesNotContainsText() {
         MatcherAssert.assertThat(
             new RsWithBody("Some response"),
-            Matchers.not(new HmRsTextBody("expected something else"))
+            new IsNot<>(new HmRsTextBody("expected something else"))
         );
     }
 }


### PR DESCRIPTION
For PF #893:

Removed the static Matchers from some classes.