### PR TITLE
#944 Substitution of MatcherAsssert.assertThat () by Assertion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.11</version>
+      <version>0.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/takes/facets/auth/IdentityTest.java
+++ b/src/test/java/org/takes/facets/auth/IdentityTest.java
@@ -24,9 +24,9 @@
 package org.takes.facets.auth;
 
 import java.io.IOException;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link Identity}.
@@ -40,8 +40,9 @@ public final class IdentityTest {
      */
     @Test
     public void equalsToItself() throws IOException {
-        MatcherAssert.assertThat(
-            Identity.ANONYMOUS,
+        new Assertion<>(
+            "Comparison error",
+            () -> Identity.ANONYMOUS,
             new IsEqual<>(Identity.ANONYMOUS)
         );
     }

--- a/src/test/java/org/takes/facets/auth/PsAllTest.java
+++ b/src/test/java/org/takes/facets/auth/PsAllTest.java
@@ -27,9 +27,9 @@ import com.jcabi.aspects.Tv;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.takes.Response;
 import org.takes.rq.RqFake;
 import org.takes.rs.RsEmpty;
@@ -37,6 +37,7 @@ import org.takes.rs.RsEmpty;
 /**
  * Test of {@link PsAll}.
  * @since 0.22
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */
 public final class PsAllTest {
 
@@ -44,10 +45,11 @@ public final class PsAllTest {
      * Fails if PsAll with 0 Passes is created.
      * @throws Exception If fails
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void thereShouldBeAtLeastOnePass() throws Exception {
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing thereShouldBeAtLeastOnePass()",
+            () -> new PsAll(
                 new ArrayList<Pass>(0),
                 0
             ).enter(new RqFake()).has(),
@@ -59,10 +61,11 @@ public final class PsAllTest {
      * Fails if index is less then 0.
      * @throws Exception If fails
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void indexMustBeNonNegative() throws Exception {
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing indexMustBeNonNegative()",
+            () -> new PsAll(
                 Collections.singletonList(new PsFake(true)),
                 -1
             ).enter(new RqFake()).has(),
@@ -74,10 +77,11 @@ public final class PsAllTest {
      * Fails if index is greater or equal to the number of Passes to enter.
      * @throws Exception If fails
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void indexMustBeSmallEnough() throws Exception {
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing indexMustBeSmallEnough()",
+            () -> new PsAll(
                 Arrays.asList(
                     new PsFake(true),
                     new PsFake(false)
@@ -94,8 +98,9 @@ public final class PsAllTest {
      */
     @Test
     public void testOneSuccessfull() throws Exception {
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing testOneSuccessfull()",
+            () -> new PsAll(
                 Collections.singletonList(new PsFake(true)),
                 0
             ).enter(new RqFake()).has(),
@@ -109,8 +114,9 @@ public final class PsAllTest {
      */
     @Test
     public void testOneFail() throws Exception {
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing testOneFail()",
+            () -> new PsAll(
                 Collections.singletonList(new PsFake(false)),
                 0
             ).enter(new RqFake()).has(),
@@ -129,8 +135,9 @@ public final class PsAllTest {
             new Identity.Simple("urn:foo:test")
         );
         final RqFake request = new RqFake();
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing testSuccessfullIdx()",
+            () -> new PsAll(
                 Arrays.asList(
                     new PsFake(true),
                     new PsFake(true),
@@ -149,8 +156,9 @@ public final class PsAllTest {
      */
     @Test
     public void testFail() throws Exception {
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing testFail()",
+            () -> new PsAll(
                 Arrays.asList(
                     new PsFake(true),
                     new PsFake(true),
@@ -171,8 +179,9 @@ public final class PsAllTest {
     public void exits() throws Exception {
         final Response response = new RsEmpty();
         final PsFake exiting = new PsFake(true);
-        MatcherAssert.assertThat(
-            new PsAll(
+        new Assertion<>(
+            "An error occurred while executing exits()",
+            () -> new PsAll(
                 Arrays.asList(
                     new PsFake(true),
                     exiting

--- a/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
@@ -37,6 +37,9 @@ public final class PsBasicDefaultTest {
     /**
      * PsBasic.Default can accept a correct login/password pair.
      * @throws Exception If fails
+     * @todo #944:30min Continue replacing MatcherAsssert.assertThat
+     *  with Assertion (org.llorllale.cactoos.matchers.Assertion of
+     *  cactus-matchers).
      */
     @Test
     public void acceptsCorrectLoginPasswordPair() throws Exception {

--- a/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicDefaultTest.java
@@ -37,9 +37,10 @@ public final class PsBasicDefaultTest {
     /**
      * PsBasic.Default can accept a correct login/password pair.
      * @throws Exception If fails
-     * @todo #944:30min Continue replacing MatcherAsssert.assertThat
-     *  with Assertion (org.llorllale.cactoos.matchers.Assertion of
-     *  cactus-matchers).
+     * @todo #944:30min Continue replacing all the MatcherAsssert.assertThat
+     *  of the project by Assertion (org.llorllale.cactoos.matchers.Assertion
+     *  of cactus-matchers). PsAllTest and RsPrettyXmlTest can be used as an
+     *  example.
      */
     @Test
     public void acceptsCorrectLoginPasswordPair() throws Exception {

--- a/src/test/java/org/takes/rs/RsPrettyXmlTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXmlTest.java
@@ -27,30 +27,32 @@ import com.google.common.base.Joiner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringContains;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link RsPrettyXml}.
  * @since 1.0
  */
 public final class RsPrettyXmlTest {
-
     /**
      * RsPrettyXML can format response with XML body.
      * @throws IOException If some problem inside
      */
     @Test
     public void formatsXmlBody() throws IOException {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing formatsXmlBody()",
+            () -> new RsPrint(
                 new RsPrettyXml(
                     new RsWithBody("<test><a>foo</a></test>")
                 )
             ).printBody(),
-            Matchers.is("<test>\n   <a>foo</a>\n</test>\n")
-        );
+            new IsEqual<>("<test>\n   <a>foo</a>\n</test>\n")
+        ).affirm();
     }
 
     /**
@@ -60,15 +62,16 @@ public final class RsPrettyXmlTest {
     @Test
     // @checkstyle MethodNameCheck (1 line)
     public void formatsHtml5DoctypeBody() throws IOException {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing formatsHtml5DoctypeBody()",
+            () -> new RsPrint(
                 new RsPrettyXml(
                     new RsWithBody(
                         "<!DOCTYPE html><html><head></head><body></body></html>"
                     )
                 )
             ).printBody(),
-            Matchers.containsString("<!DOCTYPE HTML>")
+            new StringContains("<!DOCTYPE HTML>")
         );
     }
 
@@ -80,8 +83,9 @@ public final class RsPrettyXmlTest {
     @Test
     // @checkstyle MethodNameCheck (1 line)
     public void formatsHtml5ForLegacyBrowsersDoctypeBody() throws IOException {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing",
+            () -> new RsPrint(
                 new RsPrettyXml(
                     new RsWithBody(
                         Joiner.on("").appendTo(
@@ -92,7 +96,7 @@ public final class RsPrettyXmlTest {
                     )
                 )
             ).printBody(),
-            Matchers.is(
+            new IsEqual<>(
                 Joiner.on("").appendTo(
                     new StringBuilder("<!DOCTYPE html\n"),
                     "  SYSTEM \"about:legacy-compat\">\n",
@@ -119,8 +123,9 @@ public final class RsPrettyXmlTest {
         final String pid = "PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" ";
         final String xhtml = "<html xmlns=\"http://www.w3.org/1999/xhtml\" "
             .concat("lang=\"en\">");
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing formatsHtml4DoctypeBody()",
+            () -> new RsPrint(
                 new RsPrettyXml(
                     new RsWithBody(
                         Joiner.on("").appendTo(
@@ -134,7 +139,7 @@ public final class RsPrettyXmlTest {
                     )
                 )
             ).printBody(),
-            Matchers.is(
+            new IsEqual<>(
                 Joiner.on("").appendTo(
                     new StringBuilder("<!DOCTYPE html\n  "),
                     pid,
@@ -170,8 +175,9 @@ public final class RsPrettyXmlTest {
                 "<test>\n   <a>test</a>\n</test>\n"
             )
         ).printBody(baos);
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing reportsCorrectContentLength()",
+            () -> new RsPrint(
                 new RsPrettyXml(
                     new RsWithBody("<test><a>test</a></test>")
                 )

--- a/src/test/java/org/takes/rs/RsWithStatusTest.java
+++ b/src/test/java/org/takes/rs/RsWithStatusTest.java
@@ -26,9 +26,10 @@ package org.takes.rs;
 import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.takes.Response;
 
 /**
@@ -44,14 +45,15 @@ public final class RsWithStatusTest {
      */
     @Test
     public void addsStatus() throws IOException {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing addsStatus()",
+            () -> new RsPrint(
                 new RsWithStatus(
                     new RsWithHeader("Host", "example.com"),
                     HttpURLConnection.HTTP_NOT_FOUND
                 )
             ).print(),
-            Matchers.equalTo(
+            new IsEqual<>(
                 Joiner.on("\r\n").join(
                     "HTTP/1.1 404 Not Found",
                     "Host: example.com",
@@ -75,12 +77,9 @@ public final class RsWithStatusTest {
             ),
             HttpURLConnection.HTTP_SEE_OTHER
         );
-        MatcherAssert.assertThat(
-            response.head(),
-            Matchers.<String>iterableWithSize(1)
-        );
-        MatcherAssert.assertThat(
-            response.head(),
+        new Assertion<>(
+            "An error occurred while executing addsStatusMultipleTimes()",
+            () -> response.head(),
             Matchers.<String>iterableWithSize(1)
         );
     }

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -26,8 +26,8 @@ package org.takes.rs;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.text.JoinedText;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.TextIs;
 
 /**
@@ -85,8 +85,9 @@ public final class RsWithTypeTest {
     @Test
     public void replaceTypeToResponse() throws Exception {
         final String type = RsWithTypeTest.TYPE_TEXT;
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replaceTypeToResponse()",
+            () -> new RsPrint(
                 new RsWithType(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     type
@@ -111,8 +112,9 @@ public final class RsWithTypeTest {
     @Test
     public void doesNotReplaceResponseCode() throws Exception {
         final String body = "Error!";
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing doesNotReplaceResponseCode()",
+            () -> new RsPrint(
                 new RsWithType(
                     new RsWithBody(
                         new RsWithStatus(HttpURLConnection.HTTP_INTERNAL_ERROR),
@@ -140,8 +142,9 @@ public final class RsWithTypeTest {
      */
     @Test
     public void replacesTypeWithHtml() throws Exception {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithHtml()",
+            () -> new RsPrint(
                 new RsWithType.Html(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML)
                 )
@@ -159,8 +162,9 @@ public final class RsWithTypeTest {
                 )
             )
         );
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithHtml() - ISO",
+            () -> new RsPrint(
                 new RsWithType.Html(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     StandardCharsets.ISO_8859_1
@@ -188,8 +192,9 @@ public final class RsWithTypeTest {
      */
     @Test
     public void replacesTypeWithJson() throws Exception {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithJson()",
+            () -> new RsPrint(
                 new RsWithType.Json(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML)
                 )
@@ -207,8 +212,9 @@ public final class RsWithTypeTest {
                 )
             )
         );
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithJson() - ISO",
+            () -> new RsPrint(
                 new RsWithType.Json(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_XML),
                     StandardCharsets.ISO_8859_1
@@ -236,8 +242,9 @@ public final class RsWithTypeTest {
      */
     @Test
     public void replacesTypeWithXml() throws Exception {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithXml()",
+            () -> new RsPrint(
                 new RsWithType.Xml(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML)
                 )
@@ -254,8 +261,9 @@ public final class RsWithTypeTest {
                 )
             )
         );
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithXml() - ISO",
+            () -> new RsPrint(
                 new RsWithType.Xml(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML),
                     StandardCharsets.ISO_8859_1
@@ -283,8 +291,9 @@ public final class RsWithTypeTest {
      */
     @Test
     public void replacesTypeWithText() throws Exception {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithText()",
+            () -> new RsPrint(
                 new RsWithType.Text(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML)
                 )
@@ -301,8 +310,9 @@ public final class RsWithTypeTest {
                 )
             )
         );
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing replacesTypeWithText() - ISO",
+            () -> new RsPrint(
                 new RsWithType.Text(
                     new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_HTML),
                     StandardCharsets.ISO_8859_1
@@ -330,8 +340,9 @@ public final class RsWithTypeTest {
      */
     @Test
     public void addsContentType() throws Exception {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing addsContentType()",
+            () -> new RsPrint(
                 new RsWithType(new RsEmpty(), RsWithTypeTest.TYPE_TEXT)
             ),
             new TextIs(
@@ -356,8 +367,9 @@ public final class RsWithTypeTest {
      */
     @Test
     public void addsCharsetToContentType() throws Exception {
-        MatcherAssert.assertThat(
-            new RsPrint(
+        new Assertion<>(
+            "An error occurred while executing addsCharsetToContentType()",
+            () -> new RsPrint(
                 new RsWithType(
                     new RsEmpty(),
                     RsWithTypeTest.TYPE_TEXT,


### PR DESCRIPTION
For #944:

- Substitution of some `MatcherAsssert.assertThat` by `Assertion` (`org.llorllale.cactoos.matchers`).