### PR TITLE
Make sure all bytes written are flushed

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -103,6 +103,7 @@ public final class BkBasic implements Back {
                     ),
                     output
                 );
+                output.flush();
                 if (input.available() <= 0) {
                     break;
                 }


### PR DESCRIPTION
Currently BkBasic uses a BufferedOutputStream, so all content is first buffered before send to the actual stream. While the stream is implicitly flushed after writing headers, it is not when writing the body. So if the body is quite small it might never been send to the socket before close.

This now explicitly flush the content after calling print to not loose bytes regardless of how the printing is actually implemented.