### PR TITLE
#1058: BkBasic returns 400 Bad Request for malformed URIs

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -100,18 +100,24 @@ public final class BkBasic implements Back {
     @SuppressWarnings("PMD.AvoidCatchingThrowable")
     private void print(final Request req, final OutputStream output)
         throws IOException {
+        new RsPrint(handledResponse(req)).print(output);
+    }
+
+    private Response handledResponse(Request req){
         try {
-            new RsPrint(this.take.act(req)).print(output);
+            return this.take.act(req);
         } catch (final HttpException ex) {
-            new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
-            // @checkstyle IllegalCatchCheck (10 lines)
+            return BkBasic.failure(ex, ex.code());
+        } catch (final IllegalArgumentException ex){
+            return BkBasic.failure(
+                    ex,
+                    HttpURLConnection.HTTP_BAD_REQUEST
+            );
         } catch (final Throwable ex) {
-            new RsPrint(
-                BkBasic.failure(
+            return BkBasic.failure(
                     ex,
                     HttpURLConnection.HTTP_INTERNAL_ERROR
-                )
-            ).print(output);
+            );
         }
     }
 

--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -314,23 +314,27 @@ public final class Href implements CharSequence {
      *  encoded properly.
      */
     private static URI createUri(final String txt) {
-        URI result;
-        try {
-            result = new URI(txt);
-        } catch (final URISyntaxException ex) {
-            final int index = ex.getIndex();
-            if (index == -1) {
-                throw new IllegalArgumentException(ex.getMessage(), ex);
+        final StringBuilder value = new StringBuilder(txt);
+        while (true){
+            try {
+                return new URI(value.toString());
+            } catch (final URISyntaxException ex) {
+                final int index = ex.getIndex();
+                if (index < 0 || index >= value.length()) {
+                    throw new IllegalArgumentException(ex.getMessage(), ex);
+                } else if (ex.getReason().contains("authority")) {
+                    throw new IllegalArgumentException(
+                            "Illegal URI: " + txt + ". Parsing breaks on index " +
+                                    (index - (value.length() - txt.length())),
+                            ex);
+                }
+                value.replace(
+                    index,
+                    index + 1,
+                    Href.encode(value.substring(index, index + 1))
+                );
             }
-            final StringBuilder value = new StringBuilder(txt);
-            value.replace(
-                index,
-                index + 1,
-                Href.encode(value.substring(index, index + 1))
-            );
-            result = Href.createUri(value.toString());
         }
-        return result;
     }
 
     /**


### PR DESCRIPTION
This PR solves issue #1058 and completes the corresponding @todo in `BkBasicTest`.

### Changes introduced:
1. Rewrote `Href#createUri` to reject malformed URIs containing illegual characters before path, which previously led to incorrect parsing and silent URI normalization.
2. Updated `BkBasic#print()` to handle `IllegalArgumentException` and return HTTP 400 (Bad Request).
3. Re-enabled, validated, and renamed the test `returnsABadRequestToAnInvalidRequestUri` (renamed to `returnsABadRequestToAMissingPath`), which now passes.
4. Add new test, assosiated with vulnerable for stability bug #1441
All tests pass locally.