### PR TITLE
(#1074, #1075) Refactor RsPrint and introduce tests for HeadPrint and BodyPrint

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputStreamOf;
@@ -122,17 +123,29 @@ public final class BkBasic implements Back {
     private void print(final Request req, final OutputStream output)
         throws IOException {
         try {
-            new RsPrint(this.take.act(req)).print(output);
+            output.write(
+                new RsPrint(this.take.act(req))
+                    .asString()
+                    .getBytes(StandardCharsets.UTF_8)
+            );
         } catch (final HttpException ex) {
-            new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
-            // @checkstyle IllegalCatchCheck (7 lines)
+            output.write(
+                new RsPrint(BkBasic.failure(ex, ex.code()))
+                    .asString()
+                    .getBytes(StandardCharsets.UTF_8)
+            );
+            // @checkstyle IllegalCatchCheck (10 lines)
         } catch (final Throwable ex) {
-            new RsPrint(
-                BkBasic.failure(
-                    ex,
-                    HttpURLConnection.HTTP_INTERNAL_ERROR
+            output.write(
+                new RsPrint(
+                    BkBasic.failure(
+                        ex,
+                        HttpURLConnection.HTTP_INTERNAL_ERROR
+                    )
                 )
-            ).print(output);
+                .asString()
+                .getBytes(StandardCharsets.UTF_8)
+            );
         }
     }
 

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -29,10 +29,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import org.cactoos.io.BytesOf;
 import org.cactoos.io.InputStreamOf;
+import org.cactoos.io.UncheckedBytes;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -124,27 +124,25 @@ public final class BkBasic implements Back {
         throws IOException {
         try {
             output.write(
-                new RsPrint(this.take.act(req))
-                    .asString()
-                    .getBytes(StandardCharsets.UTF_8)
+                new RsPrint(this.take.act(req)).asBytes()
             );
         } catch (final HttpException ex) {
             output.write(
-                new RsPrint(BkBasic.failure(ex, ex.code()))
-                    .asString()
-                    .getBytes(StandardCharsets.UTF_8)
+                new UncheckedBytes(
+                    new RsPrint(BkBasic.failure(ex, ex.code()))
+                ).asBytes()
             );
             // @checkstyle IllegalCatchCheck (10 lines)
         } catch (final Throwable ex) {
             output.write(
-                new RsPrint(
-                    BkBasic.failure(
-                        ex,
-                        HttpURLConnection.HTTP_INTERNAL_ERROR
+                new UncheckedBytes(
+                    new RsPrint(
+                        BkBasic.failure(
+                            ex,
+                            HttpURLConnection.HTTP_INTERNAL_ERROR
+                        )
                     )
-                )
-                .asString()
-                .getBytes(StandardCharsets.UTF_8)
+                ).asBytes()
             );
         }
     }

--- a/src/main/java/org/takes/rs/BodyPrint.java
+++ b/src/main/java/org/takes/rs/BodyPrint.java
@@ -26,7 +26,6 @@ package org.takes.rs;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import org.cactoos.Text;
 import org.cactoos.text.TextOf;
 import org.takes.Response;
@@ -55,13 +54,9 @@ public final class BodyPrint implements Body, Text {
         this.response = res;
     }
 
-    /**
-     * Print it into output stream in UTF8.
-     *
-     * @param output Output to print into
-     * @throws IOException If fails
-     */
-    public void print(final OutputStream output) throws IOException {
+    @Override
+    public String asString() throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         // @checkstyle MagicNumber (1 line)
         final byte[] buf = new byte[4096];
         final InputStream body = this.response.body();
@@ -71,17 +66,11 @@ public final class BodyPrint implements Body, Text {
                 if (bts < 0) {
                     break;
                 }
-                output.write(buf, 0, bts);
+                baos.write(buf, 0, bts);
             }
         } finally {
-            output.flush();
+            baos.flush();
         }
-    }
-
-    @Override
-    public String asString() throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        this.print(baos);
         return new TextOf(baos.toByteArray()).asString();
     }
 

--- a/src/main/java/org/takes/rs/HeadPrint.java
+++ b/src/main/java/org/takes/rs/HeadPrint.java
@@ -24,8 +24,6 @@
 package org.takes.rs;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import org.cactoos.Text;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.Joined;
@@ -39,9 +37,6 @@ import org.takes.Response;
  * <p>The class is immutable and thread-safe.
  *
  * @since 2.0
- * @todo #1054:30min Develop tests for {@link HeadPrint} and {@link BodyPrint}.
- *  Although these classes are tested by {@link RsPrint} they need their own
- *  unit tests.
  */
 public final class HeadPrint implements Head, Text {
 
@@ -63,27 +58,13 @@ public final class HeadPrint implements Head, Text {
         this.response = res;
     }
 
-    /**
-     * Print it into output stream in UTF8.
-     *
-     * @param output Output to print into
-     * @throws IOException If fails
-     */
-    public void print(final OutputStream output) throws IOException {
-        try {
-            output.write(this.asString().getBytes(StandardCharsets.UTF_8));
-        } finally {
-            output.flush();
-        }
-    }
-
     @Override
     public String asString() throws IOException {
         return new FormattedText(
             "%s%s%s",
             new Joined(
                 HeadPrint.EOL,
-                this.response.head()
+                this.head()
             ),
             HeadPrint.EOL,
             HeadPrint.EOL

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -24,8 +24,6 @@
 package org.takes.rs;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Writer;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.cactoos.Text;
@@ -75,71 +73,4 @@ public final class RsPrint extends RsWrap implements Text {
             this.body
         ).asString();
     }
-
-    /**
-     * Print body into string.
-     * @return Entire body of HTTP response
-     * @throws IOException If fails
-     */
-    public String printBody() throws IOException {
-        return this.body.asString();
-    }
-
-    /**
-     * Print head into string.
-     * @return Entire head of HTTP response
-     * @throws IOException If fails
-     * @since 0.10
-     */
-    public String printHead() throws IOException {
-        return this.head.asString();
-    }
-
-    /**
-     * Print it into output stream.
-     * @param output Output to print into
-     * @throws IOException If fails
-     * @todo #1054:30min Remove the #print(OutputStream) methods.
-     *  After the creation of {@link HeadPrint} and {@link BodyPrint} classes,
-     *  these methods lost sense and need be removed from these classes and
-     *  all tests that uses #print() method.
-     */
-    public void print(final OutputStream output) throws IOException {
-        this.head.print(output);
-        this.body.print(output);
-    }
-
-    /**
-     * Print it into output stream in UTF8.
-     * @param output Output to print into
-     * @throws IOException If fails
-     * @since 0.10
-     */
-    public void printHead(final OutputStream output) throws IOException {
-        this.head.print(output);
-    }
-
-    /**
-     * Print it into a writer.
-     * @param writer Writer to print into
-     * @throws IOException If fails
-     * @since 2.0
-     */
-    public void printHead(final Writer writer) throws IOException {
-        try {
-            writer.write(this.head.asString());
-        } finally {
-            writer.flush();
-        }
-    }
-
-    /**
-     * Print it into output stream.
-     * @param output Output to print into
-     * @throws IOException If fails
-     */
-    public void printBody(final OutputStream output) throws IOException {
-        this.body.print(output);
-    }
-
 }

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -24,9 +24,12 @@
 package org.takes.rs;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.Bytes;
 import org.cactoos.Text;
+import org.cactoos.io.BytesOf;
 import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
 import org.takes.Response;
@@ -43,7 +46,7 @@ import org.takes.Response;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class RsPrint extends RsWrap implements Text {
+public final class RsPrint extends RsWrap implements Text, Bytes {
 
     /**
      * Head print representation.
@@ -72,5 +75,13 @@ public final class RsPrint extends RsWrap implements Text {
             this.head,
             this.body
         ).asString();
+    }
+
+    @Override
+    public byte[] asBytes() throws Exception {
+        return new BytesOf(
+            this.asString(),
+            StandardCharsets.UTF_8
+        ).asBytes();
     }
 }

--- a/src/test/java/org/takes/facets/auth/PsBasicTest.java
+++ b/src/test/java/org/takes/facets/auth/PsBasicTest.java
@@ -41,6 +41,7 @@ import org.takes.rq.RqFake;
 import org.takes.rq.RqMethod;
 import org.takes.rq.RqWithHeader;
 import org.takes.rq.RqWithHeaders;
+import org.takes.rs.HeadPrint;
 import org.takes.rs.RsPrint;
 import org.takes.tk.TkText;
 
@@ -152,7 +153,7 @@ public final class PsBasicTest {
             forward = ex;
         }
         MatcherAssert.assertThat(
-            new RsPrint(forward).printHead(),
+            new HeadPrint(forward).asString(),
             Matchers.allOf(
                 Matchers.containsString("HTTP/1.1 401 Unauthorized"),
                 Matchers.containsString(

--- a/src/test/java/org/takes/facets/fallback/FbChainTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbChainTest.java
@@ -27,7 +27,7 @@ import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.takes.rs.RsPrint;
+import org.takes.rs.BodyPrint;
 import org.takes.rs.RsText;
 
 /**
@@ -46,13 +46,13 @@ final class FbChainTest {
             HttpURLConnection.HTTP_NOT_FOUND
         );
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new FbChain(
                     new FbEmpty(),
                     new FbFixed(new RsText("first rs")),
                     new FbFixed(new RsText("second rs"))
                 ).route(req).get()
-            ).printBody(),
+            ).asString(),
             Matchers.startsWith("first")
         );
     }

--- a/src/test/java/org/takes/facets/fallback/FbStatusTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbStatusTest.java
@@ -30,6 +30,7 @@ import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.TextIs;
 import org.takes.rs.BodyPrint;
 import org.takes.rs.HeadPrint;
 import org.takes.rs.RsPrint;
@@ -126,8 +127,8 @@ final class FbStatusTest {
             new FbStatus(code).route(req).get()
         );
         MatcherAssert.assertThat(
-            new BodyPrint(response).asString(),
-            Matchers.equalTo("404 Not Found: Exception message")
+            new BodyPrint(response),
+            new TextIs("404 Not Found: Exception message")
         );
         MatcherAssert.assertThat(
             new HeadPrint(response).asString(),

--- a/src/test/java/org/takes/facets/fallback/FbStatusTest.java
+++ b/src/test/java/org/takes/facets/fallback/FbStatusTest.java
@@ -30,6 +30,8 @@ import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.takes.rs.BodyPrint;
+import org.takes.rs.HeadPrint;
 import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 import org.takes.tk.TkFixed;
@@ -50,12 +52,12 @@ final class FbStatusTest {
         final int status = HttpURLConnection.HTTP_NOT_FOUND;
         final RqFallback req = new RqFallback.Fake(status);
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new FbStatus(
                     status,
                     new TkFixed(new RsText("not found response"))
                 ).route(req).get()
-            ).printBody(),
+            ).asString(),
             Matchers.startsWith("not found")
         );
     }
@@ -70,7 +72,7 @@ final class FbStatusTest {
             HttpURLConnection.HTTP_MOVED_PERM
         );
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new FbStatus(
                     new Filtered<>(
                         status -> {
@@ -84,7 +86,7 @@ final class FbStatusTest {
                     ),
                     new FbFixed(new RsText("response text"))
                 ).route(req).get()
-            ).printBody(),
+            ).asString(),
             Matchers.startsWith("response")
         );
     }
@@ -124,11 +126,11 @@ final class FbStatusTest {
             new FbStatus(code).route(req).get()
         );
         MatcherAssert.assertThat(
-            response.printBody(),
+            new BodyPrint(response).asString(),
             Matchers.equalTo("404 Not Found: Exception message")
         );
         MatcherAssert.assertThat(
-            response.printHead(),
+            new HeadPrint(response).asString(),
             Matchers.both(
                 Matchers.containsString("Content-Type: text/plain")
             ).and(Matchers.containsString("404 Not Found"))

--- a/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
+++ b/src/test/java/org/takes/facets/fallback/TkFallbackTest.java
@@ -31,8 +31,8 @@ import org.takes.Response;
 import org.takes.Take;
 import org.takes.misc.Opt;
 import org.takes.rq.RqFake;
+import org.takes.rs.BodyPrint;
 import org.takes.rs.ResponseOf;
-import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 import org.takes.tk.TkFailure;
 
@@ -51,7 +51,7 @@ final class TkFallbackTest {
     void fallsBack() throws Exception {
         final String err = "message";
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new TkFallback(
                     new TkFailure(err),
                     new Fallback() {
@@ -63,7 +63,7 @@ final class TkFallbackTest {
                         }
                     }
                 ).act(new RqFake())
-            ).printBody(),
+            ).asString(),
             Matchers.endsWith(err)
         );
     }
@@ -75,7 +75,7 @@ final class TkFallbackTest {
     @Test
     void fallsBackInsideResponse() throws Exception {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new TkFallback(
                     new Take() {
                         @Override
@@ -94,7 +94,7 @@ final class TkFallbackTest {
                     },
                     new FbFixed(new RsText("caught here!"))
                 ).act(new RqFake())
-            ).printBody(),
+            ).asString(),
             Matchers.startsWith("caught")
         );
     }

--- a/src/test/java/org/takes/facets/fork/RsForkTest.java
+++ b/src/test/java/org/takes/facets/fork/RsForkTest.java
@@ -30,7 +30,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.takes.Request;
 import org.takes.rq.RqFake;
-import org.takes.rs.RsPrint;
+import org.takes.rs.BodyPrint;
 import org.takes.rs.RsText;
 
 /**
@@ -54,13 +54,13 @@ final class RsForkTest {
             ""
         );
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsFork(
                     req,
                     new FkTypes("text/plain", new RsText("it's a text")),
                     new FkTypes("image/*", new RsText("it's an image"))
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.endsWith("a text")
         );
     }
@@ -72,12 +72,12 @@ final class RsForkTest {
     @Test
     void negotiatesContentWithoutAccept() throws IOException {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsFork(
                     new RqFake(),
                     new FkTypes("image/png,*/*", new RsText("a png"))
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.endsWith("png")
         );
     }
@@ -96,7 +96,7 @@ final class RsForkTest {
             ""
         );
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsFork(
                     req,
                     new FkTypes(
@@ -104,7 +104,7 @@ final class RsForkTest {
                         new RsText("how are you?")
                     )
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.endsWith("you?")
         );
     }
@@ -116,13 +116,13 @@ final class RsForkTest {
     @Test
     void dispatchesByRequestMethod() throws IOException {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsFork(
                     new RqFake("POST", "/test?1", "alpha=1"),
                     new FkMethods("GET", new RsText("it's a GET")),
                     new FkMethods("POST,PUT", new RsText("it's a POST"))
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.endsWith("a POST")
         );
     }

--- a/src/test/java/org/takes/rs/BodyPrintTest.java
+++ b/src/test/java/org/takes/rs/BodyPrintTest.java
@@ -27,12 +27,13 @@ import java.io.IOException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.object.HasToString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link BodyPrint}.
  * @since 1.19
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class BodyPrintTest {
 
     @Test

--- a/src/test/java/org/takes/rs/BodyPrintTest.java
+++ b/src/test/java/org/takes/rs/BodyPrintTest.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rs;
+
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.object.HasToString;
+import org.junit.Test;
+
+/**
+ * Test case for {@link BodyPrint}.
+ * @since 1.19
+ */
+public final class BodyPrintTest {
+
+    @Test
+    public void simple() throws IOException {
+        MatcherAssert.assertThat(
+            "must write body",
+            new BodyPrint(
+                new RsText("World!")
+            ).asString(),
+            new HasToString<>(
+                new IsEqual<>("World!")
+            )
+        );
+    }
+}

--- a/src/test/java/org/takes/rs/HeadPrintTest.java
+++ b/src/test/java/org/takes/rs/HeadPrintTest.java
@@ -25,12 +25,11 @@ package org.takes.rs;
 
 import java.io.IOException;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.object.HasToString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
+import org.llorllale.cactoos.matchers.TextIs;
+import org.llorllale.cactoos.matchers.Throws;
 
 /**
  * Test case for {@link HeadPrint}.
@@ -42,9 +41,16 @@ public final class HeadPrintTest {
      * HeadPrint can fail on invalid chars.
      * @throws IOException If some problem inside
      */
-    @Test(expected = IllegalArgumentException.class)
     public void failsOnInvalidHeader() throws IOException {
-        new HeadPrint(new RsWithHeader("name", "\n\n\n")).asString();
+        MatcherAssert.assertThat(
+            "Must catch invalid header exception",
+            () -> {
+                return new HeadPrint(
+                    new RsWithHeader("name", "\n\n\n")
+                ).asString();
+            },
+            new Throws<>(IllegalArgumentException.class)
+        );
     }
 
     @Test
@@ -52,11 +58,9 @@ public final class HeadPrintTest {
         MatcherAssert.assertThat(
             "must write head",
             new HeadPrint(
-                new RsSimple(new SetOf<>("HTTP/1.1 500 Internal Server Error"), "")
-            ).asString(),
-            new HasToString<>(
-                new IsEqual<>("HTTP/1.1 500 Internal Server Error\r\n\r\n")
-            )
+                new RsSimple(new IterableOf<>("HTTP/1.1 500 Internal Server Error"), "")
+            ),
+            new TextIs("HTTP/1.1 500 Internal Server Error\r\n\r\n")
         );
     }
 
@@ -69,10 +73,8 @@ public final class HeadPrintTest {
             "must write head with dashes",
             new HeadPrint(
                 new RsSimple(new IterableOf<>("HTTP/1.1 203 Non-Authoritative"), "")
-            ).asString(),
-            new HasToString<>(
-                new IsEqual<>("HTTP/1.1 203 Non-Authoritative\r\n\r\n")
-            )
+            ),
+            new TextIs("HTTP/1.1 203 Non-Authoritative\r\n\r\n")
         );
     }
 }

--- a/src/test/java/org/takes/rs/HeadPrintTest.java
+++ b/src/test/java/org/takes/rs/HeadPrintTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.rs;
+
+import java.io.IOException;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.set.SetOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.object.HasToString;
+import org.junit.Test;
+import org.llorllale.cactoos.matchers.Assertion;
+
+/**
+ * Test case for {@link HeadPrint}.
+ * @since 1.19
+ */
+public final class HeadPrintTest {
+
+    /**
+     * HeadPrint can fail on invalid chars.
+     * @throws IOException If some problem inside
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void failsOnInvalidHeader() throws IOException {
+        new HeadPrint(new RsWithHeader("name", "\n\n\n")).asString();
+    }
+
+    @Test
+    public void simple() throws IOException {
+        MatcherAssert.assertThat(
+            "must write head",
+            new HeadPrint(
+                new RsSimple(new SetOf<>("HTTP/1.1 500 Internal Server Error"), "")
+            ).asString(),
+            new HasToString<>(
+                new IsEqual<>("HTTP/1.1 500 Internal Server Error\r\n\r\n")
+            )
+        );
+    }
+
+    /**
+     * RFC 7230 says we shall support dashes in response first line.
+     */
+    @Test
+    public void simpleWithDash() throws IOException {
+        new Assertion<>(
+            "must write head with dashes",
+            new HeadPrint(
+                new RsSimple(new IterableOf<>("HTTP/1.1 203 Non-Authoritative"), "")
+            ).asString(),
+            new HasToString<>(
+                new IsEqual<>("HTTP/1.1 203 Non-Authoritative\r\n\r\n")
+            )
+        );
+    }
+}

--- a/src/test/java/org/takes/rs/RsPrettyJsonTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyJsonTest.java
@@ -25,6 +25,8 @@ package org.takes.rs;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Writer;
+import java.io.OutputStreamWriter;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -45,11 +47,11 @@ public final class RsPrettyJsonTest {
     @Test
     public void formatsJsonBody() throws Exception {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsPrettyJson(
                     new RsWithBody("{\"widget\": {\"debug\": \"on\" }}")
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.is(
                 "\n{\n    \"widget\":{\n        \"debug\":\"on\"\n    }\n}"
             )
@@ -62,7 +64,7 @@ public final class RsPrettyJsonTest {
      */
     @Test(expected = IOException.class)
     public void rejectsNonJsonBody() throws Exception {
-        new RsPrint(new RsPrettyJson(new RsWithBody("foo"))).printBody();
+        new BodyPrint(new RsPrettyJson(new RsWithBody("foo"))).asString();
     }
 
     /**
@@ -72,17 +74,21 @@ public final class RsPrettyJsonTest {
     @Test
     public void reportsCorrectContentLength() throws Exception {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new RsPrint(
-            new RsWithBody(
-                "\n{\n    \"test\":{\n        \"test\":\"test\"\n    }\n}"
-            )
-        ).printBody(baos);
+        try (Writer w = new OutputStreamWriter(baos)) {
+            w.write(
+                new BodyPrint(
+                    new RsWithBody(
+                        "\n{\n    \"test\":{\n        \"test\":\"test\"\n    }\n}"
+                    )
+                ).asString()
+            );
+        }
         MatcherAssert.assertThat(
-            new RsPrint(
+            new HeadPrint(
                 new RsPrettyJson(
                     new RsWithBody("{\"test\": {\"test\": \"test\" }}")
                 )
-            ).printHead(),
+            ).asString(),
             Matchers.containsString(
                 String.format(
                     "Content-Length: %d",

--- a/src/test/java/org/takes/rs/RsPrettyJsonTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyJsonTest.java
@@ -25,8 +25,8 @@ package org.takes.rs;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.Writer;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -36,6 +36,7 @@ import org.llorllale.cactoos.matchers.Assertion;
 /**
  * Test case for {@link RsPrettyJson}.
  * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RsPrettyJsonTest {

--- a/src/test/java/org/takes/rs/RsPrettyXmlTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXmlTest.java
@@ -180,7 +180,7 @@ public final class RsPrettyXmlTest {
      */
     @Test
     public void reportsCorrectContentLength() throws IOException {
-        final int contentlength = new BodyPrint(
+        final int clength = new BodyPrint(
             new RsWithBody(
                 "<test>\n   <a>test</a>\n</test>\n"
             )
@@ -194,7 +194,7 @@ public final class RsPrettyXmlTest {
             Matchers.containsString(
                 String.format(
                     "Content-Length: %d",
-                    contentlength
+                    clength
                 )
             )
         );

--- a/src/test/java/org/takes/rs/RsPrettyXmlTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyXmlTest.java
@@ -23,7 +23,6 @@
  */
 package org.takes.rs;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.cactoos.io.InputStreamOf;
 import org.cactoos.text.Joined;
@@ -49,11 +48,11 @@ public final class RsPrettyXmlTest {
     @Test
     public void formatsXmlBody() throws IOException {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsPrettyXml(
                     new RsWithBody("<test><a>foo</a></test>")
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.is("<test>\n   <a>foo</a>\n</test>\n")
         );
     }
@@ -66,13 +65,13 @@ public final class RsPrettyXmlTest {
     // @checkstyle MethodNameCheck (1 line)
     public void formatsHtml5DoctypeBody() throws IOException {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new BodyPrint(
                 new RsPrettyXml(
                     new RsWithBody(
                         "<!DOCTYPE html><html><head></head><body></body></html>"
                     )
                 )
-            ).printBody(),
+            ).asString(),
             Matchers.containsString("<!DOCTYPE HTML>")
         );
     }
@@ -87,7 +86,7 @@ public final class RsPrettyXmlTest {
     public void formatsHtml5ForLegacyBrowsersDoctypeBody() throws IOException {
         MatcherAssert.assertThat(
             new TextOf(
-                new RsPrint(
+                new BodyPrint(
                     new RsPrettyXml(
                         new RsWithBody(
                             new InputStreamOf(
@@ -100,7 +99,7 @@ public final class RsPrettyXmlTest {
                             )
                         )
                     )
-                ).printBody()
+                ).asString()
             ),
             new IsEqual<>(
                 new Joined(
@@ -132,7 +131,7 @@ public final class RsPrettyXmlTest {
             .concat("lang=\"en\">");
         MatcherAssert.assertThat(
             new TextOf(
-                new RsPrint(
+                new BodyPrint(
                     new RsPrettyXml(
                         new RsWithBody(
                             new InputStreamOf(
@@ -148,7 +147,7 @@ public final class RsPrettyXmlTest {
                             )
                         )
                     )
-                ).printBody()
+                ).asString()
             ),
             new IsEqual<>(
                 new Joined(
@@ -172,7 +171,7 @@ public final class RsPrettyXmlTest {
      */
     @Test(expected = IOException.class)
     public void formatsNonXmlBody() throws IOException {
-        new RsPrint(new RsPrettyXml(new RsWithBody("foo"))).printBody();
+        new BodyPrint(new RsPrettyXml(new RsWithBody("foo"))).asString();
     }
 
     /**
@@ -181,22 +180,21 @@ public final class RsPrettyXmlTest {
      */
     @Test
     public void reportsCorrectContentLength() throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new RsPrint(
+        final int contentlength = new BodyPrint(
             new RsWithBody(
                 "<test>\n   <a>test</a>\n</test>\n"
             )
-        ).printBody(baos);
+        ).length();
         MatcherAssert.assertThat(
-            new RsPrint(
+            new HeadPrint(
                 new RsPrettyXml(
                     new RsWithBody("<test><a>test</a></test>")
                 )
-            ).printHead(),
+            ).asString(),
             Matchers.containsString(
                 String.format(
                     "Content-Length: %d",
-                    baos.toByteArray().length
+                    contentlength
                 )
             )
         );

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -24,8 +24,8 @@
 package org.takes.rs;
 
 import java.io.IOException;
+import org.cactoos.io.BytesOf;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.object.HasToString;
@@ -35,7 +35,9 @@ import org.llorllale.cactoos.matchers.Assertion;
 /**
  * Test case for {@link RsPrint}.
  * @since 1.19
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class RsPrintTest {
 
     /**
@@ -48,14 +50,22 @@ public final class RsPrintTest {
     }
 
     @Test
-    public void simple() throws IOException {
+    public void simple() throws Exception {
+        final RsPrint response = new RsPrint(
+            new RsSimple(new IterableOf<>("HTTP/1.1 500 Internal Server Error"), "")
+        );
         MatcherAssert.assertThat(
-            "must write head",
-            new RsPrint(
-                new RsSimple(new SetOf<>("HTTP/1.1 500 Internal Server Error"), "")
-            ).asString(),
+            "must write head as String",
+            response.asString(),
             new HasToString<>(
                 new IsEqual<>("HTTP/1.1 500 Internal Server Error\r\n\r\n")
+            )
+        );
+        MatcherAssert.assertThat(
+            "must write head as Bytes",
+            response.asBytes(),
+            new IsEqual<>(
+                new BytesOf("HTTP/1.1 500 Internal Server Error\r\n\r\n").asBytes()
             )
         );
     }

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -24,16 +24,9 @@
 package org.takes.rs;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import org.cactoos.io.InputStreamOf;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.object.HasToString;
 import org.junit.Test;
@@ -41,10 +34,8 @@ import org.llorllale.cactoos.matchers.Assertion;
 
 /**
  * Test case for {@link RsPrint}.
- * @since 0.8
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ * @since 1.19
  */
-@SuppressWarnings("PMD.TooManyMethods")
 public final class RsPrintTest {
 
     /**
@@ -56,61 +47,13 @@ public final class RsPrintTest {
         new RsPrint(new RsWithHeader("name", "\n\n\n")).asString();
     }
 
-    /**
-     * RsPrint can flush body contents even when exception happens.
-     * @throws IOException If some problem inside
-     */
-    @Test
-    public void flushBodyEvenWhenExceptionHappens() throws IOException {
-        final IOException exception = new IOException("Failure");
-        final FailOutputStream output = new FailOutputStream(exception);
-        try {
-            new RsPrint(new RsText("Hello"))
-                .printBody(output);
-        } catch (final IOException ex) {
-            if (!ex.equals(exception)) {
-                throw ex;
-            }
-        }
-        MatcherAssert.assertThat(
-            output.haveFlushed(),
-            Matchers.is(true)
-        );
-    }
-
-    /**
-     * RsPrint can close body contents even when exception happens.
-     * @throws IOException If some problem inside
-     */
-    @Test
-    public void closeBodyEvenWhenExceptionHappens() throws IOException {
-        final IOException exception = new IOException("Smth went wrong");
-        final FailOutputStream output = new FailOutputStream(exception);
-        final FakeInput input = new FakeInput(new InputStreamOf("abc"));
-        try {
-            new RsPrint(new RsText(input))
-                .printBody(output);
-        } catch (final IOException ex) {
-            if (!ex.equals(exception)) {
-                throw ex;
-            }
-        }
-        MatcherAssert.assertThat(
-            "Input body was not closed",
-            input.isClosed(),
-            new IsEqual<>(true)
-        );
-    }
-
     @Test
     public void simple() throws IOException {
-        final StringWriter writer = new StringWriter();
-        new RsPrint(
-            new RsSimple(new SetOf<>("HTTP/1.1 500 Internal Server Error"), "")
-        ).printHead(writer);
         MatcherAssert.assertThat(
             "must write head",
-            writer.getBuffer(),
+            new RsPrint(
+                new RsSimple(new SetOf<>("HTTP/1.1 500 Internal Server Error"), "")
+            ).asString(),
             new HasToString<>(
                 new IsEqual<>("HTTP/1.1 500 Internal Server Error\r\n\r\n")
             )
@@ -122,182 +65,14 @@ public final class RsPrintTest {
      */
     @Test
     public void simpleWithDash() throws IOException {
-        final StringWriter writer = new StringWriter();
-        new RsPrint(
-            new RsSimple(new IterableOf<>("HTTP/1.1 203 Non-Authoritative"), "")
-        ).printHead(writer);
         new Assertion<>(
             "must write head with dashes",
-            writer.getBuffer(),
+            new RsPrint(
+                new RsSimple(new IterableOf<>("HTTP/1.1 203 Non-Authoritative"), "")
+            ).asString(),
             new HasToString<>(
                 new IsEqual<>("HTTP/1.1 203 Non-Authoritative\r\n\r\n")
             )
         );
-    }
-
-    /**
-     * RsPrint can flush head contents even when exception happens.
-     * @throws IOException If some problem inside
-     */
-    @Test
-    public void flushHeadEvenWhenExceptionHappens() throws IOException {
-        final IOException exception = new IOException("Error");
-        final FailWriter writer = new FailWriter(exception);
-        try {
-            new RsPrint(new RsText("World!"))
-                .printHead(writer);
-        } catch (final IOException ex) {
-            if (!ex.equals(exception)) {
-                throw ex;
-            }
-        }
-        MatcherAssert.assertThat(
-            writer.haveFlushed(),
-            Matchers.is(true)
-        );
-    }
-
-    /**
-     * Writer that throws IOException on method write.
-     *
-     * @since 2.0
-     */
-    private static final class FailWriter extends Writer {
-
-        /**
-         * Failing output stream.
-         */
-        private final FailOutputStream output;
-
-        /**
-         * Ctor.
-         * @param exception Exception to throw
-         */
-        FailWriter(final IOException exception) {
-            super();
-            this.output = new FailOutputStream(exception);
-        }
-
-        @Override
-        public void write(
-            final char[] cbuf,
-            final int off,
-            final int len
-        ) throws IOException {
-            this.output.write(
-                new String(cbuf).getBytes(StandardCharsets.UTF_8),
-                off,
-                len
-            );
-        }
-
-        @Override
-        public void flush() throws IOException {
-            this.output.flush();
-        }
-
-        @Override
-        public void close() throws IOException {
-            this.output.close();
-        }
-
-        /**
-         * Have contents been flushed?
-         * @return True, if contents were flushed, false - otherwise
-         */
-        public boolean haveFlushed() {
-            return this.output.haveFlushed();
-        }
-    }
-
-    /**
-     * FailOutputStream that throws IOException on method write.
-     *
-     * @since 2.0
-     */
-    private static final class FailOutputStream extends OutputStream {
-
-        /**
-         * Have contents been flushed?
-         */
-        private boolean flushed;
-
-        /**
-         * Exception, that needs to be thrown.
-         */
-        private final IOException exception;
-
-        /**
-         * Ctor.
-         * @param exception Exception to throw
-         */
-        FailOutputStream(final IOException exception) {
-            super();
-            this.exception = exception;
-        }
-
-        @Override
-        public void write(final int value) throws IOException {
-            throw this.exception;
-        }
-
-        @Override
-        public void flush() throws IOException {
-            this.flushed = true;
-        }
-
-        /**
-         * Have contents been flushed?
-         * @return True, if contents were flushed, false - otherwise
-         */
-        public boolean haveFlushed() {
-            return this.flushed;
-        }
-    }
-
-    /**
-     * Fake wrapper for InputStream to make sure body is closed.
-     *
-     * @since 2.0
-     */
-    private static final class FakeInput extends InputStream {
-
-        /**
-         * Have input been closed?
-         */
-        private boolean closed;
-
-        /**
-         * Origin.
-         */
-        private final InputStream origin;
-
-        /**
-         * Ctor.
-         * @param origin Origin input
-         */
-        FakeInput(final InputStream origin) {
-            super();
-            this.origin = origin;
-        }
-
-        @Override
-        public int read() throws IOException {
-            return this.origin.read();
-        }
-
-        @Override
-        public void close() throws IOException {
-            this.origin.close();
-            this.closed = true;
-        }
-
-        /**
-         * Have input been closed?
-         * @return True, if input wes closed, false - otherwise
-         */
-        public boolean isClosed() {
-            return this.closed;
-        }
     }
 }

--- a/src/test/java/org/takes/rs/RsTextTest.java
+++ b/src/test/java/org/takes/rs/RsTextTest.java
@@ -66,12 +66,12 @@ final class RsTextTest {
     @Test
     void makesTextResponseWithStatus() throws IOException {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new HeadPrint(
                 new RsText(
                     new RsWithStatus(HttpURLConnection.HTTP_NOT_FOUND),
                     "something not found"
                 )
-            ).printHead(),
+            ).asString(),
             Matchers.containsString(
                 Integer.toString(HttpURLConnection.HTTP_NOT_FOUND)
             )

--- a/src/test/java/org/takes/tk/TkClasspathTest.java
+++ b/src/test/java/org/takes/tk/TkClasspathTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.llorllale.cactoos.matchers.StartsWith;
 import org.takes.HttpException;
 import org.takes.rq.RqFake;
-import org.takes.rs.RsPrint;
+import org.takes.rs.HeadPrint;
 
 /**
  * Test case for {@link TkClasspath}.
@@ -44,7 +44,7 @@ public final class TkClasspathTest {
     @Test
     public void dispatchesByResourceName() throws Exception {
         MatcherAssert.assertThat(
-            new RsPrint(
+            new HeadPrint(
                 new TkClasspath().act(
                     new RqFake(
                         "GET", "/org/takes/Take.class?a", ""
@@ -65,5 +65,4 @@ public final class TkClasspathTest {
             new RqFake("PUT", "/something-else", "")
         );
     }
-
 }

--- a/src/test/java/org/takes/tk/TkCorsTest.java
+++ b/src/test/java/org/takes/tk/TkCorsTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.takes.facets.hamcrest.HmRsStatus;
 import org.takes.rq.RqFake;
 import org.takes.rq.RqWithHeaders;
-import org.takes.rs.RsPrint;
+import org.takes.rs.HeadPrint;
 import org.takes.rs.RsText;
 
 /**
@@ -87,7 +87,7 @@ final class TkCorsTest {
         throws Exception {
         MatcherAssert.assertThat(
             "Wrong value on header.",
-            new RsPrint(
+            new HeadPrint(
                 new TkCors(
                     new TkFixed(new RsText()),
                     "http://www.teamed.io",
@@ -98,7 +98,7 @@ final class TkCorsTest {
                         "Origin: http://wrong.teamed.io"
                     )
                 )
-            ).printHead(),
+            ).asString(),
             Matchers.allOf(
                 Matchers.containsString("HTTP/1.1 403"),
                 Matchers.containsString(

--- a/src/test/java/org/takes/tk/TkFilesTest.java
+++ b/src/test/java/org/takes/tk/TkFilesTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import org.llorllale.cactoos.matchers.StartsWith;
 import org.takes.HttpException;
 import org.takes.rq.RqFake;
-import org.takes.rs.RsPrint;
+import org.takes.rs.HeadPrint;
 
 /**
  * Test case for {@link TkFiles}.
@@ -56,7 +56,7 @@ public final class TkFilesTest {
             this.temp.newFile("a.txt"), "hello, world!", StandardCharsets.UTF_8
         );
         MatcherAssert.assertThat(
-            new RsPrint(
+            new HeadPrint(
                 new TkFiles(this.temp.getRoot()).act(
                     new RqFake(
                         "GET", "/a.txt?hash=a1b2c3", ""

--- a/src/test/java/org/takes/tk/TkProxyTest.java
+++ b/src/test/java/org/takes/tk/TkProxyTest.java
@@ -43,6 +43,8 @@ import org.takes.rq.RqFake;
 import org.takes.rq.RqHref;
 import org.takes.rq.RqMethod;
 import org.takes.rq.RqPrint;
+import org.takes.rs.BodyPrint;
+import org.takes.rs.HeadPrint;
 import org.takes.rs.RsPrint;
 import org.takes.rs.RsText;
 
@@ -153,14 +155,14 @@ public final class TkProxyTest {
                 @Override
                 public void exec(final URI home) throws Exception {
                     MatcherAssert.assertThat(
-                        new RsPrint(
+                        new BodyPrint(
                             new TkProxy(home).act(
                                 new RqFake(
                                     TkProxyTest.this.method,
                                     "/a/%D0%B0/c?%D0%B0=1#%D0%B0"
                                 )
                             )
-                        ).printBody(),
+                        ).asString(),
                         Matchers.equalTo(
                             String.format(
                                 "http://%s:%d/a/%%D0%%B0/c?%%D0%%B0=1",
@@ -189,7 +191,7 @@ public final class TkProxyTest {
                 @Override
                 public void exec(final URI home) throws Exception {
                     MatcherAssert.assertThat(
-                        new RsPrint(new TkProxy(
+                        new BodyPrint(new TkProxy(
                             home.toURL().toString()
                         ).act(
                             new RqFake(
@@ -204,7 +206,7 @@ public final class TkProxyTest {
                                 ),
                                 ""
                             )
-                        )).printBody(),
+                        )).asString(),
                         Matchers.containsString(
                             String.format(
                                 "Host: %s:%d",
@@ -235,7 +237,7 @@ public final class TkProxyTest {
                 @Override
                 public void exec(final URI home) throws Exception {
                     MatcherAssert.assertThat(
-                        new RsPrint(new TkProxy(
+                        new HeadPrint(new TkProxy(
                             home.toURL().toString(),
                             mark
                         ).act(
@@ -249,7 +251,7 @@ public final class TkProxyTest {
                                 ),
                                 ""
                             )
-                        )).printHead(),
+                        )).asString(),
                         Matchers.containsString(
                             String.format(
                                 // @checkstyle LineLengthCheck (1 line)
@@ -281,7 +283,7 @@ public final class TkProxyTest {
                 @Override
                 public void exec(final URI home) throws Exception {
                     MatcherAssert.assertThat(
-                        new RsPrint(
+                        new BodyPrint(
                             new TkProxy(home).act(
                                 new RqFake(
                                     Arrays.asList(
@@ -300,7 +302,7 @@ public final class TkProxyTest {
                                     body
                                 )
                             )
-                        ).printBody(),
+                        ).asString(),
                         Matchers.allOf(
                             Matchers.containsString("Content-Length:"),
                             Matchers.containsString("Content-Type:"),


### PR DESCRIPTION
For #1074, #1075

- Remove print methods from RsPrint, HeadPrint and BodyPrint
- Introduce test for HeadPrint and BodyPrint

