### PR TITLE
Fix Servlet version reference in Architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,7 +1283,7 @@ changing application code.**
 [`SrvTake`](src/main/java/org/takes/servlet/SrvTake.java) adapts any `Take` to a
 standard [`HttpServlet`](https://jakarta.ee/specifications/servlet/), allowing
 the same application to run standalone (via `FtBasic`) or inside Tomcat, Jetty,
-or any [Servlet 3.x](https://jakarta.ee/specifications/servlet/3.1/) container.
+or any [Servlet 6.x](https://jakarta.ee/specifications/servlet/6.1/) container.
 The adapter translates a `ServletRequest` into a `Request` and serialises the
 `Response` back to the `ServletResponse`. This provides deployment flexibility
 without coupling the application logic to any container API.


### PR DESCRIPTION
@yegor256, the Architecture section in `README.md` mentioned `Servlet 3.x` and linked to the Servlet 3.1 specification, but the project's `pom.xml` already declares `jakarta.servlet-api` version **6.1.0** (Jakarta EE 10 / Jakarta Servlet 6.x). I updated the single reference on that line from `3.x` to `6.x` and changed the link from `.../servlet/3.1/` to `.../servlet/6.1/` to match the actual dependency.

**Change summary:**
- `README.md` line in the *Servlet bridge* paragraph of the Architecture section: `Servlet 3.x` → `Servlet 6.x`, spec URL updated accordingly.

No other changes were made; `markdownlint` reports no warnings before or after the fix.