### PR TITLE
fix: Put HTTP print methods behind a contract

### DIFF
--- a/src/main/java/org/takes/Printable.java
+++ b/src/main/java/org/takes/Printable.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2014-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package org.takes;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Printable HTTP message.
+ *
+ * <p>An object implementing this interface can print a complete HTTP message,
+ * its head, or its body into a string or an output stream.
+ *
+ * @since 2.0
+ */
+public interface Printable {
+
+    /**
+     * Print the complete HTTP message into a string.
+     * @return Complete HTTP message
+     * @throws IOException If something goes wrong
+     */
+    String print() throws IOException;
+
+    /**
+     * Print the complete HTTP message into an output stream.
+     * @param output Output stream
+     * @throws IOException If something goes wrong
+     */
+    void print(OutputStream output) throws IOException;
+
+    /**
+     * Print the HTTP message head into a string.
+     * @return HTTP message head
+     * @throws IOException If something goes wrong
+     */
+    String printHead() throws IOException;
+
+    /**
+     * Print the HTTP message head into an output stream.
+     * @param output Output stream
+     * @throws IOException If something goes wrong
+     */
+    void printHead(OutputStream output) throws IOException;
+
+    /**
+     * Print the HTTP message body into a string.
+     * @return HTTP message body
+     * @throws IOException If something goes wrong
+     */
+    String printBody() throws IOException;
+
+    /**
+     * Print the HTTP message body into an output stream.
+     * @param output Output stream
+     * @throws IOException If something goes wrong
+     */
+    void printBody(OutputStream output) throws IOException;
+}

--- a/src/main/java/org/takes/rq/RqPrint.java
+++ b/src/main/java/org/takes/rq/RqPrint.java
@@ -18,6 +18,7 @@ import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.Sticky;
 import org.cactoos.text.TextOf;
+import org.takes.Printable;
 import org.takes.Request;
 
 /**
@@ -34,7 +35,7 @@ import org.takes.Request;
  * @since 0.1
  */
 @EqualsAndHashCode(callSuper = true)
-public final class RqPrint extends RqWrap implements Text {
+public final class RqPrint extends RqWrap implements Text, Printable {
 
     /**
      * The textual representation.
@@ -64,6 +65,7 @@ public final class RqPrint extends RqWrap implements Text {
      * @return Text form of request
      * @throws IOException If fails
      */
+    @Override
     public String print() throws IOException {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             this.print(baos);
@@ -76,6 +78,7 @@ public final class RqPrint extends RqWrap implements Text {
      * @param output Output stream
      * @throws IOException If fails
      */
+    @Override
     public void print(final OutputStream output) throws IOException {
         new IoChecked<>(
             new LengthOf(new TeeInput(this.text, new OutputTo(output)))
@@ -87,6 +90,7 @@ public final class RqPrint extends RqWrap implements Text {
      * @return Text form of request
      * @throws IOException If fails
      */
+    @Override
     public String printHead() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         this.printHead(baos);
@@ -98,6 +102,7 @@ public final class RqPrint extends RqWrap implements Text {
      * @param output Output stream
      * @throws IOException If fails
      */
+    @Override
     public void printHead(final OutputStream output) throws IOException {
         final String eol = new String(
             new char[]{(char) 13, (char) 10}
@@ -117,6 +122,7 @@ public final class RqPrint extends RqWrap implements Text {
      * @return Text form of request
      * @throws IOException If fails
      */
+    @Override
     public String printBody() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         this.printBody(baos);
@@ -129,6 +135,7 @@ public final class RqPrint extends RqWrap implements Text {
      * @throws IOException If fails
      */
     @SuppressWarnings("PMD.CloseResource")
+    @Override
     public void printBody(final OutputStream output) throws IOException {
         final InputStream input = new RqChunk(new RqLengthAware(this)).body();
         final byte[] buf = new byte[4096];

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.cactoos.Text;
+import org.takes.Printable;
 import org.takes.Response;
 
 /**
@@ -32,7 +33,7 @@ import org.takes.Response;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public final class RsPrint extends RsWrap implements Text {
+public final class RsPrint extends RsWrap implements Text, Printable {
 
     /**
      * Pattern for first line.
@@ -66,6 +67,7 @@ public final class RsPrint extends RsWrap implements Text {
      * @return Entire HTTP response
      * @throws IOException If fails
      */
+    @Override
     public String print() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         this.print(baos);
@@ -77,6 +79,7 @@ public final class RsPrint extends RsWrap implements Text {
      * @return Entire body of HTTP response
      * @throws IOException If fails
      */
+    @Override
     public String printBody() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         this.printBody(baos);
@@ -89,6 +92,7 @@ public final class RsPrint extends RsWrap implements Text {
      * @throws IOException If fails
      * @since 0.10
      */
+    @Override
     public String printHead() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         this.printHead(baos);
@@ -100,6 +104,7 @@ public final class RsPrint extends RsWrap implements Text {
      * @param output Output to print into
      * @throws IOException If fails
      */
+    @Override
     public void print(final OutputStream output) throws IOException {
         this.printHead(output);
         this.printBody(output);
@@ -111,6 +116,7 @@ public final class RsPrint extends RsWrap implements Text {
      * @throws IOException If fails
      * @since 0.10
      */
+    @Override
     public void printHead(final OutputStream output) throws IOException {
         final String eol = new String(
             new char[]{(char) 13, (char) 10}
@@ -148,6 +154,7 @@ public final class RsPrint extends RsWrap implements Text {
      * @param output Output to print into
      * @throws IOException If fails
      */
+    @Override
     public void printBody(final OutputStream output) throws IOException {
         try (InputStream body = this.body()) {
             final byte[] buf = new byte[4096];

--- a/src/test/java/org/takes/rq/RqPrintTest.java
+++ b/src/test/java/org/takes/rq/RqPrintTest.java
@@ -4,10 +4,13 @@
  */
 package org.takes.rq;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.llorllale.cactoos.matchers.HasString;
+import org.takes.Printable;
 
 /**
  * Test case for {@link RqPrint}.
@@ -15,22 +18,64 @@ import org.llorllale.cactoos.matchers.HasString;
  */
 final class RqPrintTest {
 
+    /**
+     * Carriage return + line feed.
+     */
+    private static final String CRLF =
+        String.valueOf((char) 13) + (char) 10;
+
     @Test
-    void printsHttpRequest() {
+    void printsHttpRequestThroughContract() throws Exception {
+        final String head = String.join(
+            RqPrintTest.CRLF,
+            "POST /print HTTP/1.1",
+            "Host: www.example.com",
+            "Content-Length: 4",
+            ""
+        ) + RqPrintTest.CRLF;
+        final String body = "body";
+        final String request = head + body;
         MatcherAssert.assertThat(
-            "Printed request must contain the request path",
-            new RqPrint(
-                new RqFake(
-                    Arrays.asList(
-                        "GET /h?a=3",
-                        "Host: www.example.com",
-                        "Content-type: text/plain",
-                        "Content-Length: 0"
-                    ),
-                    ""
-                )
+            "must print every request part as a string",
+            Arrays.asList(
+                RqPrintTest.request(body).print(),
+                RqPrintTest.request(body).printHead(),
+                RqPrintTest.request(body).printBody()
             ),
-            new HasString("/h?a=3")
+            Matchers.contains(request, head, body)
+        );
+        final ByteArrayOutputStream entire = new ByteArrayOutputStream();
+        final ByteArrayOutputStream headers = new ByteArrayOutputStream();
+        final ByteArrayOutputStream content = new ByteArrayOutputStream();
+        RqPrintTest.request(body).print(entire);
+        RqPrintTest.request(body).printHead(headers);
+        RqPrintTest.request(body).printBody(content);
+        MatcherAssert.assertThat(
+            "must print every request part to a stream",
+            Arrays.asList(
+                new String(entire.toByteArray(), StandardCharsets.UTF_8),
+                new String(headers.toByteArray(), StandardCharsets.UTF_8),
+                new String(content.toByteArray(), StandardCharsets.UTF_8)
+            ),
+            Matchers.contains(request, head, body)
+        );
+    }
+
+    /**
+     * Request printer referenced through its contract.
+     * @param body Request body
+     * @return Request printer
+     */
+    private static Printable request(final String body) {
+        return new RqPrint(
+            new RqFake(
+                Arrays.asList(
+                    "POST /print HTTP/1.1",
+                    "Host: www.example.com",
+                    "Content-Length: 4"
+                ),
+                body
+            )
         );
     }
 }

--- a/src/test/java/org/takes/rs/RsPrintTest.java
+++ b/src/test/java/org/takes/rs/RsPrintTest.java
@@ -4,13 +4,18 @@
  */
 package org.takes.rs;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import org.cactoos.Text;
 import org.cactoos.iterable.IterableOf;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.object.HasToString;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.takes.Printable;
 
 /**
  * Test case for {@link RsPrint}.
@@ -44,12 +49,48 @@ final class RsPrintTest {
 
     @Test
     void failsOnInvalidHeader() {
-        final Text response = new RsPrint(
+        final Printable response = new RsPrint(
             new RsWithHeader("name", RsPrintTest.THREE_LFS)
         );
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            response::asString
+            response::print
+        );
+    }
+
+    @Test
+    void printsHttpResponseThroughContract() throws Exception {
+        final String head = String.join(
+            RsPrintTest.CRLF,
+            "HTTP/1.1 200 OK",
+            "Content-Type: text/plain; charset=UTF-8",
+            ""
+        ) + RsPrintTest.CRLF;
+        final String body = "привет";
+        final String response = head + body;
+        MatcherAssert.assertThat(
+            "must print every response part as a string",
+            Arrays.asList(
+                RsPrintTest.response(body).print(),
+                RsPrintTest.response(body).printHead(),
+                RsPrintTest.response(body).printBody()
+            ),
+            Matchers.contains(response, head, body)
+        );
+        final ByteArrayOutputStream entire = new ByteArrayOutputStream();
+        final ByteArrayOutputStream headers = new ByteArrayOutputStream();
+        final ByteArrayOutputStream content = new ByteArrayOutputStream();
+        RsPrintTest.response(body).print(entire);
+        RsPrintTest.response(body).printHead(headers);
+        RsPrintTest.response(body).printBody(content);
+        MatcherAssert.assertThat(
+            "must print every response part to a stream",
+            Arrays.asList(
+                new String(entire.toByteArray(), StandardCharsets.UTF_8),
+                new String(headers.toByteArray(), StandardCharsets.UTF_8),
+                new String(content.toByteArray(), StandardCharsets.UTF_8)
+            ),
+            Matchers.contains(response, head, body)
         );
     }
 
@@ -86,6 +127,23 @@ final class RsPrintTest {
                         RsPrintTest.CRLF
                     )
                 )
+            )
+        );
+    }
+
+    /**
+     * Response printer referenced through its contract.
+     * @param body Response body
+     * @return Response printer
+     */
+    private static Printable response(final String body) {
+        return new RsPrint(
+            new RsSimple(
+                new IterableOf<>(
+                    "HTTP/1.1 200 OK",
+                    "Content-Type: text/plain; charset=UTF-8"
+                ),
+                body
             )
         );
     }


### PR DESCRIPTION
Add one shared `org.takes.Printable` production interface that declares the six existing printing operations with their current return types, parameters, and checked-I/O behavior. Make `RqPrint` and `RsPrint` implement that interface alongside `Text`, marking each existing printing operation as an override without changing serialization, validation, buffering, or stream ownership behavior. Use the shared contract rather than parallel request/response interfaces because the two classes already expose an identical operation set, while `Text` remains the composable representation used by current callers. `RqPrint` and `RsPrint` expose the same six public printing operations for a complete HTTP message, its head, and its body, either as a string or into an `OutputStream`. Although both decorators now implement Cactoos `Text`, only `asString()` belongs to that contract; the public `print`, `printHead`, and `printBody` overloads remain class-specific methods. This conflicts with the repository's documented architecture that components expose behavior through composable interfaces. The issue is limited to the two concrete decorators it identifies and does not call for a repository-wide object audit.

Testing: A request printer referenced as `Printable` renders the complete request, head, and body with the same CRLF boundaries and content as `RqPrint` does today; A response printer referenced as `Printable` renders the complete response, head, and body with the same status/header validation and UTF-8 output as `RsPrint` does today.

Fixes #1007
