### PR TITLE
Update tests to replace guava with cactoos #888

### DIFF
--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -42,7 +42,7 @@ import org.takes.misc.Utf8String;
  * <p>The class is immutable and thread-safe.
  *
  * @since 0.1
- * @todo #804:30min Continue removing Guava's code from tests, starting
+ * @todo #888:30min Continue removing Guava's code from tests, starting
  *  with all the calls to Joiner by replacing them with Cactoos JoinedText
  *  and the use of cactoos-matchers TextIs or TextHasContent coupled with this
  *  class RsPrint as a Text as it was started in #804. When there is no more

--- a/src/test/java/org/takes/facets/cookies/RsWithCookieTest.java
+++ b/src/test/java/org/takes/facets/cookies/RsWithCookieTest.java
@@ -23,10 +23,10 @@
  */
 package org.takes.facets.cookies;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -118,8 +118,9 @@ public final class RsWithCookieTest {
      * Returns the joined cookie.
      * @param cookies Cookies values
      * @return Joined cookie
+     * @throws IOException when there is a problem
      */
-    private static String cookies(final String... cookies) {
+    private static String cookies(final String... cookies) throws IOException {
         final List<String> list = new ArrayList<>(cookies.length + 3);
         list.add("HTTP/1.1 200 OK");
         for (final String cookie : cookies) {
@@ -127,7 +128,7 @@ public final class RsWithCookieTest {
         }
         list.add("");
         list.add("");
-        return Joiner.on("\r\n").join(list.iterator());
+        return new JoinedText("\r\n", list).asString();
     }
 
     /**

--- a/src/test/java/org/takes/facets/fork/FkChainTest.java
+++ b/src/test/java/org/takes/facets/fork/FkChainTest.java
@@ -23,7 +23,7 @@
  */
 package org.takes.facets.fork;
 
-import com.google.common.base.Joiner;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -67,13 +67,14 @@ public final class FkChainTest {
                 ).route(new RqFake("GET", "/hey?yu")).get()
             ).print(),
             Matchers.equalTo(
-                Joiner.on("\r\n").join(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     String.format("Content-Length: %s", body.length()),
                     "Content-Type: text/plain",
                     "",
                     body
-                )
+                ).asString()
             )
         );
     }

--- a/src/test/java/org/takes/facets/fork/TkConsumesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkConsumesTest.java
@@ -23,11 +23,11 @@
  */
 package org.takes.facets.fork;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.util.Arrays;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -75,10 +75,11 @@ public final class TkConsumesTest {
         MatcherAssert.assertThat(
             new RsPrint(response).print(),
             Matchers.startsWith(
-                Joiner.on("\r\n").join(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     contenttype
-                )
+                ).asString()
             )
         );
     }

--- a/src/test/java/org/takes/facets/fork/TkForkTest.java
+++ b/src/test/java/org/takes/facets/fork/TkForkTest.java
@@ -23,8 +23,8 @@
  */
 package org.takes.facets.fork;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -51,13 +51,14 @@ public final class TkForkTest {
                 )
             ).print(),
             Matchers.equalTo(
-                Joiner.on("\r\n").join(
+                new JoinedText(
+                    "\r\n",
                     "HTTP/1.1 200 OK",
                     String.format("Content-Length: %s", body.length()),
                     "Content-Type: text/plain",
                     "",
                     body
-                )
+                ).asString()
             )
         );
     }

--- a/src/test/java/org/takes/facets/fork/TkProducesTest.java
+++ b/src/test/java/org/takes/facets/fork/TkProducesTest.java
@@ -23,9 +23,9 @@
  */
 package org.takes.facets.fork;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.util.Arrays;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -42,6 +42,7 @@ import org.takes.tk.TkFixed;
 /**
  * Test case for {@link TkProduces}.
  * @since 0.14
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkProducesTest {
 
@@ -90,12 +91,12 @@ public final class TkProducesTest {
         MatcherAssert.assertThat(
             new RsPrint(response).print(),
             Matchers.equalTo(
-                Joiner.on("\r\n").join(
-                    "HTTP/1.1 200 OK",
+                new JoinedText(
+                    "\r\n", "HTTP/1.1 200 OK",
                     "Content-Type: application/json",
                     "",
                     ""
-                )
+                ).asString()
             )
         );
     }

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -23,7 +23,6 @@
  */
 package org.takes.http;
 
-import com.google.common.base.Joiner;
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
 import com.jcabi.matchers.RegexMatchers;
@@ -37,6 +36,8 @@ import java.net.Socket;
 import java.net.URI;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
+import org.cactoos.io.BytesOf;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -82,10 +83,10 @@ public final class BkBasicTest {
     /**
      * BkBasic can handle socket data.
      *
-     * @throws IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void handlesSocket() throws IOException {
+    public void handlesSocket() throws Exception {
         final MkSocket socket = BkBasicTest.createMockSocket();
         final ByteArrayOutputStream baos = socket.bufferedOutput();
         final String hello = "Hello World";
@@ -124,10 +125,10 @@ public final class BkBasicTest {
     /**
      * BkBasic produces headers with addresses without slashes.
      *
-     * @throws IOException If some problem inside
+     * @throws Exception If some problem inside
      */
     @Test
-    public void addressesInHeadersAddedWithoutSlashes() throws IOException {
+    public void addressesInHeadersAddedWithoutSlashes() throws Exception {
         final Socket socket = BkBasicTest.createMockSocket();
         final AtomicReference<Request> ref = new AtomicReference<>();
         new BkBasic(
@@ -211,7 +212,8 @@ public final class BkBasicTest {
                 )
             ) {
                 socket.getOutputStream().write(
-                    Joiner.on(BkBasicTest.CRLF).join(
+                    new JoinedText(
+                        BkBasicTest.CRLF,
                         BkBasicTest.POST,
                         BkBasicTest.HOST,
                         "Content-Length: 11",
@@ -222,7 +224,7 @@ public final class BkBasicTest {
                         "Content-Length: 12",
                         "",
                         "Hello Second"
-                    ).getBytes()
+                    ).asString().getBytes()
                 );
                 final InputStream input = socket.getInputStream();
                 // @checkstyle MagicNumber (1 line)
@@ -273,12 +275,15 @@ public final class BkBasicTest {
                 )
             ) {
                 socket.getOutputStream().write(
-                    Joiner.on(BkBasicTest.CRLF).join(
-                        BkBasicTest.POST,
-                        BkBasicTest.HOST,
-                        "",
-                        text
-                    ).getBytes()
+                    new BytesOf(
+                        new JoinedText(
+                            BkBasicTest.CRLF,
+                            BkBasicTest.POST,
+                            BkBasicTest.HOST,
+                            "",
+                            text
+                        )
+                    ).asBytes()
                 );
                 final InputStream input = socket.getInputStream();
                 // @checkstyle MagicNumber (1 line)
@@ -327,13 +332,16 @@ public final class BkBasicTest {
                 )
             ) {
                 socket.getOutputStream().write(
-                    Joiner.on(BkBasicTest.CRLF).join(
-                        BkBasicTest.POST,
-                        BkBasicTest.HOST,
-                        "Connection: Close",
-                        "",
-                        greetings
-                    ).getBytes()
+                    new BytesOf(
+                        new JoinedText(
+                            BkBasicTest.CRLF,
+                            BkBasicTest.POST,
+                            BkBasicTest.HOST,
+                            "Connection: Close",
+                            "",
+                            greetings
+                        )
+                    ).asBytes()
                 );
                 final InputStream input = socket.getInputStream();
                 // @checkstyle MagicNumber (1 line)
@@ -354,18 +362,21 @@ public final class BkBasicTest {
      * Creates Socket mock for reuse.
      *
      * @return Prepared Socket mock
-     * @throws IOException If some problem inside
+     * @throws Exception If some problem inside
      */
-    private static MkSocket createMockSocket() throws IOException {
+    private static MkSocket createMockSocket() throws Exception {
         return new MkSocket(
             new ByteArrayInputStream(
-                Joiner.on(BkBasicTest.CRLF).join(
-                    "GET / HTTP/1.1",
-                    BkBasicTest.HOST,
-                    "Content-Length: 2",
-                    "",
-                    "hi"
-                ).getBytes()
+                new BytesOf(
+                    new JoinedText(
+                        BkBasicTest.CRLF,
+                        "GET / HTTP/1.1",
+                        BkBasicTest.HOST,
+                        "Content-Length: 2",
+                        "",
+                        "hi"
+                    )
+                ).asBytes()
             )
         );
     }

--- a/src/test/java/org/takes/misc/ConcatTest.java
+++ b/src/test/java/org/takes/misc/ConcatTest.java
@@ -23,9 +23,10 @@
  */
 package org.takes.misc;
 
-import com.google.common.base.Joiner;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -39,32 +40,36 @@ public final class ConcatTest {
 
     /**
      * Concat can concatenate.
+     * @throws IOException when there is a problem
      */
     @Test
-    public void concatenates() {
+    public void concatenates() throws IOException {
         MatcherAssert.assertThat(
-            Joiner.on(" ").join(
+            new JoinedText(
+                " ",
                 new Concat<String>(
                     Arrays.asList("one", "two"),
                     Arrays.asList("three", "four")
                 )
-            ),
+            ).asString(),
             Matchers.equalTo("one two three four")
         );
     }
 
     /**
      * Concat can concatenate with empty list.
+     * @throws IOException when there is a problem
      */
     @Test
-    public void concatenatesWithEmptyList() {
+    public void concatenatesWithEmptyList() throws IOException {
         MatcherAssert.assertThat(
-            Joiner.on("+").join(
+            new JoinedText(
+                "+",
                 new Concat<String>(
                     Arrays.asList("five", "six"),
                     Collections.<String>emptyList()
                 )
-            ),
+            ).asString(),
             Matchers.equalTo("five+six")
         );
     }

--- a/src/test/java/org/takes/misc/TransformTest.java
+++ b/src/test/java/org/takes/misc/TransformTest.java
@@ -23,8 +23,9 @@
  */
 package org.takes.misc;
 
-import com.google.common.base.Joiner;
+import java.io.IOException;
 import java.util.Arrays;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -38,11 +39,13 @@ public final class TransformTest {
 
     /**
      * Transform can transform list.
+     * @throws IOException when there is a problem
      */
     @Test
-    public void transformsList() {
+    public void transformsList() throws IOException {
         MatcherAssert.assertThat(
-            Joiner.on(" ").join(
+            new JoinedText(
+                " ",
                 new Transform<String, String>(
                     Arrays.asList("one", "two", "three"),
                     new TransformAction<String, String>() {
@@ -52,7 +55,7 @@ public final class TransformTest {
                         }
                     }
                 )
-            ),
+            ).asString(),
             Matchers.equalTo("onet twot threet")
         );
     }

--- a/src/test/java/org/takes/rq/ChunkedInputStreamTest.java
+++ b/src/test/java/org/takes/rq/ChunkedInputStreamTest.java
@@ -23,11 +23,11 @@
  */
 package org.takes.rq;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -59,12 +59,13 @@ public final class ChunkedInputStreamTest {
         final String length = Integer.toHexString(data.length());
         final InputStream stream = new ChunkedInputStream(
             IOUtils.toInputStream(
-                Joiner.on(ChunkedInputStreamTest.CRLF).join(
+                new JoinedText(
+                    ChunkedInputStreamTest.CRLF,
                     length,
                     data,
                     ChunkedInputStreamTest.END_OF_CHUNK,
                     ""
-                ),
+                ).asString(),
                 StandardCharsets.UTF_8
             )
         );
@@ -91,7 +92,8 @@ public final class ChunkedInputStreamTest {
         final Integer length = data.length();
         final InputStream stream = new ChunkedInputStream(
             IOUtils.toInputStream(
-                Joiner.on(ChunkedInputStreamTest.CRLF).join(
+                new JoinedText(
+                    ChunkedInputStreamTest.CRLF,
                     Integer.toHexString(first.length()),
                     first,
                     Integer.toHexString(second.length()),
@@ -100,7 +102,7 @@ public final class ChunkedInputStreamTest {
                     third,
                     ChunkedInputStreamTest.END_OF_CHUNK,
                     ""
-                ),
+                ).asString(),
                 StandardCharsets.UTF_8
             )
         );
@@ -125,12 +127,13 @@ public final class ChunkedInputStreamTest {
         final String length = Integer.toHexString(data.length());
         final InputStream stream = new ChunkedInputStream(
             IOUtils.toInputStream(
-                Joiner.on(ChunkedInputStreamTest.CRLF).join(
+                new JoinedText(
+                    ChunkedInputStreamTest.CRLF,
                     length + ignored,
                     data,
                     ChunkedInputStreamTest.END_OF_CHUNK,
                     ""
-                ),
+                ).asString(),
                 StandardCharsets.UTF_8
             )
         );

--- a/src/test/java/org/takes/rq/RqChunkTest.java
+++ b/src/test/java/org/takes/rq/RqChunkTest.java
@@ -23,10 +23,10 @@
  */
 package org.takes.rq;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -68,12 +68,13 @@ public final class RqChunkTest {
                     "Host: www.example.com",
                     RqChunkTest.CHUNKED_HEADER
                 ),
-                Joiner.on(RqChunkTest.CRLF).join(
+                new JoinedText(
+                    RqChunkTest.CRLF,
                     length,
                     data,
                     RqChunkTest.END_OF_CHUNK,
                     ""
-                )
+                ).asString()
             )
         ).body();
         final byte[] buf = new byte[data.length()];
@@ -103,7 +104,8 @@ public final class RqChunkTest {
                     "Host: b.example.com",
                     RqChunkTest.CHUNKED_HEADER
                 ),
-                Joiner.on(RqChunkTest.CRLF).join(
+                new JoinedText(
+                    RqChunkTest.CRLF,
                     Integer.toHexString(first.length()),
                     first,
                     Integer.toHexString(second.length()),
@@ -112,7 +114,7 @@ public final class RqChunkTest {
                     third,
                     RqChunkTest.END_OF_CHUNK,
                     ""
-                )
+                ).asString()
             )
         ).body();
         final byte[] buf = new byte[length];
@@ -140,12 +142,13 @@ public final class RqChunkTest {
                     "Host: c.example.com",
                     RqChunkTest.CHUNKED_HEADER
                 ),
-                Joiner.on(RqChunkTest.CRLF).join(
+                new JoinedText(
+                    RqChunkTest.CRLF,
                     length + ignored,
                     data,
                     RqChunkTest.END_OF_CHUNK,
                     ""
-                )
+                ).asString()
             )
         ).body();
         final byte[] buf = new byte[data.length()];

--- a/src/test/java/org/takes/rq/RqGreedyTest.java
+++ b/src/test/java/org/takes/rq/RqGreedyTest.java
@@ -23,9 +23,9 @@
  */
 package org.takes.rq;
 
-import com.google.common.base.Joiner;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -43,12 +43,13 @@ public final class RqGreedyTest {
      */
     @Test
     public void makesRequestGreedy() throws IOException {
-        final String body = Joiner.on("\r\n").join(
+        final String body = new JoinedText(
+            "\r\n",
             "GET /test HTTP/1.1",
             "Host: localhost",
             "",
             "... the body ..."
-        );
+        ).asString();
         final Request req = new RqGreedy(
             new RqWithHeader(
                 new RqLive(

--- a/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
@@ -23,9 +23,9 @@
  */
 package org.takes.rq.multipart;
 
-import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.util.Arrays;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -132,13 +132,14 @@ public final class RqMtBaseTest {
                     RqMtBaseTest.CONTENT_TYPE,
                     length
                 ),
-                Joiner.on(RqMtBaseTest.CRLF).join(
+                new JoinedText(
+                    RqMtBaseTest.CRLF,
                     RqMtBaseTest.BODY_ELEMENT,
                     "Content-Disposition: form-data; fake=\"t2\"",
                     "",
                     address,
                     "Content-Transfer-Encoding: uwf-8"
-                )
+                ).asString()
             )
         );
     }
@@ -162,13 +163,14 @@ public final class RqMtBaseTest {
                     RqMtBaseTest.CONTENT_TYPE,
                     length
                 ),
-                Joiner.on(RqMtBaseTest.CRLF).join(
+                new JoinedText(
+                    RqMtBaseTest.CRLF,
                     RqMtBaseTest.BODY_ELEMENT,
                     String.format(RqMtBaseTest.CONTENT, part),
                     "",
                     address,
                     RqMtBaseTest.BODY_ELEMENT
-                )
+                ).asString()
             )
         );
         try {

--- a/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
@@ -23,7 +23,6 @@
  */
 package org.takes.rq.multipart;
 
-import com.google.common.base.Joiner;
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
 import java.io.BufferedWriter;
@@ -35,6 +34,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.util.Arrays;
 import org.apache.commons.lang.StringUtils;
+import org.cactoos.text.JoinedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
@@ -102,13 +102,14 @@ public final class RqMtSmartTest {
         final int length = 5000;
         final String part = "x-1";
         final String body =
-            Joiner.on(RqMtSmartTest.CRLF).join(
+            new JoinedText(
+                RqMtSmartTest.CRLF,
                 RqMtSmartTest.BODY_ELEMENT,
                 String.format(RqMtSmartTest.CONTENT, part),
                 "",
                 StringUtils.repeat("X", length),
                 String.format("%s--", RqMtSmartTest.BODY_ELEMENT)
-            );
+            ).asString();
         final Request req = new RqFake(
             Arrays.asList(
                 post,
@@ -144,14 +145,15 @@ public final class RqMtSmartTest {
         final int length = 9000;
         final String part = "foo-1";
         final String body =
-            Joiner.on(RqMtSmartTest.CRLF).join(
+            new JoinedText(
+                RqMtSmartTest.CRLF,
                 "----foo",
                 String.format(RqMtSmartTest.CONTENT, part),
                 "",
                 StringUtils.repeat("F", length),
                 "",
                 "----foo--"
-            );
+            ).asString();
         final Request req = new RqFake(
             Arrays.asList(
                 "POST /post?foo=3 HTTP/1.1",
@@ -197,11 +199,12 @@ public final class RqMtSmartTest {
             }
         };
         final String body =
-            Joiner.on(RqMtSmartTest.CRLF).join(
+            new JoinedText(
+                RqMtSmartTest.CRLF,
                 "--AaB0zz",
                 String.format(RqMtSmartTest.CONTENT, part), "",
                 "my picture", "--AaB0zz--"
-            );
+            ).asString();
         new FtRemote(take).exec(
             // @checkstyle AnonInnerLengthCheck (50 lines)
             new FtRemote.Script() {
@@ -241,12 +244,13 @@ public final class RqMtSmartTest {
         final File file = this.temp.newFile("handlesRequestInTime.tmp");
         final BufferedWriter bwr = Files.newBufferedWriter(file.toPath());
         bwr.write(
-            Joiner.on(RqMtSmartTest.CRLF).join(
+            new JoinedText(
+                RqMtSmartTest.CRLF,
                 RqMtSmartTest.BODY_ELEMENT,
                 String.format(RqMtSmartTest.CONTENT, part),
                 "",
                 ""
-            )
+            ).asString()
         );
         for (int ind = 0; ind < length; ++ind) {
             bwr.write("X");
@@ -296,23 +300,25 @@ public final class RqMtSmartTest {
         final File file = this.temp.newFile("notDistortContent.tmp");
         final BufferedWriter bwr = Files.newBufferedWriter(file.toPath());
         final String head =
-            Joiner.on(RqMtSmartTest.CRLF).join(
+            new JoinedText(
+                RqMtSmartTest.CRLF,
                 "--zzz1",
                 String.format(RqMtSmartTest.CONTENT, part),
                 "",
                 ""
-            );
+            ).asString();
         bwr.write(head);
         final int byt = 0x7f;
         for (int idx = 0; idx < length; ++idx) {
             bwr.write(idx % byt);
         }
         final String foot =
-            Joiner.on(RqMtSmartTest.CRLF).join(
+            new JoinedText(
+                RqMtSmartTest.CRLF,
                 "",
                 "--zzz1--",
                 ""
-            );
+            ).asString();
         bwr.write(foot);
         bwr.close();
         final String post = "POST /post?u=5 HTTP/1.1";


### PR DESCRIPTION
In this PR I replaced several occurences of Joiner with JoinedText. See #888

I intentionally did not touch the other idiomatic problems in the tests cases.

I left a puzzle that describes the tasks that still have to be done.
