### PR TITLE
For #990: Added support for keeping trailing slashes in FkRegex.

### DIFF
--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -203,10 +203,10 @@ public final class FkRegex implements Fork {
 
     /**
      * Allows disabling the standard way for handling trailing slashes.
-     * @param enabled
+     * @param enabled Enables/Disables the removal of a trailing slash.
      * @return FkRegex
      */
-    public FkRegex setRemoveTrailingSlash(boolean enabled) {
+    public FkRegex setRemoveTrailingSlash(final boolean enabled) {
         this.removeslash = enabled;
         return this;
     }

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -198,6 +198,7 @@ public final class FkRegex implements Fork {
     public FkRegex(final Pattern ptn, final Scalar<TkRegex> tke) {
         this.pattern = ptn;
         this.target = tke;
+        this.removeslash = true;
     }
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -95,6 +95,11 @@ public final class FkRegex implements Fork {
     private final Scalar<TkRegex> target;
 
     /**
+     * Remove trailing slashes is optional
+     */
+    private boolean removeTrailingSlash = true;
+
+    /**
      * Ctor.
      * @param ptn Pattern
      * @param text Text
@@ -195,10 +200,20 @@ public final class FkRegex implements Fork {
         this.target = tke;
     }
 
+    /**
+     * Allows disabling the standard way for handling trailing slashes.
+     * @param removeTrailingSlash
+     * @return
+     */
+    public FkRegex setRemoveTrailingSlash(boolean removeTrailingSlash) {
+        this.removeTrailingSlash = removeTrailingSlash;
+        return this;
+    }
+
     @Override
     public Opt<Response> route(final Request req) throws Exception {
         String path = new RqHref.Base(req).href().path();
-        if (path.length() > 1 && path.charAt(path.length() - 1) == '/') {
+        if (removeTrailingSlash && path.length() > 1 && path.charAt(path.length() - 1) == '/') {
             path = path.substring(0, path.length() - 1);
         }
         final Matcher matcher = this.pattern.matcher(path);

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -215,9 +215,9 @@ public final class FkRegex implements Fork {
     public Opt<Response> route(final Request req) throws Exception {
         String path = new RqHref.Base(req).href().path();
         if (
-                this.removeslash
-                && path.length() > 1
-                && path.charAt(path.length() - 1) == '/'
+            this.removeslash
+            && path.length() > 1
+            && path.charAt(path.length() - 1) == '/'
         ) {
             path = path.substring(0, path.length() - 1);
         }

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -95,9 +95,9 @@ public final class FkRegex implements Fork {
     private final Scalar<TkRegex> target;
 
     /**
-     * Remove trailing slashes is optional
+     * Remove trailing slashes is optional.
      */
-    private boolean removeTrailingSlash = true;
+    private boolean removeslash;
 
     /**
      * Ctor.
@@ -202,18 +202,22 @@ public final class FkRegex implements Fork {
 
     /**
      * Allows disabling the standard way for handling trailing slashes.
-     * @param removeTrailingSlash
-     * @return
+     * @param enabled
+     * @return FkRegex
      */
-    public FkRegex setRemoveTrailingSlash(boolean removeTrailingSlash) {
-        this.removeTrailingSlash = removeTrailingSlash;
+    public FkRegex setRemoveTrailingSlash(boolean enabled) {
+        this.removeslash = enabled;
         return this;
     }
 
     @Override
     public Opt<Response> route(final Request req) throws Exception {
         String path = new RqHref.Base(req).href().path();
-        if (removeTrailingSlash && path.length() > 1 && path.charAt(path.length() - 1) == '/') {
+        if (
+                this.removeslash
+                && path.length() > 1
+                && path.charAt(path.length() - 1) == '/'
+        ) {
             path = path.substring(0, path.length() - 1);
         }
         final Matcher matcher = this.pattern.matcher(path);

--- a/src/main/java/org/takes/facets/fork/FkRegex.java
+++ b/src/main/java/org/takes/facets/fork/FkRegex.java
@@ -216,8 +216,8 @@ public final class FkRegex implements Fork {
         String path = new RqHref.Base(req).href().path();
         if (
             this.removeslash
-            && path.length() > 1
-            && path.charAt(path.length() - 1) == '/'
+                && path.length() > 1
+                && path.charAt(path.length() - 1) == '/'
         ) {
             path = path.substring(0, path.length() - 1);
         }

--- a/src/test/java/org/takes/facets/fork/FkRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/FkRegexTest.java
@@ -82,12 +82,12 @@ public final class FkRegexTest {
     @Test
     public void keepsTrailingSlash() throws Exception {
         MatcherAssert.assertThat(
-                new FkRegex(FkRegexTest.TESTPATH, new TkEmpty())
-                        .setRemoveTrailingSlash(false)
-                        .route(
-                        new RqFake(RqMethod.POST, FkRegexTest.TESTPATH)
-                ).has(),
-                Matchers.is(true)
+            new FkRegex(FkRegexTest.TESTPATH, new TkEmpty())
+            .setRemoveTrailingSlash(false)
+            .route(
+                new RqFake(RqMethod.POST, FkRegexTest.TESTPATH)
+            ).has(),
+            Matchers.is(true)
         );
     }
 

--- a/src/test/java/org/takes/facets/fork/FkRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/FkRegexTest.java
@@ -62,7 +62,7 @@ public final class FkRegexTest {
     }
 
     /**
-     * FkRegex can remove trailing slash from URI.
+     * FkRegex can remove trailing slash from URI (default).
      * @throws Exception If some problem inside
      */
     @Test
@@ -76,7 +76,7 @@ public final class FkRegexTest {
     }
 
     /**
-     * FkRegex can remove trailing slash from URI.
+     * FkRegex can keep trailing slash from URI.
      * @throws Exception If some problem inside
      */
     @Test

--- a/src/test/java/org/takes/facets/fork/FkRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/FkRegexTest.java
@@ -27,6 +27,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.takes.rq.RqFake;
+import org.takes.rq.RqMethod;
 import org.takes.tk.TkEmpty;
 
 /**
@@ -34,6 +35,8 @@ import org.takes.tk.TkEmpty;
  * @since 0.4
  */
 public final class FkRegexTest {
+
+    private static final String testpath =  "/h/tail/";
 
     /**
      * FkRegex can match by regular expression.
@@ -63,7 +66,7 @@ public final class FkRegexTest {
     public void removesTrailingSlash() throws Exception {
         MatcherAssert.assertThat(
             new FkRegex("/h/tail", new TkEmpty()).route(
-                new RqFake("POST", "/h/tail/")
+                new RqFake(RqMethod.POST, "/h/tail/")
             ).has(),
             Matchers.is(true)
         );
@@ -76,10 +79,10 @@ public final class FkRegexTest {
     @Test
     public void keepsTrailingSlash() throws Exception {
         MatcherAssert.assertThat(
-                new FkRegex("/h/tail/", new TkEmpty())
+                new FkRegex(testpath, new TkEmpty())
                         .setRemoveTrailingSlash(false)
                         .route(
-                        new RqFake("POST", "/h/tail/")
+                        new RqFake(RqMethod.POST, testpath)
                 ).has(),
                 Matchers.is(true)
         );

--- a/src/test/java/org/takes/facets/fork/FkRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/FkRegexTest.java
@@ -69,4 +69,20 @@ public final class FkRegexTest {
         );
     }
 
+    /**
+     * FkRegex can remove trailing slash from URI.
+     * @throws Exception If some problem inside
+     */
+    @Test
+    public void keepsTrailingSlash() throws Exception {
+        MatcherAssert.assertThat(
+                new FkRegex("/h/tail/", new TkEmpty())
+                        .setRemoveTrailingSlash(false)
+                        .route(
+                        new RqFake("POST", "/h/tail/")
+                ).has(),
+                Matchers.is(true)
+        );
+    }
+
 }

--- a/src/test/java/org/takes/facets/fork/FkRegexTest.java
+++ b/src/test/java/org/takes/facets/fork/FkRegexTest.java
@@ -36,7 +36,10 @@ import org.takes.tk.TkEmpty;
  */
 public final class FkRegexTest {
 
-    private static final String testpath =  "/h/tail/";
+    /**
+     * Test path for trailing slash.
+     */
+    private static final String TESTPATH =  "/h/tail/";
 
     /**
      * FkRegex can match by regular expression.
@@ -66,7 +69,7 @@ public final class FkRegexTest {
     public void removesTrailingSlash() throws Exception {
         MatcherAssert.assertThat(
             new FkRegex("/h/tail", new TkEmpty()).route(
-                new RqFake(RqMethod.POST, "/h/tail/")
+                new RqFake(RqMethod.POST, FkRegexTest.TESTPATH)
             ).has(),
             Matchers.is(true)
         );
@@ -79,10 +82,10 @@ public final class FkRegexTest {
     @Test
     public void keepsTrailingSlash() throws Exception {
         MatcherAssert.assertThat(
-                new FkRegex(testpath, new TkEmpty())
+                new FkRegex(FkRegexTest.TESTPATH, new TkEmpty())
                         .setRemoveTrailingSlash(false)
                         .route(
-                        new RqFake(RqMethod.POST, testpath)
+                        new RqFake(RqMethod.POST, FkRegexTest.TESTPATH)
                 ).has(),
                 Matchers.is(true)
         );


### PR DESCRIPTION
For: #990
- Added a fluent setter for disabling the removal of the trailing slash
 `new FkRegEx().setRemoveTrailingSlash(false)`
- Removing the trailing slash is still the default
- Extended FkRegex component test