### PR TITLE
Only print body if there is a body

### DIFF
--- a/src/main/java/org/takes/rq/RqPrint.java
+++ b/src/main/java/org/takes/rq/RqPrint.java
@@ -38,6 +38,7 @@ import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.Sticky;
 import org.cactoos.text.TextOf;
 import org.takes.Request;
+import org.takes.rq.RqHeaders.Smart;
 
 /**
  * Request decorator, to print it all.
@@ -140,14 +141,18 @@ public final class RqPrint extends RqWrap implements Text {
      * @throws IOException If fails
      */
     public void printBody(final OutputStream output) throws IOException {
-        final InputStream input = new RqChunk(new RqLengthAware(this)).body();
-        final byte[] buf = new byte[4096];
-        while (true) {
-            final int bytes = input.read(buf);
-            if (bytes < 0) {
-                break;
+        final Smart smart = new RqHeaders.Smart(this);
+        if (!smart.single("Transfer-Encoding", "").isEmpty()
+            || !smart.single("Content-Length", "").isEmpty()) {
+            final InputStream input = new RqChunk(new RqLengthAware(this)).body();
+            final byte[] buf = new byte[4096];
+            while (true) {
+                final int bytes = input.read(buf);
+                if (bytes < 0) {
+                    break;
+                }
+                output.write(buf, 0, bytes);
             }
-            output.write(buf, 0, bytes);
         }
     }
 


### PR DESCRIPTION
Currently reading from a request can hang forever if there is no content available (e.g. GET / HEAD / DELETE / ...).

This adds a check if any of the content headers are there to indicate that actually something can be read.

Follow-Up for
- https://github.com/yegor256/takes/pull/1302