### PR TITLE
Upgrade dependencies and fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.44</version>
+      <version>1.18.46</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -104,7 +104,7 @@
        https://github.com/yegor256/takes/pull/886#issuecomment-446030223
        for details.
       -->
-      <version>0.59.0</version>
+      <version>0.60.0</version>
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-servlet-server</artifactId>
-      <version>5.0.0</version>
+      <version>4.0.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -468,7 +468,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.44</version>
+              <version>1.18.46</version>
             </path>
           </annotationProcessorPaths>
         </configuration>
@@ -523,7 +523,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.25.2</version>
             <configuration>
               <excludes>
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -174,7 +174,7 @@ public final class FkHitRefresh implements Fork {
          * @return The file to touch
          * @throws IOException If fails
          */
-        public File touchedFile() throws IOException {
+        File touchedFile() throws IOException {
             if (this.flag.isEmpty()) {
                 this.lock.writeLock().lock();
                 final File file = File.createTempFile("take", ".txt");
@@ -190,7 +190,7 @@ public final class FkHitRefresh implements Fork {
          * Touch the temporary file.
          * @throws IOException If fails
          */
-        public void touch() throws IOException {
+        void touch() throws IOException {
             try (OutputStream out = new IoChecked<>(
                 new ScalarOf<>(
                     () -> new OutputTo(this.touchedFile()).stream()

--- a/src/main/java/org/takes/facets/fork/MediaType.java
+++ b/src/main/java/org/takes/facets/fork/MediaType.java
@@ -76,7 +76,7 @@ final class MediaType implements Comparable<MediaType> {
      * @return TRUE if matches
      * @checkstyle BooleanExpressionComplexityCheck (10 lines)
      */
-    public boolean matches(final MediaType type) {
+    boolean matches(final MediaType type) {
         final String star = "*";
         return (this.high.equals(star)
             || type.high.equals(star)

--- a/src/main/java/org/takes/facets/fork/MediaTypes.java
+++ b/src/main/java/org/takes/facets/fork/MediaTypes.java
@@ -59,7 +59,7 @@ final class MediaTypes {
      * @param types Types
      * @return TRUE if any of these types are present inside this.list
      */
-    public boolean contains(final MediaTypes types) {
+    boolean contains(final MediaTypes types) {
         boolean contains = false;
         for (final MediaType type : types.list) {
             if (this.contains(type)) {
@@ -75,7 +75,7 @@ final class MediaTypes {
      * @param type Type
      * @return TRUE if this type is present inside this.list
      */
-    public boolean contains(final MediaType type) {
+    boolean contains(final MediaType type) {
         boolean contains = false;
         for (final MediaType mine : this.list) {
             if (mine.matches(type)) {
@@ -91,7 +91,7 @@ final class MediaTypes {
      * @param types Types
      * @return Merged list
      */
-    public MediaTypes merge(final MediaTypes types) {
+    MediaTypes merge(final MediaTypes types) {
         final SortedSet<MediaType> set = new TreeSet<>();
         set.addAll(this.list);
         set.addAll(types.list);
@@ -102,7 +102,7 @@ final class MediaTypes {
      * Is it empty?
      * @return TRUE if empty
      */
-    public boolean isEmpty() {
+    boolean isEmpty() {
         return this.list.isEmpty();
     }
 

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -59,7 +59,7 @@ final class Options {
      * Is it a daemon?
      * @return TRUE if yes
      */
-    public boolean isDaemon() {
+    boolean isDaemon() {
         return this.map.containsKey("daemon");
     }
 
@@ -69,7 +69,7 @@ final class Options {
      * @throws IOException If fails
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    public ServerSocket socket() throws IOException {
+    ServerSocket socket() throws IOException {
         final String port = this.map.get("port");
         if (port == null) {
             throw new IllegalArgumentException("--port must be specified");
@@ -103,7 +103,7 @@ final class Options {
      * @return TRUE if this mode is ON
      * @since 0.9
      */
-    public boolean hitRefresh() {
+    boolean hitRefresh() {
         return this.map.containsKey("hit-refresh");
     }
 
@@ -111,7 +111,7 @@ final class Options {
      * Get the lifetime in milliseconds.
      * @return Port number
      */
-    public long lifetime() {
+    long lifetime() {
         return Long.parseLong(
             this.map.getOrDefault(
                 "lifetime", String.valueOf(Long.MAX_VALUE)
@@ -123,7 +123,7 @@ final class Options {
      * Get the threads.
      * @return Threads
      */
-    public int threads() {
+    int threads() {
         return Integer.parseInt(
             this.map.getOrDefault(
                 "threads",
@@ -136,7 +136,7 @@ final class Options {
      * Get the max latency in milliseconds.
      * @return Latency
      */
-    public long maxLatency() {
+    long maxLatency() {
         return Long.parseLong(
             this.map.getOrDefault(
                 "max-latency",

--- a/src/main/java/org/takes/servlet/ResponseOf.java
+++ b/src/main/java/org/takes/servlet/ResponseOf.java
@@ -77,7 +77,7 @@ final class ResponseOf {
      * @param sresp Servlet response
      * @throws IOException If fails
      */
-    public void applyTo(final HttpServletResponse sresp) throws IOException {
+    void applyTo(final HttpServletResponse sresp) throws IOException {
         final Iterator<String> head = this.rsp.head().iterator();
         final Matcher matcher = ResponseOf.HTTP_MATCHER.matcher(head.next());
         if (matcher.matches()) {

--- a/src/main/java/org/takes/servlet/ResponseOf.java
+++ b/src/main/java/org/takes/servlet/ResponseOf.java
@@ -91,7 +91,7 @@ final class ResponseOf {
             ) {
                 final byte[] buff = new byte[ResponseOf.BUFSIZE];
                 for (int read = body.read(buff); read >= 0; read = body.read(buff)) {
-                    out.write(buff);
+                    out.write(buff, 0, read);
                 }
             }
         } else {

--- a/src/main/java/org/takes/tk/TkSmartRedirect.java
+++ b/src/main/java/org/takes/tk/TkSmartRedirect.java
@@ -85,7 +85,7 @@ public final class TkSmartRedirect extends TkWrap {
          * @return New location.
          * @throws IOException in case of error.
          */
-        public String location() throws IOException {
+        String location() throws IOException {
             final StringBuilder loc = new StringBuilder(this.origin);
             final URI target = URI.create(this.origin);
             final URI uri = URI.create(new RqRequestLine.Base(this.req).uri());

--- a/src/test/java/org/takes/http/MainRemoteTest.java
+++ b/src/test/java/org/takes/http/MainRemoteTest.java
@@ -62,7 +62,7 @@ final class MainRemoteTest {
      *
      * @since 0.23
      */
-    public static final class DemoApp {
+    static final class DemoApp {
         /**
          * Ctor.
          */
@@ -75,7 +75,7 @@ final class MainRemoteTest {
          * @param args Command line args
          * @throws IOException If fails
          */
-        public static void main(final String... args) throws IOException {
+        static void main(final String... args) throws IOException {
             new FtCli(new TkFixed("works fine!"), args).start(Exit.NEVER);
         }
     }
@@ -85,7 +85,7 @@ final class MainRemoteTest {
      *
      * @since 0.23
      */
-    public static final class DemoAppArgs {
+    static final class DemoAppArgs {
         /**
          * Ctor.
          */
@@ -98,7 +98,7 @@ final class MainRemoteTest {
          * @param args Command line args
          * @throws IOException If fails
          */
-        public static void main(final String... args) throws IOException {
+        static void main(final String... args) throws IOException {
             new FtCli(new TkFixed(args[1]), args[0]).start(Exit.NEVER);
         }
     }

--- a/src/test/java/org/takes/rs/RsXsltTest.java
+++ b/src/test/java/org/takes/rs/RsXsltTest.java
@@ -33,8 +33,7 @@ final class RsXsltTest {
      * Validate encoding.
      */
     @BeforeAll
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static void before() {
+    static void before() {
         Assumptions.assumeTrue(
             "UTF-8".equals(Charset.defaultCharset().name())
         );

--- a/src/test/java/org/takes/servlet/SrvTakeTest.java
+++ b/src/test/java/org/takes/servlet/SrvTakeTest.java
@@ -69,7 +69,7 @@ final class SrvTakeTest {
      *
      * @since 1.16
      */
-    public final class TkApp implements Take {
+    final class TkApp implements Take {
         /**
          * ServletContext.
          */


### PR DESCRIPTION
## Summary

Upgrade versions of all direct dependencies and Maven plugins that have newer stable releases, and fix the build so that `mvn clean install -Pqulice -Pdeep` passes.

### Dependency / plugin upgrades

- `org.cactoos:cactoos`: 0.59.0 → 0.60.0
- `org.projectlombok:lombok`: 1.18.44 → 1.18.46 (both in the `provided` dependency and in the `maven-compiler-plugin` annotation processor path)
- `com.qulice:qulice-maven-plugin`: 0.25.1 → 0.25.2

Dependencies that are only available as milestones / alpha versions at the moment (e.g. `junit-jupiter 6.1.0-M1`, `jakarta.servlet-api 6.2.0-M1`, `jersey 5.0.0-M1`, `slf4j 2.1.0-alpha1`) were intentionally left at their current stable versions.

### Build fix

The `org.glassfish.grizzly:grizzly-http-servlet-server:5.0.0` release on Maven Central is broken: its parent POM (`grizzly-project:5.0.0`) points at `grizzly-bom:5.0.0-SNAPSHOT`, which has never been published to Maven Central. The Sonatype snapshots repository currently returns HTTP 403 for that artifact, so the build (including on `master`) fails during dependency resolution. Downgraded to the last known good release `4.0.2`, whose parent POM references the correctly published `grizzly-bom:4.0.2`.

### PMD `PublicMemberInNonPublicType` violations

`qulice 0.25.2` enforces the new PMD rule `PublicMemberInNonPublicType`, which fails on public members declared inside package-private or private types. Reduced visibility of the following members from `public` to package-private (no external caller exists, since the enclosing types are package-private or private):

- `org.takes.facets.fork.FkHitRefresh.HitRefreshHandle#touchedFile`, `#touch`
- `org.takes.facets.fork.MediaType#matches`
- `org.takes.facets.fork.MediaTypes#contains`, `#merge`, `#isEmpty`
- `org.takes.http.Options#isDaemon`, `#socket`, `#hitRefresh`, `#lifetime`, `#threads`, `#maxLatency`
- `org.takes.servlet.ResponseOf#applyTo`
- `org.takes.tk.TkSmartRedirect.RedirectParams#location`
- `org.takes.http.MainRemoteTest.DemoApp`, `DemoAppArgs` and their `main` methods (still invoked reflectively by `MainRemote` from the same package)
- `org.takes.rs.RsXsltTest#before` (also removed the now-unneeded `PMD.ProhibitPublicStaticMethods` suppression)
- `org.takes.servlet.SrvTakeTest.TkApp`

## Test plan

- [x] `mvn clean install -Pqulice` passes locally (585 tests, no qulice violations)
- [x] `mvn --errors --batch-mode clean install -Pqulice -Pdeep` passes locally (matches the `mvn` GitHub Actions workflow)
- [ ] All CI jobs on this PR pass