### PR TITLE
refactor: replace Files.newXXX with Cactoos IO objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,14 +102,6 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <!--
-      @todo #880:30min Once Cactoos is updated to qulice >=0.18.5
-      remove all references to Files.newXXX static methods and
-      replace them with OO objects such as InputOf or OutputOf
-      depending on the need. See
-      https://github.com/yegor256/takes/pull/886#issuecomment-446030223
-      for details.
-      -->
       <version>0.61.1</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -15,8 +15,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +24,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.cactoos.Scalar;
+import org.cactoos.io.OutputStreamTo;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
@@ -242,10 +241,8 @@ public final class RqMtBase implements RqMultipart {
             RqMultipart.class.getName(), ".tmp"
         );
         try (
-            WritableByteChannel channel = Files.newByteChannel(
-                file.toPath(),
-                StandardOpenOption.READ,
-                StandardOpenOption.WRITE
+            WritableByteChannel channel = Channels.newChannel(
+                new OutputStreamTo(file)
             )
         ) {
             channel.write(

--- a/src/main/java/org/takes/rq/multipart/RqTemp.java
+++ b/src/main/java/org/takes/rq/multipart/RqTemp.java
@@ -7,8 +7,8 @@ package org.takes.rq.multipart;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import lombok.EqualsAndHashCode;
+import org.cactoos.io.InputStreamOf;
 import org.takes.Request;
 import org.takes.rq.RqLive;
 import org.takes.rq.RqWithHeader;
@@ -79,7 +79,7 @@ final class RqTemp extends RqWrap {
                 this.cached = new RqWithHeader(
                     new RqLive(
                         new TempInputStream(
-                            Files.newInputStream(this.file.toPath()),
+                            new InputStreamOf(this.file),
                             this.file
                         )
                     ),

--- a/src/test/java/org/takes/rq/TempInputStreamTest.java
+++ b/src/test/java/org/takes/rq/TempInputStreamTest.java
@@ -4,11 +4,12 @@
  */
 package org.takes.rq;
 
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
+import java.io.Writer;
+import org.cactoos.io.InputStreamOf;
+import org.cactoos.io.WriterTo;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -22,12 +23,12 @@ final class TempInputStreamTest {
     @Test
     void isAvailableForReading() throws IOException {
         final File file = File.createTempFile("tempfile-avail", ".tmp");
-        try (BufferedWriter out = Files.newBufferedWriter(file.toPath())) {
+        try (Writer out = new WriterTo(file)) {
             out.write("Temp file reading test");
         }
         try (
             InputStream body = new TempInputStream(
-                Files.newInputStream(file.toPath()), file
+                new InputStreamOf(file), file
             )
         ) {
             MatcherAssert.assertThat(
@@ -41,10 +42,10 @@ final class TempInputStreamTest {
     @Test
     void deletesTempFileOnClose() throws IOException {
         final File file = File.createTempFile("tempfile-delete", ".tmp");
-        try (BufferedWriter out = Files.newBufferedWriter(file.toPath())) {
+        try (Writer out = new WriterTo(file)) {
             out.write("Temp file deletion test");
         }
-        new TempInputStream(Files.newInputStream(file.toPath()), file).close();
+        new TempInputStream(new InputStreamOf(file), file).close();
         MatcherAssert.assertThat(
             "File exists after stream closure",
             file.exists(),

--- a/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtBaseTest.java
@@ -169,7 +169,7 @@ final class RqMtBaseTest {
 
     /**
      * Try to parse a multipart request that has no closing boundary.
-     *  Parsing is lazy, so {@code names()} is called to force it.
+     * Parsing is lazy, so {@code names()} is called to force it.
      * @throws Exception If fails
      */
     private static void parseWithoutClosingBoundary() throws Exception {

--- a/src/test/java/org/takes/rq/multipart/RqMtFakeTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtFakeTest.java
@@ -6,7 +6,6 @@ package org.takes.rq.multipart;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -14,7 +13,6 @@ import org.cactoos.list.ListOf;
 import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.takes.rq.RqFake;
@@ -149,13 +147,10 @@ final class RqMtFakeTest {
         final RqMtBase multi = RqMtFakeTest.closableMulti();
         multi.part("name").iterator().next().body().read();
         multi.body().close();
-        MatcherAssert.assertThat(
-            "Exception must be ClosedChannelException for name part",
-            Assertions.assertThrows(
-                IOException.class,
-                () -> multi.part("name").iterator().next().body().read()
-            ),
-            new IsInstanceOf(ClosedChannelException.class)
+        Assertions.assertThrows(
+            IOException.class,
+            () -> multi.part("name").iterator().next().body().read(),
+            "Reading the name part must fail after the body is closed"
         );
     }
 
@@ -164,13 +159,10 @@ final class RqMtFakeTest {
         final RqMtBase multi = RqMtFakeTest.closableMulti();
         multi.part("content").iterator().next().body().read();
         multi.body().close();
-        MatcherAssert.assertThat(
-            "Exception must be ClosedChannelException for content part",
-            Assertions.assertThrows(
-                IOException.class,
-                () -> multi.part("content").iterator().next().body().read()
-            ),
-            new IsInstanceOf(ClosedChannelException.class)
+        Assertions.assertThrows(
+            IOException.class,
+            () -> multi.part("content").iterator().next().body().read(),
+            "Reading the content part must fail after the body is closed"
         );
     }
 

--- a/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
+++ b/src/test/java/org/takes/rq/multipart/RqMtSmartTest.java
@@ -11,12 +11,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang.StringUtils;
 import org.cactoos.Text;
+import org.cactoos.io.InputStreamOf;
+import org.cactoos.io.WriterTo;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.text.Joined;
 import org.cactoos.text.UncheckedText;
@@ -236,7 +237,7 @@ final class RqMtSmartTest {
                 ""
             ).asString();
         final byte[] expected = new byte[length];
-        try (BufferedWriter bwr = Files.newBufferedWriter(file)) {
+        try (BufferedWriter bwr = new BufferedWriter(new WriterTo(file))) {
             bwr.write(head);
             for (int idx = 0; idx < length; ++idx) {
                 bwr.write(idx % the);
@@ -254,7 +255,7 @@ final class RqMtSmartTest {
                 ),
                 "Content-Type: multipart/form-data; boundary=zzz1"
             ),
-            new TempInputStream(Files.newInputStream(file), file.toFile())
+            new TempInputStream(new InputStreamOf(file), file.toFile())
         );
         try (
             InputStream stream = new RqMtSmart(
@@ -275,7 +276,7 @@ final class RqMtSmartTest {
         final Path temp, final int length, final String part
     ) throws IOException {
         final File file = temp.resolve("handlesRequestInTime.tmp").toFile();
-        try (BufferedWriter bwr = Files.newBufferedWriter(file.toPath())) {
+        try (BufferedWriter bwr = new BufferedWriter(new WriterTo(file))) {
             bwr.write(
                 new Joined(
                     RqMtSmartTest.CRLF,
@@ -303,7 +304,7 @@ final class RqMtSmartTest {
                 RqMtSmartTest.CONTENT_TYPE,
                 String.format("Content-Length:%s", file.length())
             ),
-            new TempInputStream(Files.newInputStream(file.toPath()), file)
+            new TempInputStream(new InputStreamOf(file), file)
         );
     }
 


### PR DESCRIPTION
Closes #1729.

Resolves the `880-32a00e91` puzzle from #880: the `@todo` in `pom.xml` asked to remove all references to the `java.nio.file.Files.newXXX` static methods and replace them with OO objects.

Changes:

* `RqTemp` builds the request body from `new InputStreamOf(file)` instead of `Files.newInputStream(file.toPath())`.
* `RqMtBase#make` writes the temporary part file through `Channels.newChannel(new OutputStreamTo(file))` instead of `Files.newByteChannel(path, READ, WRITE)`. The `READ` open option was never used — the channel is only written to and then closed.
* `TempInputStreamTest` and `RqMtSmartTest` write with `WriterTo` instead of `Files.newBufferedWriter`, and read with `InputStreamOf` instead of `Files.newInputStream`. The `BufferedWriter` wrapper is kept in `RqMtSmartTest`, where a million characters are written one at a time.
* The puzzle text is removed from `pom.xml`.

`grep -rn 'Files\.new' src/` now returns nothing.

### One behaviour change worth reviewing

`RqMtFakeTest` asserted that reading a part after the multipart body is closed throws `ClosedChannelException`. That subclass came from `Files.newInputStream` returning a channel-backed stream — nothing in `RqTemp` or `TempInputStream` documented it. Reading through `InputStreamOf` (a `FileInputStream` underneath) surfaces the plain `IOException: Stream Closed` instead. Both are `IOException`, which is what the `Request.body()` contract declares.

The two tests now assert the guarantee itself — reading a part fails once the body is closed — with the `Assertions.assertThrows(IOException.class, ...)` idiom the rest of that class already uses. If you would rather keep the exact `ClosedChannelException` type, say so and I will open the temp file through a `FileChannel` instead.

### Unrelated commit

`master` is currently red under `mvn -Pqulice`: a `JavadocNoIndentCheck` violation at `RqMtBaseTest.java:172`, introduced by #1098. It is a one-space Javadoc fix, kept in its own commit so it can be dropped if a fix lands on `master` first.

### Verification

Rebased onto `master` at 817259b. #1098 refactored `RqMtBase` to lazy `Scalar`/`Sticky` fields; the only conflict was the import block, and `make()` now combines both changes (`OutputStreamTo` channel + `new Unchecked<>(this.sbuffer).value()`).

`mvn test -DexcludedGroups=` — 665 tests, 0 failures, 5 skipped (the full suite including the `deep`-tagged tests, among them `notDistortContent`, which round-trips 1 MB through the rewritten multipart path). `mvn -Pqulice -DskipTests verify` is green.