### PR TITLE
ci(rultor): remove sonar checks in release command

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -36,4 +36,4 @@ release:
   script: |-
     mvn versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
-    mvn clean deploy -Psonar -Psonatype -Pqulice -Dinvoker.skip --errors --settings ../settings.xml
+    mvn clean deploy -Psonatype -Pqulice -Dinvoker.skip --errors --settings ../settings.xml


### PR DESCRIPTION
It is to fix sonar error about link not found while releasing with Rultor.

Ref: https://github.com/yegor256/takes/pull/1123#issuecomment-1141056834