### PR TITLE
fix #1436

### DIFF
--- a/src/test/java/org/takes/tk/TkClasspathTest.java
+++ b/src/test/java/org/takes/tk/TkClasspathTest.java
@@ -23,12 +23,15 @@
  */
 package org.takes.tk;
 
+import java.net.HttpURLConnection;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.StartsWith;
 import org.takes.HttpException;
 import org.takes.rq.RqFake;
+import org.takes.rq.RqMethod;
 import org.takes.rs.RsHeadPrint;
 
 /**
@@ -40,10 +43,11 @@ final class TkClasspathTest {
     @Test
     void dispatchesByResourceName() throws Exception {
         MatcherAssert.assertThat(
+            "TkClasspath must serve existing classpath resources with HTTP OK status",
             new RsHeadPrint(
                 new TkClasspath().act(
                     new RqFake(
-                        "GET", "/org/takes/Take.class?a", ""
+                        RqMethod.GET, "/org/takes/Take.class?a", ""
                     )
                 )
             ),
@@ -53,11 +57,16 @@ final class TkClasspathTest {
 
     @Test
     void throwsWhenResourceNotFound() {
-        Assertions.assertThrows(
+        final HttpException exception = Assertions.assertThrows(
             HttpException.class,
             () -> new TkClasspath().act(
-                new RqFake("PUT", "/something-else", "")
+                new RqFake(RqMethod.PUT, "/something-else", "")
             )
+        );
+        MatcherAssert.assertThat(
+            "Exception should have HTTP_NOT_FOUND status code",
+            exception.code(),
+            Matchers.equalTo(HttpURLConnection.HTTP_NOT_FOUND)
         );
     }
 }


### PR DESCRIPTION
Replaced assertThrows(...) with an object-oriented failure handling strategy
Replaced string-based request setup with composable request objects