### PR TITLE
#1117 Add HeadOnce and BodyOnce decorators

### DIFF
--- a/src/main/java/org/takes/rq/BodyOnce.java
+++ b/src/main/java/org/takes/rq/BodyOnce.java
@@ -4,14 +4,25 @@
  */
 package org.takes.rq;
 
+import java.io.InputStream;
 import lombok.EqualsAndHashCode;
+import org.cactoos.Scalar;
+import org.cactoos.io.InputStreamOf;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.text.TextOf;
 import org.takes.Request;
 
 /**
  * Request decorator that prevents multiple reads of body content.
  *
- * <p>Skeleton without caching — to be implemented next; the existing test
- * {@link BodyOnceTest#cachesBodyOnFirstAccess} fails until caching is added.
+ * <p>This decorator caches the request body on first access, ensuring that
+ * subsequent calls to {@code body()} produce input streams over the same
+ * cached content. The head is delegated to the original request without
+ * caching. This is useful when the underlying body stream can only be read
+ * once, but multiple components need to access it.
+ *
+ * <p>The class is immutable and thread-safe.
  *
  * @since 2.0
  */
@@ -23,6 +34,22 @@ public final class BodyOnce extends RqWrap {
      * @param req Original request
      */
     public BodyOnce(final Request req) {
-        super(req);
+        super(
+            new RequestOf(
+                req::head,
+                new IoChecked<>(
+                    new Scalar<InputStream>() {
+                        private final Scalar<String> text = new Sticky<>(
+                            new TextOf(req::body)::asString
+                        );
+
+                        @Override
+                        public InputStream value() throws Exception {
+                            return new InputStreamOf(this.text.value());
+                        }
+                    }
+                )::value
+            )
+        );
     }
 }

--- a/src/main/java/org/takes/rq/BodyOnce.java
+++ b/src/main/java/org/takes/rq/BodyOnce.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.rq;
+
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+
+/**
+ * Request decorator that prevents multiple reads of body content.
+ *
+ * <p>Skeleton without caching — to be implemented next; the existing test
+ * {@link BodyOnceTest#cachesBodyOnFirstAccess} fails until caching is added.
+ *
+ * @since 2.0
+ */
+@EqualsAndHashCode(callSuper = true)
+public final class BodyOnce extends RqWrap {
+
+    /**
+     * Ctor.
+     * @param req Original request
+     */
+    public BodyOnce(final Request req) {
+        super(req);
+    }
+}

--- a/src/main/java/org/takes/rq/HeadOnce.java
+++ b/src/main/java/org/takes/rq/HeadOnce.java
@@ -5,13 +5,20 @@
 package org.takes.rq;
 
 import lombok.EqualsAndHashCode;
+import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.Sticky;
 import org.takes.Request;
 
 /**
  * Request decorator that prevents multiple reads of head content.
  *
- * <p>Skeleton without caching — to be implemented next; the existing test
- * {@link HeadOnceTest#cachesHeadOnFirstAccess} fails until caching is added.
+ * <p>This decorator caches the request headers on first access, ensuring that
+ * subsequent calls to {@code head()} return the same cached data. The body
+ * is delegated to the original request without caching. This is useful when
+ * the head is computed lazily and we want to make sure it is not produced
+ * more than once, while still allowing the body to be streamed normally.
+ *
+ * <p>The class is immutable and thread-safe.
  *
  * @since 2.0
  */
@@ -23,6 +30,11 @@ public final class HeadOnce extends RqWrap {
      * @param req Original request
      */
     public HeadOnce(final Request req) {
-        super(req);
+        super(
+            new RequestOf(
+                new IoChecked<>(new Sticky<>(req::head))::value,
+                req::body
+            )
+        );
     }
 }

--- a/src/main/java/org/takes/rq/HeadOnce.java
+++ b/src/main/java/org/takes/rq/HeadOnce.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.rq;
+
+import lombok.EqualsAndHashCode;
+import org.takes.Request;
+
+/**
+ * Request decorator that prevents multiple reads of head content.
+ *
+ * <p>Skeleton without caching — to be implemented next; the existing test
+ * {@link HeadOnceTest#cachesHeadOnFirstAccess} fails until caching is added.
+ *
+ * @since 2.0
+ */
+@EqualsAndHashCode(callSuper = true)
+public final class HeadOnce extends RqWrap {
+
+    /**
+     * Ctor.
+     * @param req Original request
+     */
+    public HeadOnce(final Request req) {
+        super(req);
+    }
+}

--- a/src/main/java/org/takes/rq/RqOnce.java
+++ b/src/main/java/org/takes/rq/RqOnce.java
@@ -4,13 +4,7 @@
  */
 package org.takes.rq;
 
-import java.io.InputStream;
 import lombok.EqualsAndHashCode;
-import org.cactoos.Scalar;
-import org.cactoos.io.InputStreamOf;
-import org.cactoos.scalar.IoChecked;
-import org.cactoos.scalar.Sticky;
-import org.cactoos.text.TextOf;
 import org.takes.Request;
 
 /**
@@ -25,9 +19,6 @@ import org.takes.Request;
  * <p>The class is immutable and thread-safe.
  *
  * @since 0.36
- * @todo #1080:30min Please make two decorators (HeadOnce and BodyOnce)
- *  that prevent multiple reads of their contents. Introduce some units
- *  tests for these new classes.
  */
 @EqualsAndHashCode(callSuper = true)
 public final class RqOnce extends RqWrap {
@@ -37,22 +28,6 @@ public final class RqOnce extends RqWrap {
      * @param req Original request
      */
     public RqOnce(final Request req) {
-        super(
-            new RequestOf(
-                new IoChecked<>(new Sticky<>(req::head))::value,
-                new IoChecked<>(
-                    new Scalar<InputStream>() {
-                        private final Scalar<String> text = new Sticky<>(
-                            new TextOf(req::body)::asString
-                        );
-
-                        @Override
-                        public InputStream value() throws Exception {
-                            return new InputStreamOf(this.text.value());
-                        }
-                    }
-                )::value
-            )
-        );
+        super(new HeadOnce(new BodyOnce(req)));
     }
 }

--- a/src/test/java/org/takes/rq/BodyOnceTest.java
+++ b/src/test/java/org/takes/rq/BodyOnceTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.rq;
+
+import java.io.IOException;
+import org.cactoos.io.InputStreamOf;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.text.Randomized;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.takes.Request;
+
+/**
+ * Test case for {@link BodyOnce}.
+ * @since 2.0
+ */
+final class BodyOnceTest {
+
+    @Test
+    void cachesBodyOnFirstAccess() throws IOException {
+        final Request req = new BodyOnce(
+            new RequestOf(
+                () -> new IterableOf<>("GET / HTTP/1.1"),
+                () -> new InputStreamOf(new Randomized())
+            )
+        );
+        MatcherAssert.assertThat(
+            "the body must be cached and identical on subsequent reads",
+            new RqPrint(req).printBody(),
+            new IsEqual<>(
+                new RqPrint(req).printBody()
+            )
+        );
+    }
+
+    @Test
+    void doesNotCacheHead() throws IOException {
+        final Request req = new BodyOnce(
+            new RequestOf(
+                () -> new IterableOf<>(
+                    "GET / HTTP/1.1",
+                    new Randomized().toString()
+                ),
+                () -> new InputStreamOf("body")
+            )
+        );
+        MatcherAssert.assertThat(
+            "the head must NOT be cached by BodyOnce",
+            new RqPrint(req).printHead(),
+            org.hamcrest.Matchers.not(
+                new IsEqual<>(new RqPrint(req).printHead())
+            )
+        );
+    }
+}

--- a/src/test/java/org/takes/rq/HeadOnceTest.java
+++ b/src/test/java/org/takes/rq/HeadOnceTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes.rq;
+
+import java.io.IOException;
+import org.cactoos.io.InputStreamOf;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.text.Randomized;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.takes.Request;
+
+/**
+ * Test case for {@link HeadOnce}.
+ * @since 2.0
+ */
+final class HeadOnceTest {
+
+    @Test
+    void cachesHeadOnFirstAccess() throws IOException {
+        final Request req = new HeadOnce(
+            new RequestOf(
+                () -> new IterableOf<>(new Randomized().toString()),
+                () -> new InputStreamOf(new Randomized())
+            )
+        );
+        MatcherAssert.assertThat(
+            "the head must be cached and identical on subsequent reads",
+            new RqPrint(req).printHead(),
+            new IsEqual<>(
+                new RqPrint(req).printHead()
+            )
+        );
+    }
+
+    @Test
+    void doesNotCacheBody() throws IOException {
+        final Request req = new HeadOnce(
+            new RequestOf(
+                () -> new IterableOf<>("GET / HTTP/1.1"),
+                () -> new InputStreamOf(new Randomized())
+            )
+        );
+        MatcherAssert.assertThat(
+            "the body must NOT be cached by HeadOnce",
+            new RqPrint(req).printBody(),
+            org.hamcrest.Matchers.not(
+                new IsEqual<>(new RqPrint(req).printBody())
+            )
+        );
+    }
+}


### PR DESCRIPTION
@yegor256 this PR resolves the puzzle in `RqOnce.java` (#1117) by introducing two new request decorators — `HeadOnce` and `BodyOnce` — and refactoring `RqOnce` to compose them.

**What changed**

- **`HeadOnce`** (new) — caches the `head()` iterable on first access via `Sticky`; `body()` is a pass-through to the wrapped request.
- **`BodyOnce`** (new) — caches the body content as a `String` on first access and emits a fresh `InputStream` over it on every `body()` call; `head()` is a pass-through.
- **`RqOnce`** (refactored) — its constructor is now `super(new HeadOnce(new BodyOnce(req)))`, replacing the inlined caching logic. The `@todo #1080:30min` puzzle comment is removed.
- **`HeadOnceTest`**, **`BodyOnceTest`** (new) — each has one positive assertion (decorator caches its target) and one negative assertion (it does not cache the other side), demonstrating the orthogonal behavior.

**Why two commits**

- The first commit adds the tests plus non-caching skeletons of the two decorators, so the cache-tests fail on that commit, demonstrating the missing behavior. 
- The second commit adds the caching implementation and refactors `RqOnce`, turning the failing tests green.

**Verification**

- All 605 existing tests continue to pass; the 4 new tests in `HeadOnceTest`/`BodyOnceTest` pass after the second commit.
- Local `mvn -Pqulice -Pdeep clean install` is green.
- CI: all 12 checks green (3× `mvn` on ubuntu/windows/macos plus all lint workflows).

Ready for merge.