### PR TITLE
Changed CapInputStream

### DIFF
--- a/src/main/java/org/takes/rq/CapInputStream.java
+++ b/src/main/java/org/takes/rq/CapInputStream.java
@@ -96,7 +96,10 @@ final class CapInputStream extends InputStream {
 
     @Override
     public long skip(final long num) throws IOException {
-        return this.origin.skip(num);
+        final long nskip = Math.min(num, this.more);
+        final long skipped = this.origin.skip(nskip);
+        this.more -= skipped;
+        return skipped;
     }
 
     @Override

--- a/src/test/java/org/takes/rq/CapInputStreamTest.java
+++ b/src/test/java/org/takes/rq/CapInputStreamTest.java
@@ -67,4 +67,11 @@ final class CapInputStreamTest {
         Mockito.verify(stream, Mockito.times(1)).skip(skip);
     }
 
+    @Test
+    void skipRespectsCap() throws IOException {
+        final InputStream stream = new ByteArrayInputStream(new byte[100]);
+        final CapInputStream wrapper = new CapInputStream(stream, 50L);
+        final long skipped = wrapper.skip(75L);
+        MatcherAssert.assertThat(skipped, Matchers.equalTo(50L));
+    }
 }


### PR DESCRIPTION
@yegor256, after reviewing code of CapInputStream i found possible mistake in logic. There we have skip function, which skips buffer, however this class is different from InputStream because of its cap. So by logic, skipping something should also change cap. So i ran all tests written before me with my changes of code, they all went good, and i created my own test, that checks one simple case:
we have stream and cap of 50
we skip 75, it should skip 50, since the cap is 50, and also it should decrease "more" variable, which represents how much we can read at that point and not violate cap.