### PR TITLE
#1559: add HmRsCookie and HmRqCookie matchers

### DIFF
--- a/src/main/java/org/takes/facets/hamcrest/HmRqCookie.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRqCookie.java
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.takes.Request;
+
+/**
+ * Matcher for a single cookie in a request's {@code Cookie} header.
+ *
+ * <p>Verifies only the cookie's name and value. Multiple cookies packed
+ * into one {@code Cookie} header (separated by {@code ;}) or spread across
+ * several {@code Cookie} headers are all searched. Use it instead of a
+ * hand-rolled {@link HmHeader} assertion against {@code Cookie}:
+ *
+ * <pre> MatcherAssert.assertThat(
+ *     request,
+ *     new HmRqCookie("session", "abc")
+ * );</pre>
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @since 2.0
+ */
+public final class HmRqCookie extends TypeSafeMatcher<Request> {
+
+    /**
+     * Cookie header name.
+     */
+    private static final String COOKIE = "cookie";
+
+    /**
+     * Cookie name matcher.
+     */
+    private final Matcher<String> name;
+
+    /**
+     * Cookie value matcher.
+     */
+    private final Matcher<String> value;
+
+    /**
+     * Value observed for the cookie, kept for mismatch description.
+     */
+    private String actual;
+
+    /**
+     * Ctor.
+     * @param cookie Exact cookie name
+     * @param val Exact cookie value
+     */
+    public HmRqCookie(final String cookie, final String val) {
+        this(Matchers.equalTo(cookie), Matchers.equalTo(val));
+    }
+
+    /**
+     * Ctor.
+     * @param cookie Exact cookie name
+     * @param val Cookie value matcher
+     */
+    public HmRqCookie(final String cookie, final Matcher<String> val) {
+        this(Matchers.equalTo(cookie), val);
+    }
+
+    /**
+     * Ctor.
+     * @param cookie Cookie name matcher
+     * @param val Cookie value matcher
+     */
+    public HmRqCookie(final Matcher<String> cookie,
+        final Matcher<String> val) {
+        super();
+        this.name = cookie;
+        this.value = val;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("cookie with name: ")
+            .appendDescriptionOf(this.name)
+            .appendText(" and value: ")
+            .appendDescriptionOf(this.value);
+    }
+
+    @Override
+    public boolean matchesSafely(final Request request) {
+        try {
+            boolean matched = false;
+            for (final String header : request.head()) {
+                if (!HmRqCookie.isCookie(header) || header.indexOf(':') < 0) {
+                    continue;
+                }
+                if (this.matchAny(HmRqCookie.crumbs(header))) {
+                    matched = true;
+                    break;
+                }
+            }
+            return matched;
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    public void describeMismatchSafely(final Request request,
+        final Description description) {
+        if (this.actual == null) {
+            description.appendText("no Cookie with name: ")
+                .appendDescriptionOf(this.name);
+        } else {
+            description.appendText("cookie with name: ")
+                .appendDescriptionOf(this.name)
+                .appendText(" had value: ")
+                .appendValue(this.actual);
+        }
+    }
+
+    /**
+     * Tries to match any of the supplied {@code name=value} crumbs.
+     * @param crumbs Name/value pairs from one Cookie header
+     * @return True once one pair fully matches
+     */
+    private boolean matchAny(final Iterable<String> crumbs) {
+        boolean matched = false;
+        for (final String crumb : crumbs) {
+            if (this.matchCrumb(crumb.trim())) {
+                matched = true;
+                break;
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Tries to match a single {@code name=value} pair, storing the observed
+     * value if the name is a match.
+     * @param crumb Name/value pair as "name=value"
+     * @return True if both name and value match
+     */
+    private boolean matchCrumb(final String crumb) {
+        final int sign = crumb.indexOf('=');
+        boolean matched = false;
+        if (sign >= 0
+            && this.name.matches(crumb.substring(0, sign).trim())) {
+            final String observed = crumb.substring(sign + 1).trim();
+            this.actual = observed;
+            matched = this.value.matches(observed);
+        }
+        return matched;
+    }
+
+    /**
+     * Checks whether a header line is a {@code Cookie} header.
+     * @param header Raw header line ("Name: value")
+     * @return True if the header name equals "Cookie" ignoring case
+     */
+    private static boolean isCookie(final String header) {
+        final int colon = header.indexOf(':');
+        return colon >= 0
+            && HmRqCookie.COOKIE.equalsIgnoreCase(
+                header.substring(0, colon).trim()
+            );
+    }
+
+    /**
+     * Splits a Cookie header into its individual {@code name=value} crumbs.
+     * @param header Raw header line ("Cookie: a=1; b=2; c=3")
+     * @return The crumbs ("a=1", "b=2", "c=3")
+     */
+    private static Iterable<String> crumbs(final String header) {
+        return Arrays.asList(
+            header.substring(header.indexOf(':') + 1).split(";")
+        );
+    }
+}

--- a/src/main/java/org/takes/facets/hamcrest/HmRsCookie.java
+++ b/src/main/java/org/takes/facets/hamcrest/HmRsCookie.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.facets.hamcrest;
+
+import java.io.IOException;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.takes.Response;
+
+/**
+ * Matcher for a single cookie in a response's {@code Set-Cookie} header.
+ *
+ * <p>Verifies only the cookie's name and value, ignoring attributes such as
+ * {@code Path}, {@code Domain}, {@code HttpOnly}, {@code Secure}, or
+ * {@code Expires}. Use it instead of a hand-rolled {@link HmHeader}
+ * assertion against {@code Set-Cookie}:
+ *
+ * <pre> MatcherAssert.assertThat(
+ *     response,
+ *     new HmRsCookie("session", "abc")
+ * );</pre>
+ *
+ * <p>The class is immutable and thread-safe.
+ *
+ * @since 2.0
+ */
+public final class HmRsCookie extends TypeSafeMatcher<Response> {
+
+    /**
+     * Set-Cookie header name.
+     */
+    private static final String SET_COOKIE = "set-cookie";
+
+    /**
+     * Cookie name matcher.
+     */
+    private final Matcher<String> name;
+
+    /**
+     * Cookie value matcher.
+     */
+    private final Matcher<String> value;
+
+    /**
+     * Value observed for the cookie, kept for mismatch description.
+     */
+    private String actual;
+
+    /**
+     * Ctor.
+     * @param cookie Exact cookie name
+     * @param val Exact cookie value
+     */
+    public HmRsCookie(final String cookie, final String val) {
+        this(Matchers.equalTo(cookie), Matchers.equalTo(val));
+    }
+
+    /**
+     * Ctor.
+     * @param cookie Exact cookie name
+     * @param val Cookie value matcher
+     */
+    public HmRsCookie(final String cookie, final Matcher<String> val) {
+        this(Matchers.equalTo(cookie), val);
+    }
+
+    /**
+     * Ctor.
+     * @param cookie Cookie name matcher
+     * @param val Cookie value matcher
+     */
+    public HmRsCookie(final Matcher<String> cookie,
+        final Matcher<String> val) {
+        super();
+        this.name = cookie;
+        this.value = val;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("cookie with name: ")
+            .appendDescriptionOf(this.name)
+            .appendText(" and value: ")
+            .appendDescriptionOf(this.value);
+    }
+
+    @Override
+    public boolean matchesSafely(final Response response) {
+        try {
+            boolean matched = false;
+            for (final String header : response.head()) {
+                if (!HmRsCookie.isSetCookie(header)) {
+                    continue;
+                }
+                if (this.matchCrumb(HmRsCookie.firstCrumb(header))) {
+                    matched = true;
+                    break;
+                }
+            }
+            return matched;
+        } catch (final IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    public void describeMismatchSafely(final Response response,
+        final Description description) {
+        if (this.actual == null) {
+            description.appendText("no Set-Cookie with name: ")
+                .appendDescriptionOf(this.name);
+        } else {
+            description.appendText("cookie with name: ")
+                .appendDescriptionOf(this.name)
+                .appendText(" had value: ")
+                .appendValue(this.actual);
+        }
+    }
+
+    /**
+     * Tries to match a single name=value pair against this matcher, storing
+     * the observed value if the name is a match.
+     * @param crumb Name/value pair as "name=value"
+     * @return True if both name and value match
+     */
+    private boolean matchCrumb(final String crumb) {
+        final int sign = crumb.indexOf('=');
+        boolean matched = false;
+        if (sign >= 0
+            && this.name.matches(crumb.substring(0, sign).trim())) {
+            final String observed = crumb.substring(sign + 1).trim();
+            this.actual = observed;
+            matched = this.value.matches(observed);
+        }
+        return matched;
+    }
+
+    /**
+     * Checks whether a header line is a {@code Set-Cookie} header.
+     * @param header Raw header line ("Name: value")
+     * @return True if the header name equals "Set-Cookie" ignoring case
+     */
+    private static boolean isSetCookie(final String header) {
+        final int colon = header.indexOf(':');
+        return colon >= 0
+            && HmRsCookie.SET_COOKIE.equalsIgnoreCase(
+                header.substring(0, colon).trim()
+            );
+    }
+
+    /**
+     * Extracts the first {@code name=value} crumb from a Set-Cookie header,
+     * stripping off any {@code ;}-separated attributes.
+     * @param header Raw header line ("Set-Cookie: name=value; Path=/")
+     * @return The first crumb ("name=value")
+     */
+    private static String firstCrumb(final String header) {
+        return header.substring(header.indexOf(':') + 1)
+            .trim().split(";", 2)[0].trim();
+    }
+}

--- a/src/test/java/org/takes/facets/hamcrest/HmRqCookieTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqCookieTest.java
@@ -18,12 +18,22 @@ import org.takes.rq.RqWithHeader;
  */
 final class HmRqCookieTest {
 
+    /**
+     * Sample cookie name reused in assertions.
+     */
+    private static final String SESSION = "session";
+
+    /**
+     * Sample cookie value reused in assertions.
+     */
+    private static final String ABC = "abc";
+
     @Test
     void matchesCookieByNameAndValue() {
         MatcherAssert.assertThat(
-            "Request must have cookie 'session' with value 'abc'",
+            "Request must have cookie with the expected name and value",
             new RqWithHeader(new RqFake(), "Cookie: session=abc"),
-            new HmRqCookie("session", "abc")
+            new HmRqCookie(HmRqCookieTest.SESSION, HmRqCookieTest.ABC)
         );
     }
 
@@ -35,7 +45,7 @@ final class HmRqCookieTest {
                 new RqFake(),
                 "Cookie: user=Jeff; session=abc; theme=dark"
             ),
-            new HmRqCookie("session", "abc")
+            new HmRqCookie(HmRqCookieTest.SESSION, HmRqCookieTest.ABC)
         );
     }
 
@@ -53,7 +63,9 @@ final class HmRqCookieTest {
         MatcherAssert.assertThat(
             "Matcher must not match when Cookie header is absent",
             new RqFake(),
-            Matchers.not(new HmRqCookie("session", "abc"))
+            Matchers.not(
+                new HmRqCookie(HmRqCookieTest.SESSION, HmRqCookieTest.ABC)
+            )
         );
     }
 
@@ -62,13 +74,17 @@ final class HmRqCookieTest {
         MatcherAssert.assertThat(
             "Matcher must not match when cookie value differs",
             new RqWithHeader(new RqFake(), "Cookie: session=xyz"),
-            Matchers.not(new HmRqCookie("session", "abc"))
+            Matchers.not(
+                new HmRqCookie(HmRqCookieTest.SESSION, HmRqCookieTest.ABC)
+            )
         );
     }
 
     @Test
     void describesMismatchWithCookieName() {
-        final HmRqCookie matcher = new HmRqCookie("session", "abc");
+        final HmRqCookie matcher = new HmRqCookie(
+            HmRqCookieTest.SESSION, HmRqCookieTest.ABC
+        );
         final Request request = new RqWithHeader(
             new RqFake(), "Cookie: session=xyz"
         );
@@ -79,7 +95,7 @@ final class HmRqCookieTest {
             "Mismatch description must mention cookie name and actual value",
             description.toString(),
             Matchers.allOf(
-                Matchers.containsString("session"),
+                Matchers.containsString(HmRqCookieTest.SESSION),
                 Matchers.containsString("xyz")
             )
         );

--- a/src/test/java/org/takes/facets/hamcrest/HmRqCookieTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRqCookieTest.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.facets.hamcrest;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+import org.takes.Request;
+import org.takes.rq.RqFake;
+import org.takes.rq.RqWithHeader;
+
+/**
+ * Test case for {@link org.takes.facets.hamcrest.HmRqCookie}.
+ * @since 2.0
+ */
+final class HmRqCookieTest {
+
+    @Test
+    void matchesCookieByNameAndValue() {
+        MatcherAssert.assertThat(
+            "Request must have cookie 'session' with value 'abc'",
+            new RqWithHeader(new RqFake(), "Cookie: session=abc"),
+            new HmRqCookie("session", "abc")
+        );
+    }
+
+    @Test
+    void matchesCookieAmongMultiple() {
+        MatcherAssert.assertThat(
+            "Matcher must find one cookie among many in a single Cookie header",
+            new RqWithHeader(
+                new RqFake(),
+                "Cookie: user=Jeff; session=abc; theme=dark"
+            ),
+            new HmRqCookie("session", "abc")
+        );
+    }
+
+    @Test
+    void matchesCookieValueMatcher() {
+        MatcherAssert.assertThat(
+            "Matcher must accept a Hamcrest matcher for cookie value",
+            new RqWithHeader(new RqFake(), "Cookie: user=Jeff"),
+            new HmRqCookie("user", Matchers.startsWith("Je"))
+        );
+    }
+
+    @Test
+    void doesNotMatchMissingCookie() {
+        MatcherAssert.assertThat(
+            "Matcher must not match when Cookie header is absent",
+            new RqFake(),
+            Matchers.not(new HmRqCookie("session", "abc"))
+        );
+    }
+
+    @Test
+    void doesNotMatchWrongValue() {
+        MatcherAssert.assertThat(
+            "Matcher must not match when cookie value differs",
+            new RqWithHeader(new RqFake(), "Cookie: session=xyz"),
+            Matchers.not(new HmRqCookie("session", "abc"))
+        );
+    }
+
+    @Test
+    void describesMismatchWithCookieName() {
+        final HmRqCookie matcher = new HmRqCookie("session", "abc");
+        final Request request = new RqWithHeader(
+            new RqFake(), "Cookie: session=xyz"
+        );
+        matcher.matchesSafely(request);
+        final StringDescription description = new StringDescription();
+        matcher.describeMismatchSafely(request, description);
+        MatcherAssert.assertThat(
+            "Mismatch description must mention cookie name and actual value",
+            description.toString(),
+            Matchers.allOf(
+                Matchers.containsString("session"),
+                Matchers.containsString("xyz")
+            )
+        );
+    }
+}

--- a/src/test/java/org/takes/facets/hamcrest/HmRsCookieTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsCookieTest.java
@@ -18,12 +18,22 @@ import org.takes.rs.RsEmpty;
  */
 final class HmRsCookieTest {
 
+    /**
+     * Sample cookie name reused in assertions.
+     */
+    private static final String SESSION = "session";
+
+    /**
+     * Sample cookie value reused in assertions.
+     */
+    private static final String ABC = "abc";
+
     @Test
     void matchesCookieByNameAndValue() {
         MatcherAssert.assertThat(
-            "Response must have a Set-Cookie with name 'session' and value 'abc'",
-            new RsWithCookie("session", "abc"),
-            new HmRsCookie("session", "abc")
+            "Response must have a Set-Cookie with the expected name and value",
+            new RsWithCookie(HmRsCookieTest.SESSION, HmRsCookieTest.ABC),
+            new HmRsCookie(HmRsCookieTest.SESSION, HmRsCookieTest.ABC)
         );
     }
 
@@ -32,10 +42,10 @@ final class HmRsCookieTest {
         MatcherAssert.assertThat(
             "Matcher must ignore Path/HttpOnly/Secure attributes",
             new RsWithCookie(
-                "session", "abc",
+                HmRsCookieTest.SESSION, HmRsCookieTest.ABC,
                 "Path=/", "HttpOnly", "Secure"
             ),
-            new HmRsCookie("session", "abc")
+            new HmRsCookie(HmRsCookieTest.SESSION, HmRsCookieTest.ABC)
         );
     }
 
@@ -53,7 +63,9 @@ final class HmRsCookieTest {
         MatcherAssert.assertThat(
             "Matcher must not match a response without the named cookie",
             new RsEmpty(),
-            Matchers.not(new HmRsCookie("session", "abc"))
+            Matchers.not(
+                new HmRsCookie(HmRsCookieTest.SESSION, HmRsCookieTest.ABC)
+            )
         );
     }
 
@@ -61,33 +73,39 @@ final class HmRsCookieTest {
     void doesNotMatchWrongValue() {
         MatcherAssert.assertThat(
             "Matcher must not match if cookie value differs",
-            new RsWithCookie("session", "xyz"),
-            Matchers.not(new HmRsCookie("session", "abc"))
+            new RsWithCookie(HmRsCookieTest.SESSION, "xyz"),
+            Matchers.not(
+                new HmRsCookie(HmRsCookieTest.SESSION, HmRsCookieTest.ABC)
+            )
         );
     }
 
     @Test
-    void picksRightCookieAmongMany() {
-        final Response response = new RsWithCookie(
-            new RsWithCookie("a", "1"),
-            "b", "2"
-        );
-        MatcherAssert.assertThat(
-            "Matcher must find the 'b' cookie when multiple Set-Cookie headers exist",
-            response,
-            new HmRsCookie("b", "2")
-        );
+    void picksFirstCookieAmongMany() {
         MatcherAssert.assertThat(
             "Matcher must find the 'a' cookie when multiple Set-Cookie headers exist",
-            response,
+            new RsWithCookie(new RsWithCookie("a", "1"), "b", "2"),
             new HmRsCookie("a", "1")
         );
     }
 
     @Test
+    void picksSecondCookieAmongMany() {
+        MatcherAssert.assertThat(
+            "Matcher must find the 'b' cookie when multiple Set-Cookie headers exist",
+            new RsWithCookie(new RsWithCookie("a", "1"), "b", "2"),
+            new HmRsCookie("b", "2")
+        );
+    }
+
+    @Test
     void describesMismatchWithCookieName() {
-        final HmRsCookie matcher = new HmRsCookie("session", "abc");
-        final Response response = new RsWithCookie("session", "xyz", "Path=/");
+        final HmRsCookie matcher = new HmRsCookie(
+            HmRsCookieTest.SESSION, HmRsCookieTest.ABC
+        );
+        final Response response = new RsWithCookie(
+            HmRsCookieTest.SESSION, "xyz", "Path=/"
+        );
         matcher.matchesSafely(response);
         final StringDescription description = new StringDescription();
         matcher.describeMismatchSafely(response, description);
@@ -95,7 +113,7 @@ final class HmRsCookieTest {
             "Mismatch description must mention cookie name and actual value",
             description.toString(),
             Matchers.allOf(
-                Matchers.containsString("session"),
+                Matchers.containsString(HmRsCookieTest.SESSION),
                 Matchers.containsString("xyz")
             )
         );

--- a/src/test/java/org/takes/facets/hamcrest/HmRsCookieTest.java
+++ b/src/test/java/org/takes/facets/hamcrest/HmRsCookieTest.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.facets.hamcrest;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.StringDescription;
+import org.junit.jupiter.api.Test;
+import org.takes.Response;
+import org.takes.facets.cookies.RsWithCookie;
+import org.takes.rs.RsEmpty;
+
+/**
+ * Test case for {@link org.takes.facets.hamcrest.HmRsCookie}.
+ * @since 2.0
+ */
+final class HmRsCookieTest {
+
+    @Test
+    void matchesCookieByNameAndValue() {
+        MatcherAssert.assertThat(
+            "Response must have a Set-Cookie with name 'session' and value 'abc'",
+            new RsWithCookie("session", "abc"),
+            new HmRsCookie("session", "abc")
+        );
+    }
+
+    @Test
+    void matchesCookieDespiteAdditionalAttributes() {
+        MatcherAssert.assertThat(
+            "Matcher must ignore Path/HttpOnly/Secure attributes",
+            new RsWithCookie(
+                "session", "abc",
+                "Path=/", "HttpOnly", "Secure"
+            ),
+            new HmRsCookie("session", "abc")
+        );
+    }
+
+    @Test
+    void matchesCookieValueMatcher() {
+        MatcherAssert.assertThat(
+            "Matcher must accept a Hamcrest matcher for cookie value",
+            new RsWithCookie("user", "Jeff", "Path=/"),
+            new HmRsCookie("user", Matchers.startsWith("Je"))
+        );
+    }
+
+    @Test
+    void doesNotMatchMissingCookie() {
+        MatcherAssert.assertThat(
+            "Matcher must not match a response without the named cookie",
+            new RsEmpty(),
+            Matchers.not(new HmRsCookie("session", "abc"))
+        );
+    }
+
+    @Test
+    void doesNotMatchWrongValue() {
+        MatcherAssert.assertThat(
+            "Matcher must not match if cookie value differs",
+            new RsWithCookie("session", "xyz"),
+            Matchers.not(new HmRsCookie("session", "abc"))
+        );
+    }
+
+    @Test
+    void picksRightCookieAmongMany() {
+        final Response response = new RsWithCookie(
+            new RsWithCookie("a", "1"),
+            "b", "2"
+        );
+        MatcherAssert.assertThat(
+            "Matcher must find the 'b' cookie when multiple Set-Cookie headers exist",
+            response,
+            new HmRsCookie("b", "2")
+        );
+        MatcherAssert.assertThat(
+            "Matcher must find the 'a' cookie when multiple Set-Cookie headers exist",
+            response,
+            new HmRsCookie("a", "1")
+        );
+    }
+
+    @Test
+    void describesMismatchWithCookieName() {
+        final HmRsCookie matcher = new HmRsCookie("session", "abc");
+        final Response response = new RsWithCookie("session", "xyz", "Path=/");
+        matcher.matchesSafely(response);
+        final StringDescription description = new StringDescription();
+        matcher.describeMismatchSafely(response, description);
+        MatcherAssert.assertThat(
+            "Mismatch description must mention cookie name and actual value",
+            description.toString(),
+            Matchers.allOf(
+                Matchers.containsString("session"),
+                Matchers.containsString("xyz")
+            )
+        );
+    }
+}


### PR DESCRIPTION
@yegor256 — closes #1559.

As requested in the issue, this adds two dedicated Hamcrest matchers to `org.takes.facets.hamcrest` so that cookie assertions no longer require hand-rolling a `HmHeader` on `Set-Cookie` / `Cookie` and fiddling with `containsString`:

```java
MatcherAssert.assertThat(response, new HmRsCookie("session", "abc"));
MatcherAssert.assertThat(request,  new HmRqCookie("session", "abc"));
```

## What's in the PR

- `HmRsCookie` — walks every `Set-Cookie` header on a response, splits off the `name=value` crumb and ignores the trailing `Path` / `Domain` / `HttpOnly` / `Secure` / `Expires` attributes so the matcher asserts only on the exact cookie name/value.
- `HmRqCookie` — walks every `Cookie` header on a request and handles several crumbs packed into one header (`Cookie: a=1; b=2; c=3`).
- Both matchers accept either a plain value string or a `Matcher<String>` for the value, and produce a mismatch description that names the cookie and shows the observed value.

## Commits

1. `#1559: add failing tests for HmRsCookie and HmRqCookie matchers` — tests written first; the build fails at compile time because the matcher classes don't exist yet.
2. `#1559: add HmRsCookie and HmRqCookie matchers` — the two matcher classes that make the tests pass.

## Verified

- All 12 CI checks on this PR are green (mvn on ubuntu-24.04 / macos-15 / windows-2022 with `-Pqulice -Pdeep`, plus pdd / xcop / reuse / copyrights / markdown-lint / yamllint / actionlint / simian / typos).
- Locally: `mvn test` — 599 tests, 0 failures; `mvn test -Pdeep` — 657 tests, 0 failures; `mvn verify -Pqulice -DskipTests -DskipITs` — clean (checkstyle + PMD).

Ready for merge when you are.