### PR TITLE
build(dev-deps): set version of duplicate-finder-maven-plugin to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,8 +383,9 @@ SOFTWARE.
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.ning.maven.plugins</groupId>
+        <groupId>org.basepom.maven</groupId>
         <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <version>1.5.1</version>
         <configuration>
           <ignoredDependencies>
             <dependency>


### PR DESCRIPTION
There was a bug on missing version while releasing with rultor.

Ref: https://github.com/yegor256/takes/pull/1120#issuecomment-1140376155