### PR TITLE
Only cap the input if content length header is given

### DIFF
--- a/src/test/java/org/takes/rq/RqLengthAwareTest.java
+++ b/src/test/java/org/takes/rq/RqLengthAwareTest.java
@@ -23,6 +23,8 @@
  */
 package org.takes.rq;
 
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -94,6 +96,32 @@ final class RqLengthAwareTest {
             stream.available(),
             Matchers.equalTo(data.length() - 1)
         );
+    }
+
+    @Test
+    void noContentLength() throws IOException {
+        final byte[] bytes = "test".getBytes();
+        final InputStream data = new FilterInputStream(new ByteArrayInputStream(bytes)) {
+            @Override
+            public int available() throws IOException {
+                return 1;
+            }
+        };
+        final InputStream stream = new RqLengthAware(
+            new RqFake(
+                Arrays.asList(
+                    "GET /test1",
+                    "Host: b.example.com"
+                ),
+                data
+            )
+        ).body();
+        for (final byte element : bytes) {
+            MatcherAssert.assertThat(
+                stream.read(),
+                Matchers.equalTo(element & 0xFF)
+            );
+        }
     }
 
     @Test


### PR DESCRIPTION
Currently RqLengthAware uses the InputStream#available to cap the input if no Content-Length header is given, but the return value does not say anything about the real content length, only how many bytes can be read without blocking (what might be 0).

This now only returns a CapInputStream when a Content-Length is given in the request.

Fixes https://github.com/yegor256/takes/issues/1301