### PR TITLE
#1114: configure duplicate finder in qulice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -656,31 +656,6 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.basepom.maven</groupId>
-        <artifactId>duplicate-finder-maven-plugin</artifactId>
-        <version>2.0.1</version>
-        <configuration>
-          <ignoredDependencies>
-            <dependency>
-              <groupId>javax.json</groupId>
-              <artifactId>javax.json-api</artifactId>
-              <version>1.1.4</version>
-            </dependency>
-            <dependency>
-              <groupId>javax.xml.bind</groupId>
-              <artifactId>jaxb-api</artifactId>
-              <version>2.3.1</version>
-            </dependency>
-          </ignoredDependencies>
-        </configuration>
-        <!--
-        @todo #958:30min duplicate-finder-maven-plugin found module-info as duplicate
-         and different class in [javax.json:javax.json-api:1.1,javax.xml.bind:jaxb-api:2.3.0].
-         After resolving duplicatefinder in Qulice, remove this plugin and configure qulice
-         plugin to enable these exclusions (see at https://www.qulice.com/qulice-maven-plugin/example-exclude.html).
-        -->
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -710,7 +685,8 @@
             <configuration>
               <excludes>
                 <exclude>checkstyle:/src/site/resources/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
+                <exclude>duplicatefinder:javax.json:javax.json-api:1.1.4</exclude>
+                <exclude>duplicatefinder:javax.xml.bind:jaxb-api:2.3.1</exclude>
                 <exclude>dependencies:.*</exclude>
               </excludes>
             </configuration>


### PR DESCRIPTION
Fixes #1114.

Summary:
- remove the standalone duplicate-finder plugin and its stale PDD block
- keep the same ignored dependencies through Qulice duplicatefinder excludes

Validation:
- `mvn --errors --batch-mode -Dstyle.color=never -DskipTests -Pqulice qulice:check` -> `BUILD SUCCESS`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 mvn --errors --batch-mode -Dstyle.color=never -DskipTests -Drevapi.skip=true clean install -Pqulice -Pdeep` -> `BUILD SUCCESS`
- `git diff --check` -> passed
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks

Limitation:
- The same `clean install -Pqulice -Pdeep` command without `-Drevapi.skip=true` compiled, built both jars, and passed the invoker build, then failed in Revapi with external-class-exposed-in-API reports plus a local Maven wagon `LoggerAdapter` classloading error. I left that as a local validation limitation because this patch only removes the standalone duplicate-finder configuration and the Qulice duplicatefinder path passes.