### PR TITLE
Fix Windows build: move argLine to correct Surefire location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,8 +426,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludedGroups>org.takes.misc.PerformanceTests,${excludedGroups}</excludedGroups>
+          <argLine>@{argLine} -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Duser.language=en -Duser.country=US</argLine>
           <systemPropertyVariables>
-            <argLine>@{argLine} -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Duser.language=en -Duser.country=US</argLine>
             <javax.net.ssl.keyStore>${project.build.directory}/test-classes/org/takes/http/keystore</javax.net.ssl.keyStore>
             <javax.net.ssl.keyStorePassword>abc123
             </javax.net.ssl.keyStorePassword>


### PR DESCRIPTION
## Summary

The `maven-surefire-plugin` configuration had `<argLine>` nested inside
`<systemPropertyVariables>`. In that position Maven treats it as a
system property whose **name** is `argLine` on the forked test JVM
instead of passing the flags as actual JVM command-line arguments.
As a result `-Dfile.encoding=UTF-8`, `-Duser.language=en`,
`-Duser.country=US` and `-Djava.awt.headless=true` were never applied
to the forked test JVM.

On the `windows-2022` runner the default system locale, country and
headless state differ from Linux/macOS, which is the most plausible
reason why tests pass on `ubuntu-24.04` and `macos-15` but the Windows
matrix job fails (see https://github.com/yegor256/takes/actions/runs/24815212054/job/72628127231).

## Change

Move `<argLine>` to be a direct child of `<configuration>` (next to
`<systemPropertyVariables>`) so Surefire uses it as the real `argLine`
for the forked JVM. The `@{argLine}` late-binding placeholder is kept
so the `jacoco` profile (which sets `argLine` via `prepare-agent`) keeps
working.

## Test plan
- [x] `mvn test` passes locally on Linux (585 tests, 0 failures)
- [x] `pom.xml` is still valid XML and `mvn validate` passes
- [ ] CI `mvn` matrix (ubuntu-24.04, macos-15, windows-2022) turns green


---
_Generated by [Claude Code](https://claude.ai/code/session_015crwSeudLf6zhSMhvTF22n)_