### PR TITLE
#1295: Ignore leading CRLF before the HTTP request-line

### DIFF
--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -60,8 +60,12 @@ public final class RqLive extends RqWrap {
             eof = false;
             if (data.get() == '\r') {
                 RqLive.checkLineFeed(input, baos, head.size() + 1);
-                if (baos.size() == 0) {
+                if (baos.size() == 0 && !head.isEmpty()) {
                     break;
+                }
+                if (baos.size() == 0) {
+                    data = RqLive.data(input, new Opt.Empty<>(), false);
+                    continue;
                 }
                 data = new Opt.Single<>(input.read());
                 final Opt<String> header = RqLive.newHeader(data, baos);

--- a/src/test/java/org/takes/rq/RqLiveTest.java
+++ b/src/test/java/org/takes/rq/RqLiveTest.java
@@ -110,6 +110,50 @@ final class RqLiveTest {
         );
     }
 
+    @Test
+    void ignoresLeadingCrlfBeforeRequestLine() throws IOException {
+        final Request req = new RqLive(
+            new InputStreamOf(
+                new Joined(
+                    RqLiveTest.CRLF,
+                    "",
+                    "GET /leading HTTP/1.1",
+                    "Host:e",
+                    "",
+                    ""
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Leading CRLF must be ignored and request-line parsed",
+            new RqRequestLine.Base(req).uri(),
+            Matchers.equalTo("/leading")
+        );
+    }
+
+    @Test
+    void ignoresMultipleLeadingCrlfBeforeRequestLine() throws IOException {
+        final Request req = new RqLive(
+            new InputStreamOf(
+                new Joined(
+                    RqLiveTest.CRLF,
+                    "",
+                    "",
+                    "",
+                    "GET /many HTTP/1.1",
+                    "Host:e",
+                    "",
+                    ""
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Multiple leading CRLFs must be ignored",
+            new RqRequestLine.Base(req).uri(),
+            Matchers.equalTo("/many")
+        );
+    }
+
     private static Request simpleRequest() throws IOException {
         return new RqLive(
             new InputStreamOf(


### PR DESCRIPTION
@yegor256 this fixes #1295.

## What was wrong

`RqLive.parse()` treated a CRLF received before any header had been read as the empty line that terminates the header block. It broke out of the loop with an empty `head`, and returned a `RequestOf` whose head iterable was empty. Two concrete consequences:

1. `new RqRequestLine.Base(req)` then threw `[400] HTTP Request should have Request-Line`.
2. In keep-alive conversations, the leftover `\r\n` between one request body and the next request-line was consumed as "end of headers" for the next request, so the second request's headers silently ended up inside the previous request's body (as originally observed on `BkBasicTest#handlesTwoRequestInOneConnection`).

## What changed

Per RFC 7230 §3.5:

> In the interest of robustness, a server that is expecting to receive and parse a request-line SHOULD ignore at least one empty line (CRLF) received prior to the request-line.

`RqLive` now does exactly that: when a CRLF is seen and no header has been accumulated yet (`head.isEmpty()`), we skip it and keep reading instead of breaking. An empty line *after* headers still terminates the head, as before. One or many leading CRLFs are tolerated, matching the behavior of nginx and gws referenced in the issue.

## Commits

1. Two failing tests in `RqLiveTest` covering single and multiple leading CRLFs — both failed on `master` with `[400] HTTP Request should have Request-Line`.
2. The one-spot fix in `RqLive.parse()`; all 587 existing unit tests still pass, qulice is clean.

Ready for merge.