### PR TITLE
(#975) Introduce query params test in HrefTest

### DIFF
--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -26,6 +26,7 @@ package org.takes.misc;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.llorllale.cactoos.matchers.HasValues;
 
 /**
  * Test case for {@link Href}.
@@ -69,6 +70,22 @@ final class HrefTest {
         MatcherAssert.assertThat(
             new Href(uri).toString(),
             Matchers.equalTo("http://a.example.com/")
+        );
+    }
+
+    /**
+     * Href can get query parameters.
+     */
+    @Test
+    void getQueryParameters() {
+        final String uri = "http://a.example.com?param1=hello&param2=world";
+        MatcherAssert.assertThat(
+            new Href(uri).param("param1"),
+            new HasValues<>("hello")
+        );
+        MatcherAssert.assertThat(
+            new Href(uri).param("param2"),
+            new HasValues<>("world")
         );
     }
 

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -32,6 +32,7 @@ import org.llorllale.cactoos.matchers.HasValues;
  * Test case for {@link Href}.
  * @since 0.7
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class HrefTest {
 
     /**
@@ -77,21 +78,28 @@ final class HrefTest {
      * Href can get query parameters.
      */
     @Test
-    void getQueryParameters() {
-        final String uri = "http://a.example.com?param1=hellow&param2=world";
+    void extractsParamtetersFromQuery() {
+        final String uri = "http://a.example.com?param1=hello&param2=world&param3=hello%20world";
         MatcherAssert.assertThat(
+            "Can't get first parameter.",
             new Href(uri).param("param1"),
-            new HasValues<>("hellow")
+            new HasValues<>("hello")
         );
         MatcherAssert.assertThat(
+            "Can't get second parameter.",
             new Href(uri).param("param2"),
             new HasValues<>("world")
+        );
+        MatcherAssert.assertThat(
+            "Can't extract correctly escaped sequences in parameter value.",
+            new Href(uri).param("param3"),
+            new HasValues<>("hello world")
         );
     }
 
     /**
      * Href can add path.
-     */
+     */ 
     @Test
     void addsPath() {
         MatcherAssert.assertThat(

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -99,7 +99,7 @@ final class HrefTest {
 
     /**
      * Href can add path.
-     */ 
+     */
     @Test
     void addsPath() {
         MatcherAssert.assertThat(

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -78,10 +78,10 @@ final class HrefTest {
      */
     @Test
     void getQueryParameters() {
-        final String uri = "http://a.example.com?param1=hello&param2=world";
+        final String uri = "http://a.example.com?param1=hellow&param2=world";
         MatcherAssert.assertThat(
             new Href(uri).param("param1"),
-            new HasValues<>("hello")
+            new HasValues<>("hellow")
         );
         MatcherAssert.assertThat(
             new Href(uri).param("param2"),


### PR DESCRIPTION
For #975 
- Introduce a test for query params in `HrefTest`

Documentation has been already fixed.
