### PR TITLE
(#976) Update maven-compiler-plugin and fix bug on it to allow incremental compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,9 +343,11 @@ SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This is for https://github.com/yegor256/takes/issues/976.

In this PR:
- maven-compiler-plugin updated to 3.8.0
- `useIncrementalCompilation` set to `false` to allow incremental compilation :) (see [this](https://stackoverflow.com/questions/16963012/maven-compiler-recompile-all-files-instead-modified/19653164#19653164))