### PR TITLE
#1440: Encode query chars in request target

### DIFF
--- a/src/main/java/org/takes/misc/Href.java
+++ b/src/main/java/org/takes/misc/Href.java
@@ -309,7 +309,7 @@ public final class Href implements CharSequence {
         try {
             return URLEncoder.encode(
                 txt, Charset.defaultCharset().name()
-            );
+            ).replace("+", "%20");
         } catch (final UnsupportedEncodingException ex) {
             throw new IllegalStateException(
                 String.format("Failed to encode '%s'", txt),

--- a/src/main/java/org/takes/rq/RqRequestLine.java
+++ b/src/main/java/org/takes/rq/RqRequestLine.java
@@ -6,6 +6,9 @@ package org.takes.rq;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
@@ -79,7 +82,7 @@ public interface RqRequestLine extends Request {
          * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1">RFC 2616</a>
          */
         private static final Pattern PATTERN = Pattern.compile(
-            "([!-~]+) ([^ ]+)( [^ ]+)?"
+            "([!-~]+) (.+?)( HTTP/\\d+(?:\\.\\d+)?)?"
         );
 
         /**
@@ -133,7 +136,9 @@ public interface RqRequestLine extends Request {
 
         @Override
         public String uri() throws IOException {
-            return this.token(RqRequestLine.Base.Token.URI);
+            return RqRequestLine.Base.Target.encoded(
+                this.token(RqRequestLine.Base.Token.URI)
+            );
         }
 
         @Override
@@ -179,7 +184,25 @@ public interface RqRequestLine extends Request {
          */
         private static Matcher matcher(final String line) throws HttpException {
             final Matcher matcher = RqRequestLine.Base.PATTERN.matcher(line);
-            if (!matcher.matches()) {
+            boolean valid = matcher.matches();
+            if (valid) {
+                final String uri = matcher.group(
+                    RqRequestLine.Base.Token.URI.value
+                );
+                final boolean version = matcher.group(
+                    RqRequestLine.Base.Token.HTTPVERSION.value
+                ) != null;
+                if (uri.startsWith(" ")) {
+                    valid = false;
+                }
+                if (valid && version && uri.endsWith(" ")) {
+                    valid = false;
+                }
+                if (valid && !version && uri.contains(" HTTP/")) {
+                    valid = false;
+                }
+            }
+            if (!valid) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
                     String.format(
@@ -198,15 +221,7 @@ public interface RqRequestLine extends Request {
          * @throws HttpException If fails
          */
         private static String validated(final String line) throws HttpException {
-            if (!RqRequestLine.Base.PATTERN.matcher(line).matches()) {
-                throw new HttpException(
-                    HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        RqRequestLine.Base.BAD_REQUEST_MSG,
-                        line
-                    )
-                );
-            }
+            RqRequestLine.Base.matcher(line);
             return line;
         }
 
@@ -231,6 +246,85 @@ public interface RqRequestLine extends Request {
             return new IoCheckedText(
                 new Trimmed(new TextOf(value))
             ).asString();
+        }
+
+        /**
+         * Request target encoding.
+         * @since 2.0
+         */
+        private static final class Target {
+
+            /**
+             * Utility class.
+             */
+            private Target() {
+                // intentionally empty
+            }
+
+            /**
+             * Encode illegal URI characters without changing encoded octets.
+             * @param value Request URI
+             * @return Encoded request URI
+             * @throws IOException If request target is invalid
+             */
+            private static String encoded(final String value)
+                throws IOException {
+                final StringBuilder uri = new StringBuilder(value);
+                while (true) {
+                    try {
+                        return new URI(uri.toString()).toASCIIString();
+                    } catch (final URISyntaxException err) {
+                        final int index = err.getIndex();
+                        if (
+                            index < 0 || index >= uri.length()
+                                || !RqRequestLine.Base.Target.query(uri, index)
+                        ) {
+                            throw new HttpException(
+                                HttpURLConnection.HTTP_BAD_REQUEST,
+                                String.format(
+                                    RqRequestLine.Base.BAD_REQUEST_MSG,
+                                    value
+                                ),
+                                err
+                            );
+                        }
+                        final int point = uri.codePointAt(index);
+                        uri.replace(
+                            index,
+                            index + Character.charCount(point),
+                            RqRequestLine.Base.Target.encode(point)
+                        );
+                    }
+                }
+            }
+
+            /**
+             * Check whether character at index is inside the query part.
+             * @param uri Request URI
+             * @param index Character index
+             * @return True when index is inside query
+             */
+            private static boolean query(final StringBuilder uri, final int index) {
+                final int start = uri.indexOf("?");
+                return start >= 0 && index > start;
+            }
+
+            /**
+             * Percent-encode a code point using UTF-8.
+             * @param point Code point
+             * @return Encoded code point
+             */
+            private static String encode(final int point) {
+                final StringBuilder text = new StringBuilder();
+                for (final byte octet : new String(
+                    Character.toChars(point)
+                ).getBytes(StandardCharsets.UTF_8)) {
+                    text.append('%').append(
+                        String.format("%02X", octet & 0xff)
+                    );
+                }
+                return text.toString();
+            }
         }
     }
 }

--- a/src/test/java/org/takes/misc/HrefTest.java
+++ b/src/test/java/org/takes/misc/HrefTest.java
@@ -79,6 +79,15 @@ final class HrefTest {
     }
 
     @Test
+    void preservesSpaceEncoding() {
+        MatcherAssert.assertThat(
+            "Spaces in query parameters must use URI percent-encoding",
+            new Href("http://a.example.com?param=hello world").toString(),
+            Matchers.equalTo("http://a.example.com/?param=hello%20world")
+        );
+    }
+
+    @Test
     void addsPathWithEncoding() {
         Assumptions.assumeTrue("UTF-8".equals(Charset.defaultCharset().name()));
         MatcherAssert.assertThat(

--- a/src/test/java/org/takes/rq/RqHrefTest.java
+++ b/src/test/java/org/takes/rq/RqHrefTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.takes.HttpException;
 
@@ -200,7 +199,6 @@ import org.takes.HttpException;
      * a format that can be transmitted over the Internet. URL encoding replaces unsafe ASCII
      * characters with a "%" followed by two hexadecimal digits.
      */
-    @Disabled
     @Test
     void noSpaceTruncationInUri() throws IOException {
         MatcherAssert.assertThat(

--- a/src/test/java/org/takes/rq/RqRequestLineTest.java
+++ b/src/test/java/org/takes/rq/RqRequestLineTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.takes.HttpException;
 
@@ -170,7 +169,6 @@ final class RqRequestLineTest {
      * a format that can be transmitted over the Internet. URL encoding replaces unsafe ASCII
      * characters with a "%" followed by two hexadecimal digits.
      */
-    @Disabled
     @Test
     void noSpaceTruncationInUri() throws IOException {
         MatcherAssert.assertThat(
@@ -178,13 +176,13 @@ final class RqRequestLineTest {
             new RqRequestLine.Base(
                 new RqFake(
                     Arrays.asList(
-                        "GET /?u=Hello World",
+                        "GET /?path=C:\\temp&u=Hello World",
                         "Host: www.example.com"
                     ),
                     ""
                 )
             ).uri(),
-            Matchers.equalTo("/?u=Hello%20World")
+            Matchers.equalTo("/?path=C:%5Ctemp&u=Hello%20World")
         );
     }
 }


### PR DESCRIPTION
/claim #1440

Fixes #1440.

Changes:
- Percent-encode raw spaces and backslashes inside query values before the request target is used by `RqHref`.
- Keep malformed request lines with extra elements, extra version spacing, and invalid path-only targets rejected.
- Serialize `Href` spaces as `%20` instead of `+`.

Validation:
- `git diff --check` -> passed.
- `mvn -q -Dtest=RqMethodTest,BkBasicTest,RqRequestLineTest,RqHrefTest,HrefTest test` -> passed.
- `mvn --errors --batch-mode -Pqulice qulice:check` -> BUILD SUCCESS.
- `mvn --errors --batch-mode clean install -Pqulice -Pdeep` -> unit tests passed: 666 run, 0 failures, 0 errors, 5 skipped; invoker `file-manager` passed; failed later in local `revapi` plugin with missing `org/apache/logging/log4j/spi/LoggerAdapter`.
- Current GitHub checks fail during action download from `codeload.github.com` before project commands run; rerun requires repository admin rights.