### PR TITLE
Introduce RsSmartNotEmpty #952

### DIFF
--- a/src/main/java/org/takes/rs/RsEmpty.java
+++ b/src/main/java/org/takes/rs/RsEmpty.java
@@ -25,9 +25,9 @@ package org.takes.rs;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Collections;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.list.ListOf;
 import org.takes.Response;
 
 /**
@@ -43,7 +43,7 @@ public final class RsEmpty implements Response {
 
     @Override
     public Iterable<String> head() {
-        return Collections.singletonList("HTTP/1.1 200 OK");
+        return new ListOf<>("HTTP/1.1 204 No Content");
     }
 
     @Override

--- a/src/main/java/org/takes/rs/RsHtml.java
+++ b/src/main/java/org/takes/rs/RsHtml.java
@@ -54,7 +54,7 @@ public final class RsHtml extends RsWrap {
      * @param body HTML body
      */
     public RsHtml(final CharSequence body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -62,7 +62,7 @@ public final class RsHtml extends RsWrap {
      * @param body HTML body
      */
     public RsHtml(final byte[] body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -71,7 +71,7 @@ public final class RsHtml extends RsWrap {
      * @since 0.10
      */
     public RsHtml(final URL url) {
-        this(new RsEmpty(), url);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), url);
     }
 
     /**
@@ -79,7 +79,7 @@ public final class RsHtml extends RsWrap {
      * @param body HTML body
      */
     public RsHtml(final InputStream body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**

--- a/src/main/java/org/takes/rs/RsText.java
+++ b/src/main/java/org/takes/rs/RsText.java
@@ -24,6 +24,7 @@
 package org.takes.rs;
 
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -53,7 +54,7 @@ public final class RsText extends RsWrap {
      * @param body Plain text body
      */
     public RsText(final CharSequence body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -61,7 +62,7 @@ public final class RsText extends RsWrap {
      * @param body Plain text body
      */
     public RsText(final byte[] body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -69,7 +70,7 @@ public final class RsText extends RsWrap {
      * @param body Plain text body
      */
     public RsText(final InputStream body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -78,7 +79,7 @@ public final class RsText extends RsWrap {
      * @since 0.10
      */
     public RsText(final URL url) {
-        this(new RsEmpty(), url);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), url);
     }
 
     /**

--- a/src/main/java/org/takes/rs/RsWithBody.java
+++ b/src/main/java/org/takes/rs/RsWithBody.java
@@ -25,6 +25,7 @@ package org.takes.rs;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
 import lombok.EqualsAndHashCode;
@@ -55,7 +56,7 @@ public final class RsWithBody extends RsWrap {
      * @param body Body
      */
     public RsWithBody(final CharSequence body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -63,7 +64,7 @@ public final class RsWithBody extends RsWrap {
      * @param body Body
      */
     public RsWithBody(final byte[] body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -71,7 +72,7 @@ public final class RsWithBody extends RsWrap {
      * @param body Body
      */
     public RsWithBody(final InputStream body) {
-        this(new RsEmpty(), body);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), body);
     }
 
     /**
@@ -80,7 +81,7 @@ public final class RsWithBody extends RsWrap {
      * @param url URL with body
      */
     public RsWithBody(final URL url) {
-        this(new RsEmpty(), url);
+        this(new RsWithStatus(HttpURLConnection.HTTP_OK), url);
     }
 
     /**

--- a/src/test/java/org/takes/facets/auth/PsChainTest.java
+++ b/src/test/java/org/takes/facets/auth/PsChainTest.java
@@ -63,7 +63,7 @@ public final class PsChainTest {
                 new PsFake(true)
             ).exit(new RsEmpty(), Identity.ANONYMOUS)
                 .head().iterator().next(),
-            new StringContains("HTTP/1.1 200 O")
+            new StringContains("HTTP/1.1 204 No")
         );
     }
 }

--- a/src/test/java/org/takes/facets/cookies/RsWithCookieTest.java
+++ b/src/test/java/org/takes/facets/cookies/RsWithCookieTest.java
@@ -122,7 +122,7 @@ public final class RsWithCookieTest {
      */
     private static String cookies(final String... cookies) throws IOException {
         final List<String> list = new ArrayList<>(cookies.length + 3);
-        list.add("HTTP/1.1 200 OK");
+        list.add("HTTP/1.1 204 No Content");
         for (final String cookie : cookies) {
             list.add(String.format("Set-Cookie: %s;", cookie));
         }

--- a/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsStatusTest.java
@@ -50,7 +50,7 @@ public final class HmRsStatusTest {
         );
         MatcherAssert.assertThat(
             new TkEmpty().act(new RqFake()),
-            new HmRsStatus(HttpURLConnection.HTTP_OK)
+            new HmRsStatus(HttpURLConnection.HTTP_NO_CONTENT)
         );
     }
 

--- a/src/test/java/org/takes/rs/RsWithHeaderTest.java
+++ b/src/test/java/org/takes/rs/RsWithHeaderTest.java
@@ -50,7 +50,7 @@ public final class RsWithHeaderTest {
             ).print(),
             Matchers.equalTo(
                 Joiner.on("\r\n").join(
-                    "HTTP/1.1 200 OK",
+                    "HTTP/1.1 204 No Content",
                     "host: b.example.com",
                     "Host: a.example.com",
                     "",

--- a/src/test/java/org/takes/rs/RsWithHeadersTest.java
+++ b/src/test/java/org/takes/rs/RsWithHeadersTest.java
@@ -53,7 +53,7 @@ public final class RsWithHeadersTest {
             ).print(),
             Matchers.equalTo(
                 Joiner.on("\r\n").join(
-                    "HTTP/1.1 200 OK",
+                    "HTTP/1.1 204 No Content",
                     host,
                     type,
                     "",

--- a/src/test/java/org/takes/rs/RsWithTypeTest.java
+++ b/src/test/java/org/takes/rs/RsWithTypeTest.java
@@ -63,9 +63,9 @@ public final class RsWithTypeTest {
     private static final String TYPE_JSON = "application/json";
 
     /**
-     * HTTP Status OK.
+     * HTTP Status No Content.
      */
-    private static final String HTTP_OK = "HTTP/1.1 200 OK";
+    private static final String HTTP_NO_CONTENT = "HTTP/1.1 204 No Content";
 
     /**
      * Content-Type format.
@@ -95,7 +95,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(RsWithTypeTest.CONTENT_TYPE, type),
                     "",
                     ""
@@ -149,7 +149,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE,
                         RsWithTypeTest.TYPE_HTML
@@ -169,7 +169,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
                         RsWithTypeTest.TYPE_HTML,
@@ -197,7 +197,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE,
                         RsWithTypeTest.TYPE_JSON
@@ -217,7 +217,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
                         RsWithTypeTest.TYPE_JSON,
@@ -245,7 +245,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE, RsWithTypeTest.TYPE_XML
                     ),
@@ -264,7 +264,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
                         RsWithTypeTest.TYPE_XML,
@@ -292,7 +292,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE, RsWithTypeTest.TYPE_TEXT
                     ),
@@ -311,7 +311,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
                         RsWithTypeTest.TYPE_TEXT,
@@ -337,7 +337,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.CONTENT_TYPE,
                         RsWithTypeTest.TYPE_TEXT
@@ -367,7 +367,7 @@ public final class RsWithTypeTest {
             new TextIs(
                 new JoinedText(
                     RsWithTypeTest.CRLF,
-                    RsWithTypeTest.HTTP_OK,
+                    RsWithTypeTest.HTTP_NO_CONTENT,
                     String.format(
                         RsWithTypeTest.TYPE_WITH_CHARSET,
                         RsWithTypeTest.TYPE_TEXT,

--- a/src/test/java/org/takes/rs/RsWithoutHeaderTest.java
+++ b/src/test/java/org/takes/rs/RsWithoutHeaderTest.java
@@ -50,7 +50,7 @@ public final class RsWithoutHeaderTest {
             ).print(),
             Matchers.equalTo(
                 Joiner.on("\r\n").join(
-                    "HTTP/1.1 200 OK",
+                    "HTTP/1.1 204 No Content",
                     "",
                     ""
                 )

--- a/src/test/java/org/takes/tk/TkWithHeadersTest.java
+++ b/src/test/java/org/takes/tk/TkWithHeadersTest.java
@@ -56,7 +56,7 @@ public final class TkWithHeadersTest {
             new TextIs(
                 new JoinedText(
                     "\r\n",
-                    "HTTP/1.1 200 OK",
+                    "HTTP/1.1 204 No Content",
                     host,
                     type,
                     "",


### PR DESCRIPTION
#952 suggests to change the status code from `RsEmpty` from `200` to `204`. This breaks ~60 test cases which rely on `RsEmpty returning` 200.

I had to edit a few classes that add content to the Response so that the status code is the expected (and correct) 200. I also had to edit a few tests that expected a 200 status code while 204 is the correct one.