### PR TITLE
Update Takes version to 1.24.6 in Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  compile group: 'org.takes', name: 'takes', version: '1.11.3'
+  implementation group: 'org.takes', name: 'takes', version: '1.24.6'
 }
 mainClassName='foo.App' //your main class
 ```


### PR DESCRIPTION
Fix Gradle configuration: replace deprecated `compile` with `implementation` and update Takes version.

Changes:
```
// Change from:
dependencies {
  compile group: 'org.takes', name: 'takes', version: '1.11.3'
}

// To:
dependencies {
  implementation group: 'org.takes', name: 'takes', version: '1.24.6'
}
```

Fixes #1409 