### PR TITLE
#957 update PR guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,14 @@
 Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:
 
   - You made a small amount of changes (less than 100 lines, less than 10 files)
-  - You made changes related to only one bug (create separate PRs for separate problems)
+  - You made changes related to only one bug (create separate PRs for separate problems, or leave puzzles)
   - You are ready to defend your changes (there will be a code review)
   - You don't touch what you don't understand
   - You ran the build locally and it passed
+  - Title begins with the issue's number, then a short title
+  - Description begins with the issue's number, then enumerates the changes - summarized - in bulletpoints
+  - Description does not contain GitHub keywords (https://help.github.com/articles/closing-issues-using-keywords/).
+  - You ran the build locally and it passed (see .travis.yml for all checks performed on PRs)
 
 This article will help you understand what we are looking for: http://www.yegor256.com/2015/02/09/serious-code-reviewer.html
 


### PR DESCRIPTION
Fix for #957 . I ommitted the following rule `Your commit messages comply with our rules (see .gitlint)` since we don't have a `.gitlint` check yet.
