### PR TITLE
Construct RqHeaders.Smart from Request

### DIFF
--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -88,9 +88,7 @@ public final class PsBasic implements Pass {
 
     @Override
     public Opt<Identity> enter(final Request request) throws IOException {
-        final Iterator<String> headers = new RqHeaders.Smart(
-            new RqHeaders.Base(request)
-        ).header("authorization").iterator();
+        final Iterator<String> headers = new RqHeaders.Smart(request).header("authorization").iterator();
         if (!headers.hasNext()) {
             throw new RsForward(
                 new RsWithHeader(

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -88,7 +88,8 @@ public final class PsBasic implements Pass {
 
     @Override
     public Opt<Identity> enter(final Request request) throws IOException {
-        final Iterator<String> headers = new RqHeaders.Smart(request).header("authorization").iterator();
+        final Iterator<String> headers = new RqHeaders.Smart(request)
+            .header("authorization").iterator();
         if (!headers.hasNext()) {
             throw new RsForward(
                 new RsWithHeader(

--- a/src/main/java/org/takes/facets/fork/FkHost.java
+++ b/src/main/java/org/takes/facets/fork/FkHost.java
@@ -68,9 +68,7 @@ public final class FkHost extends FkWrap {
      */
     private static Fork fork(final String host, final Take take) {
         return req -> {
-            final String hst = new RqHeaders.Smart(
-                new RqHeaders.Base(req)
-            ).single("host");
+            final String hst = new RqHeaders.Smart(req).single("host");
             return new Ternary<Opt<Response>>(
                 new EqualsNullable(
                     new Lowered(host), new Lowered(hst)

--- a/src/main/java/org/takes/rq/RqSocket.java
+++ b/src/main/java/org/takes/rq/RqSocket.java
@@ -53,8 +53,7 @@ public final class RqSocket extends RqWrap {
      */
     public InetAddress getLocalAddress() throws IOException {
         return InetAddress.getByName(
-            new RqHeaders.Smart(new RqHeaders.Base(this))
-                .single("X-Takes-LocalAddress")
+            new RqHeaders.Smart(this).single("X-Takes-LocalAddress")
         );
     }
 
@@ -65,8 +64,7 @@ public final class RqSocket extends RqWrap {
      */
     public InetAddress getRemoteAddress() throws IOException {
         return InetAddress.getByName(
-            new RqHeaders.Smart(new RqHeaders.Base(this))
-                .single("X-Takes-RemoteAddress")
+            new RqHeaders.Smart(this).single("X-Takes-RemoteAddress")
         );
     }
 
@@ -77,8 +75,7 @@ public final class RqSocket extends RqWrap {
      */
     public int getLocalPort() throws IOException {
         return Integer.parseInt(
-            new RqHeaders.Smart(new RqHeaders.Base(this))
-                .single("X-Takes-LocalPort")
+            new RqHeaders.Smart(this).single("X-Takes-LocalPort")
         );
     }
 
@@ -89,8 +86,7 @@ public final class RqSocket extends RqWrap {
      */
     public int getRemotePort() throws IOException {
         return Integer.parseInt(
-            new RqHeaders.Smart(new RqHeaders.Base(this))
-                .single("X-Takes-RemotePort")
+            new RqHeaders.Smart(this).single("X-Takes-RemotePort")
         );
     }
 }

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -164,9 +164,7 @@ public final class RqMtFake implements RqMultipart {
                             .append(RqMtFake.CRLF)
                             .append("Content-Disposition: ")
                             .append(
-                                new RqHeaders.Smart(
-                                    new RqHeaders.Base(part)
-                                ).single("Content-Disposition")
+                                new RqHeaders.Smart(part).single("Content-Disposition")
                             ).append(RqMtFake.CRLF);
                         final String body = new RqPrint(part).printBody();
                         if (!(RqMtFake.CRLF.equals(body) || body.isEmpty())) {

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -75,9 +75,7 @@ public final class TkCors implements Take {
     @Override
     public Response act(final Request req) throws Exception {
         final Response response;
-        final String domain = new RqHeaders.Smart(
-            new RqHeaders.Base(req)
-        ).single("origin", "");
+        final String domain = new RqHeaders.Smart(req).single("origin", "");
         if (this.allowed.contains(domain)) {
             response = new RsWithHeaders(
                 this.origin.act(req),

--- a/src/main/java/org/takes/tk/TkSslOnly.java
+++ b/src/main/java/org/takes/tk/TkSslOnly.java
@@ -60,9 +60,7 @@ public final class TkSslOnly implements Take {
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     public Response act(final Request req) throws Exception {
         final String href = new RqHref.Base(req).href().toString();
-        final String proto = new RqHeaders.Smart(
-            new RqHeaders.Base(req)
-        ).single("x-forwarded-proto", "https");
+        final String proto = new RqHeaders.Smart(req).single("x-forwarded-proto", "https");
         final Response answer;
         if ("https".equalsIgnoreCase(proto)) {
             answer = this.origin.act(req);

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -139,9 +139,7 @@ import org.takes.tk.TkText;
             }
         ).accept(socket);
         final Request request = ref.get();
-        final RqHeaders.Smart smart = new RqHeaders.Smart(
-            new RqHeaders.Base(request)
-        );
+        final RqHeaders.Smart smart = new RqHeaders.Smart(request);
         MatcherAssert.assertThat(
             smart.single(
                 "X-Takes-LocalAddress",

--- a/src/test/java/org/takes/rq/RqHeadersTest.java
+++ b/src/test/java/org/takes/rq/RqHeadersTest.java
@@ -86,14 +86,12 @@ final class RqHeadersTest {
     void returnsSingleHeader() throws IOException {
         MatcherAssert.assertThat(
             new RqHeaders.Smart(
-                new RqHeaders.Base(
-                    new RqFake(
-                        Arrays.asList(
-                            "GET /g",
-                            "Host: www.takes.com"
-                        ),
-                        ""
-                    )
+                new RqFake(
+                    Arrays.asList(
+                        "GET /g",
+                        "Host: www.takes.com"
+                    ),
+                    ""
                 )
             ).single("host", "www.takes.net"),
             Matchers.equalTo("www.takes.com")
@@ -109,14 +107,12 @@ final class RqHeadersTest {
         final String type = "text/plain";
         MatcherAssert.assertThat(
             new RqHeaders.Smart(
-                new RqHeaders.Base(
-                    new RqFake(
-                        Arrays.asList(
-                            "GET /f",
-                            "Accept: text/json"
-                        ),
-                        ""
-                    )
+                new RqFake(
+                    Arrays.asList(
+                        "GET /f",
+                        "Accept: text/json"
+                    ),
+                    ""
                 )
             ).single("Content-type", type),
             Matchers.equalTo(type)


### PR DESCRIPTION
Remove unnecessary `new RqHeaders.Base(req)` calls if we construct `RqHeaders.Smart`.