### PR TITLE
fixes #1227 (https://github.com/yegor256/takes/issues/1227)

### DIFF
--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -69,7 +69,7 @@ public final class RqLive extends RqWrap {
         final Collection<String> head = new LinkedList<>();
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         Opt<Integer> data = new Opt.Empty<>();
-        data = RqLive.data(input, data, false);
+        data = RqLive.data(input, data);
         while (data.get() > 0) {
             eof = false;
             if (data.get() == '\r') {
@@ -82,11 +82,11 @@ public final class RqLive extends RqWrap {
                 if (header.has()) {
                     head.add(header.get());
                 }
-                data = RqLive.data(input, data, false);
+                data = RqLive.data(input, data);
                 continue;
             }
             baos.write(RqLive.legalCharacter(data, baos, head.size() + 1));
-            data = RqLive.data(input, new Opt.Empty<>(), true);
+            data = RqLive.data(input, new Opt.Empty<>());
         }
         if (eof) {
             throw new IOException("empty request");
@@ -170,18 +170,14 @@ public final class RqLive extends RqWrap {
      * Obtains new byte if hasn't.
      * @param input Stream
      * @param data Empty or current data
-     * @param available Indicates whether or not it should check first if there
-     *  are available bytes
      * @return Next or current data
      * @throws IOException if input.read() fails
      */
     private static Opt<Integer> data(final InputStream input,
-        final Opt<Integer> data, final boolean available) throws IOException {
+        final Opt<Integer> data) throws IOException {
         final Opt<Integer> ret;
         if (data.has()) {
             ret = data;
-        } else if (available && input.available() <= 0) {
-            ret = new Opt.Single<>(-1);
         } else {
             ret = new Opt.Single<>(input.read());
         }

--- a/src/test/java/org/takes/misc/AvailableZeroInputStream.java
+++ b/src/test/java/org/takes/misc/AvailableZeroInputStream.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
+ * An InputStream wrapper whose available() method will return 0, the first time around. This is used to simulate
+ * InputStream behavior that has been shown to sometimes occur on Windows.
+ * <br/>
  * Not thread-safe.
  */
 public class AvailableZeroInputStream extends InputStream {

--- a/src/test/java/org/takes/misc/AvailableZeroInputStream.java
+++ b/src/test/java/org/takes/misc/AvailableZeroInputStream.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2024 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.takes.misc;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Not thread-safe.
+ */
+public class AvailableZeroInputStream extends InputStream {
+    private final InputStream delegate;
+    private boolean firstAvailableCall = true;
+
+    public AvailableZeroInputStream(InputStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int available() throws IOException {
+        if (firstAvailableCall) {
+            firstAvailableCall = false;
+            return 0;
+        }
+        return delegate.available();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return delegate.read();
+    }
+
+    public int read(byte[] b) throws IOException {
+        return delegate.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return delegate.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return delegate.skip(n);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        delegate.mark(readlimit);
+    }
+
+    @Override
+    public void reset() throws IOException {
+        delegate.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return delegate.markSupported();
+    }
+}

--- a/src/test/java/org/takes/misc/AvailableZeroInputStream.java
+++ b/src/test/java/org/takes/misc/AvailableZeroInputStream.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * An InputStream wrapper whose available() method will return 0, the first time around. This is used to simulate
- * InputStream behavior that has been shown to sometimes occur on Windows.
+ * An InputStream wrapper whose available() method will return 0, the first time around. This is used to replicate
+ * InputStream behavior that can be seen on Windows.
  * <br/>
  * Not thread-safe.
  */

--- a/src/test/java/org/takes/rq/RqLiveTest.java
+++ b/src/test/java/org/takes/rq/RqLiveTest.java
@@ -32,6 +32,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.takes.Request;
+import org.takes.misc.AvailableZeroInputStream;
 
 /**
  * Test case for {@link RqLive}.
@@ -55,6 +56,43 @@ final class RqLiveTest {
                     "Content-Length: 5",
                     "",
                     "hello"
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            new RqHeaders.Base(req).header("host"),
+            Matchers.hasItem("e")
+        );
+        MatcherAssert.assertThat(
+            new RqPrint(req).printBody(),
+            Matchers.endsWith("ello")
+        );
+    }
+
+    /**
+     * Regression test for #1227.
+     * Without the bug fix, this test will fail with the following exception:
+     * <br/>
+     * org.takes.HttpException: [400] A valid request must contain at least one line in the head
+     * 	at org.takes.rq.RqHeaders$Base.map(RqHeaders.java:140)
+     * 	at org.takes.rq.RqHeaders$Base.header(RqHeaders.java:95)
+     * 	at org.takes.rq.RqLiveTest.supportsInputStreamAvailable0(RqLiveTest.java:89)
+     * 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+     * 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+     */
+    @Test
+    void supportsInputStreamAvailable0() throws IOException {
+        final Request req = new RqLive(
+            new AvailableZeroInputStream(
+                new InputStreamOf(
+                    new Joined(
+                        RqLiveTest.CRLF,
+                        "GET / HTTP/1.1",
+                        "Host:e",
+                        "Content-Length: 5",
+                        "",
+                        "hello"
+                    )
                 )
             )
         );


### PR DESCRIPTION
When socket.getInputStream().available() returns 0, parsing of the request headers will be aborted. I guess the assumption was that available is 0 only in case of "end of stream", which is [not true](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/InputStream.html#available()):

> public int available()
>   Returns an estimate of the number of bytes that can be read (or skipped over) from this input stream without blocking, which may be 0, **or** 0 when end of stream is detected.

I think the appropriate thing to do is to get rid of the code that checks available() altogether, which is what this PR does. In order to reliably determine whether we have reached the end of the stream, we need to read(). No way around it.