### PR TITLE
Fix constructor parameter order in TkMethods to match FkMethods (#1005)

### DIFF
--- a/src/main/java/org/takes/facets/fork/TkMethods.java
+++ b/src/main/java/org/takes/facets/fork/TkMethods.java
@@ -5,6 +5,7 @@
 package org.takes.facets.fork;
 
 import java.net.HttpURLConnection;
+import java.util.Collection;
 import lombok.ToString;
 import org.cactoos.list.ListOf;
 import org.takes.HttpException;
@@ -26,9 +27,19 @@ public final class TkMethods extends TkWrap {
      * @param methods Methods the take should act
      */
     public TkMethods(final Take take, final String... methods) {
+        this(new ListOf<>(methods), take);
+    }
+
+    /**
+     * Ctor.
+     * @param methods Methods the take should act
+     * @param take Original take
+     * @since 1.24
+     */
+    public TkMethods(final Collection<String> methods, final Take take) {
         super(
             new TkFork(
-                new FkMethods(new ListOf<>(methods), take),
+                new FkMethods(methods, take),
                 new FkFixed(
                     new TkFailure(
                         () -> new HttpException(

--- a/src/test/java/org/takes/facets/fork/TkMethodsTest.java
+++ b/src/test/java/org/takes/facets/fork/TkMethodsTest.java
@@ -8,6 +8,7 @@ import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
 import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +28,14 @@ import org.takes.tk.TkEmpty;
  * @since 0.17
  */
 final class TkMethodsTest {
+
+    @Test
+    void acceptsCollectionOfMethodsBeforeTakeMatchingFkMethods() throws Exception {
+        final Take take = Mockito.mock(Take.class);
+        final Request req = new RqFake(RqMethod.GET);
+        new TkMethods(new ListOf<>(RqMethod.GET), take).act(req);
+        Mockito.verify(take, Mockito.times(1)).act(req);
+    }
 
     @Test
     void callsActOnProperMethods() throws Exception {


### PR DESCRIPTION
Closes #1005.

The root cause is that `TkMethods(Take, String...)` puts `Take` first while `FkMethods(Collection<String>, Take)` puts the method collection first. Anyone who learns the API from `FkMethods` will instinctively swap the arguments when calling `TkMethods`, getting a confusing compile error. This PR adds a new primary constructor `TkMethods(Collection<String>, Take)` that matches the `FkMethods` signature, and rewires the existing `TkMethods(Take, String...)` constructor to delegate to it so that all existing callers continue to compile unchanged.

https://claude.ai/code/session_01C4kW3Zay6pr3EhPAJ2kDQx