### PR TITLE
fix(github): fix deprecating auth through query param

### DIFF
--- a/src/main/java/org/takes/facets/auth/social/PsGithub.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGithub.java
@@ -143,11 +143,14 @@ public final class PsGithub implements Pass {
      * @throws IOException If fails
      */
     private Identity fetch(final String token) throws IOException {
-        final String uri = new Href(this.api).path("user")
-            .with(PsGithub.ACCESS_TOKEN, token).toString();
+        // @checkstyle MethodBodyCommentsCheck (2 lines)
+        // @checkstyle LineLengthCheck (1 line)
+        // @see https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
+        final String uri = new Href(this.api).path("user").toString();
         return PsGithub.parse(
             new JdkRequest(uri)
                 .header("accept", "application/json")
+                .header("Authorization", String.format("token %s", token))
                 .fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(JsonResponse.class).json().readObject()


### PR DESCRIPTION
Now, Github only allows sending token in the header. We fixed it.
See: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Fix: #1118