### PR TITLE
#1060 fix exception in RqSocket.getRemotePort()

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -175,7 +175,7 @@ public final class BkBasic implements Back {
                 BkBasic.REMOTEADDR,
                 socket.getInetAddress().getHostAddress()
             ),
-            String.format("%s: %d", BkBasic.REMOTEADDR, socket.getPort())
+            String.format("%s: %d", BkBasic.REMOTEPORT, socket.getPort())
         );
     }
 }

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -166,8 +166,16 @@ public final class BkBasicTest {
             Matchers.notNullValue()
         );
         MatcherAssert.assertThat(
+                new RqSocket(request).getLocalPort(),
+                Matchers.equalTo(0)
+        );
+        MatcherAssert.assertThat(
             new RqSocket(request).getRemoteAddress(),
             Matchers.notNullValue()
+        );
+        MatcherAssert.assertThat(
+            new RqSocket(request).getRemotePort(),
+            Matchers.equalTo(0)
         );
     }
 

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -166,8 +166,8 @@ public final class BkBasicTest {
             Matchers.notNullValue()
         );
         MatcherAssert.assertThat(
-                new RqSocket(request).getLocalPort(),
-                Matchers.equalTo(0)
+            new RqSocket(request).getLocalPort(),
+            Matchers.equalTo(0)
         );
         MatcherAssert.assertThat(
             new RqSocket(request).getRemoteAddress(),


### PR DESCRIPTION
The remote **port** of requests - which _takes_ adds as a custom http header - was set using the key of the remote **address**. This simple change fixes that. Test assertions have been added to make sure the exception described at #1060 is fixed.

A new version of _takes_ in maven that includes this PR would be awesome!