### PR TITLE
refactor: use FormattedText instead of String.format

### DIFF
--- a/src/main/java/org/takes/HttpException.java
+++ b/src/main/java/org/takes/HttpException.java
@@ -5,6 +5,8 @@
 package org.takes;
 
 import java.io.IOException;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * HTTP-aware exception.
@@ -73,7 +75,11 @@ public class HttpException extends IOException {
         if (this.detail == null) {
             msg = Integer.toString(this.status);
         } else {
-            msg = String.format("[%03d] %s", this.status, this.detail);
+            msg = new UncheckedText(
+                new FormattedText(
+                    "[%03d] %s", this.status, this.detail
+                )
+            ).asString();
         }
         return msg;
     }

--- a/src/main/java/org/takes/facets/auth/PsAll.java
+++ b/src/main/java/org/takes/facets/auth/PsAll.java
@@ -6,6 +6,8 @@ package org.takes.facets.auth;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.misc.Opt;
@@ -64,16 +66,22 @@ public final class PsAll implements Pass {
     private void checkIndex() {
         if (this.index < 0) {
             throw new IllegalArgumentException(
-                String.format("Index %d must be >= 0.", this.index)
+                new UncheckedText(
+                    new FormattedText(
+                        "Index %d must be >= 0.", this.index
+                    )
+                ).asString()
             );
         }
         if (this.index >= this.all.size()) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Trying to return index %d from a list of %d passes",
-                    this.index,
-                    this.all.size()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Trying to return index %d from a list of %d passes",
+                        this.index,
+                        this.all.size()
+                    )
+                ).asString()
             );
         }
     }

--- a/src/main/java/org/takes/facets/auth/PsBasic.java
+++ b/src/main/java/org/takes/facets/auth/PsBasic.java
@@ -20,9 +20,11 @@ import lombok.EqualsAndHashCode;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Trimmed;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.facets.flash.RsFlash;
@@ -78,10 +80,12 @@ public final class PsBasic implements Pass {
         if (!headers.hasNext()) {
             throw new RsForward(
                 new RsWithHeader(
-                    String.format(
-                        "WWW-Authenticate: Basic realm=\"%s\" ",
-                        this.realm
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "WWW-Authenticate: Basic realm=\"%s\" ",
+                            this.realm
+                        )
+                    ).asString()
                 ),
                 HttpURLConnection.HTTP_UNAUTHORIZED,
                 new RqHref.Base(request).href()
@@ -105,10 +109,12 @@ public final class PsBasic implements Pass {
             throw new RsForward(
                 new RsWithHeader(
                     new RsFlash("access denied", Level.WARNING),
-                    String.format(
-                        "WWW-Authenticate: Basic realm=\"%s\"",
-                        this.realm
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "WWW-Authenticate: Basic realm=\"%s\"",
+                            this.realm
+                        )
+                    ).asString()
                 ),
                 HttpURLConnection.HTTP_UNAUTHORIZED,
                 new RqHref.Base(request).href()
@@ -170,7 +176,7 @@ public final class PsBasic implements Pass {
             if (this.condition) {
                 user = new Opt.Single<>(
                     new Identity.Simple(
-                        String.format("urn:basic:%s", usr)
+                        new UncheckedText(new FormattedText("urn:basic:%s", usr)).asString()
                     )
                 );
             } else {
@@ -286,11 +292,13 @@ public final class PsBasic implements Pass {
          */
         private Opt<String> urn(final String user, final String pwd) {
             final String urn = this.usernames.value().get(
-                String.format(
-                    PsBasic.Default.KEY_FORMAT,
-                    URLEncoder.encode(user, PsBasic.Default.ENCODING),
-                    URLEncoder.encode(pwd, PsBasic.Default.ENCODING)
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        PsBasic.Default.KEY_FORMAT,
+                        URLEncoder.encode(user, PsBasic.Default.ENCODING),
+                        URLEncoder.encode(pwd, PsBasic.Default.ENCODING)
+                    )
+                ).asString()
             );
             final Opt<String> opt;
             if (urn == null) {
@@ -310,14 +318,16 @@ public final class PsBasic implements Pass {
          *  <pre>+</pre>
          */
         private static String key(final String unified) {
-            return String.format(
-                PsBasic.Default.KEY_FORMAT,
-                unified.substring(0, unified.indexOf(' ')),
-                unified.substring(
-                    unified.indexOf(' ') + 1,
-                    unified.lastIndexOf(' ')
+            return new UncheckedText(
+                new FormattedText(
+                    PsBasic.Default.KEY_FORMAT,
+                    unified.substring(0, unified.indexOf(' ')),
+                    unified.substring(
+                        unified.indexOf(' ') + 1,
+                        unified.lastIndexOf(' ')
+                    )
                 )
-            );
+            ).asString();
         }
 
         /**
@@ -331,10 +341,12 @@ public final class PsBasic implements Pass {
                 unified.indexOf(' ') + 1 == unified.lastIndexOf(' ');
             if (amount || nearby) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "One of users was incorrectly formatted: %s",
-                        unified
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "One of users was incorrectly formatted: %s",
+                            unified
+                        )
+                    ).asString()
                 );
             }
         }

--- a/src/main/java/org/takes/facets/auth/PsToken.java
+++ b/src/main/java/org/takes/facets/auth/PsToken.java
@@ -18,6 +18,7 @@ import org.cactoos.scalar.Constant;
 import org.cactoos.scalar.FirstOf;
 import org.cactoos.scalar.Not;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.IsBlank;
 import org.cactoos.text.StartsWith;
 import org.cactoos.text.TextOf;
@@ -165,12 +166,14 @@ public final class PsToken implements Pass {
         tosign.put(jwtpayload);
         final byte[] sign = this.signature.sign(tosign.array());
         try (JsonReader reader = Json.createReader(res.body())) {
-            final String jwt = String.format(
-                "%s.%s.%s",
-                new String(jwtheader, Charset.defaultCharset()),
-                new String(jwtpayload, Charset.defaultCharset()),
-                new String(sign, Charset.defaultCharset())
-            );
+            final String jwt = new UncheckedText(
+                new FormattedText(
+                    "%s.%s.%s",
+                    new String(jwtheader, Charset.defaultCharset()),
+                    new String(jwtpayload, Charset.defaultCharset()),
+                    new String(sign, Charset.defaultCharset())
+                )
+            ).asString();
             return new RsJson(
                 Json.createObjectBuilder()
                     .add("response", reader.read())

--- a/src/main/java/org/takes/facets/auth/Token.java
+++ b/src/main/java/org/takes/facets/auth/Token.java
@@ -13,6 +13,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * JSON Token interface for creating and encoding authentication tokens.
@@ -68,7 +70,7 @@ public interface Token {
             this.joseo = new Unchecked<>(
                 new Sticky<>(
                     () -> Json.createObjectBuilder()
-                        .add(Token.Jose.ALGORITHM, String.format("HS%s", bitlength))
+                        .add(Token.Jose.ALGORITHM, Token.Jose.algo(bitlength))
                         .add(Token.Jose.TYPE, "JWT")
                         .build()
                 )
@@ -85,6 +87,17 @@ public interface Token {
             return Base64.getEncoder().encode(
                 this.joseo.value().toString().getBytes(Charset.defaultCharset())
             );
+        }
+
+        /**
+         * Name of the HMAC algorithm of the given strength.
+         * @param bitlength Of encryption bits
+         * @return The name, like {@code HS256}
+         */
+        private static String algo(final int bitlength) {
+            return new UncheckedText(
+                new FormattedText("HS%s", bitlength)
+            ).asString();
         }
     }
 

--- a/src/main/java/org/takes/facets/auth/codecs/CcAes.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcAes.java
@@ -21,6 +21,8 @@ import javax.crypto.spec.SecretKeySpec;
 import lombok.EqualsAndHashCode;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.facets.auth.Identity;
 
 /**
@@ -200,10 +202,12 @@ public final class CcAes implements Codec {
     private static byte[] withCorrectBlockSize(final byte[] key) {
         if (key.length != CcAes.BLOCK) {
             throw new IllegalArgumentException(
-                String.format(
-                    "the length of the AES key must be exactly %d bytes",
-                    CcAes.BLOCK
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "the length of the AES key must be exactly %d bytes",
+                        CcAes.BLOCK
+                    )
+                ).asString()
             );
         }
         return key;

--- a/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcBase64.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.facets.auth.Identity;
 
 /**
@@ -67,10 +69,12 @@ public final class CcBase64 implements Codec {
         final byte[] illegal = CcBase64.checkIllegalCharacters(bytes);
         if (illegal.length > 0) {
             throw new DecodingException(
-                String.format(
-                    "Illegal character in Base64 encoded data. %s",
-                    Arrays.toString(illegal)
+                new UncheckedText(
+                    new FormattedText(
+                        "Illegal character in Base64 encoded data. %s",
+                        Arrays.toString(illegal)
                     )
+                ).asString()
                 );
         }
         return this.origin.decode(Base64.getDecoder().decode(bytes));

--- a/src/main/java/org/takes/facets/auth/codecs/CcHex.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcHex.java
@@ -7,6 +7,8 @@ package org.takes.facets.auth.codecs;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.facets.auth.Identity;
 
 /**
@@ -119,13 +121,13 @@ public final class CcHex implements Codec {
     private static int decode(final int hex) {
         if (hex >= CcHex.BACK.length) {
             throw new DecodingException(
-                String.format("invalid hex char: 0x%2x", hex)
+                new UncheckedText(new FormattedText("invalid hex char: 0x%2x", hex)).asString()
             );
         }
         final int dec = CcHex.BACK[hex];
         if (dec < 0) {
             throw new DecodingException(
-                String.format("invalid hex character: 0x%2x", hex)
+                new UncheckedText(new FormattedText("invalid hex character: 0x%2x", hex)).asString()
             );
         }
         return dec;

--- a/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcSalted.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Random;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.facets.auth.Identity;
 
 /**
@@ -103,18 +105,22 @@ public final class CcSalted implements Codec {
         final int size = text[0];
         if (size < 0) {
             throw new DecodingException(
-                String.format(
-                    "Length of salt %+d is negative, something is wrong",
-                    size
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Length of salt %+d is negative, something is wrong",
+                        size
+                    )
+                ).asString()
             );
         }
         if (text.length < size + 2) {
             throw new DecodingException(
-                String.format(
-                    "Not enough bytes for salt, length is %d while %d required",
-                    text.length, size + 2
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Not enough bytes for salt, length is %d while %d required",
+                        text.length, size + 2
+                    )
+                ).asString()
             );
         }
         byte sum = (byte) 0;
@@ -123,10 +129,12 @@ public final class CcSalted implements Codec {
         }
         if (text[text.length - 1] != sum) {
             throw new DecodingException(
-                String.format(
-                    "Checksum %d failure, while %d expected",
-                    text[text.length - 1], sum
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Checksum %d failure, while %d expected",
+                        text[text.length - 1], sum
+                    )
+                ).asString()
             );
         }
         final byte[] output = new byte[text.length - size - 2];

--- a/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
+++ b/src/main/java/org/takes/facets/auth/codecs/CcStrict.java
@@ -6,6 +6,8 @@ package org.takes.facets.auth.codecs;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.facets.auth.Identity;
 
 /**
@@ -78,7 +80,7 @@ public final class CcStrict implements Codec {
             }
             if (!CcStrict.PTN.matcher(urn).matches()) {
                 throw new DecodingException(
-                    String.format("urn isn't valid: \"%s\"", urn)
+                    new UncheckedText(new FormattedText("urn isn't valid: \"%s\"", urn)).asString()
                 );
             }
         }

--- a/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
+++ b/src/main/java/org/takes/facets/auth/signatures/SiHmac.java
@@ -11,6 +11,8 @@ import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * An HMAC signature implementation that supports 256, 384, and 512-bit hash variants.
@@ -112,7 +114,11 @@ public final class SiHmac implements Signature {
      * @throws IOException If MAC creation fails
      */
     private Mac create() throws IOException {
-        final String algo = String.format("HmacSHA%s", this.bitlength());
+        final String algo = new UncheckedText(
+            new FormattedText(
+                "HmacSHA%s", this.bitlength()
+            )
+        ).asString();
         try {
             final Mac mac = Mac.getInstance(algo);
             mac.init(new SecretKeySpec(this.key, algo));

--- a/src/main/java/org/takes/facets/auth/social/PsFacebook.java
+++ b/src/main/java/org/takes/facets/auth/social/PsFacebook.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import org.cactoos.Text;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.Split;
 import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
@@ -144,7 +145,7 @@ public final class PsFacebook implements Pass {
         );
         return new Opt.Single<>(
             new Identity.Simple(
-                String.format("urn:facebook:%s", user.getId()),
+                new UncheckedText(new FormattedText("urn:facebook:%s", user.getId())).asString(),
                 props
             )
         );
@@ -202,7 +203,11 @@ public final class PsFacebook implements Pass {
             final String[] pair = sector.split("=", 2);
             if (pair.length != 2) {
                 throw new IllegalArgumentException(
-                    String.format("Invalid response: '%s'", response)
+                    new UncheckedText(
+                        new FormattedText(
+                            "Invalid response: '%s'", response
+                        )
+                    ).asString()
                 );
             }
             if ("access_token".equals(pair[0])) {
@@ -210,10 +215,12 @@ public final class PsFacebook implements Pass {
             }
         }
         throw new IllegalArgumentException(
-            String.format(
-                "Access token not found in response: '%s'",
-                response
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "Access token not found in response: '%s'",
+                    response
+                )
+            ).asString()
         );
     }
 }

--- a/src/main/java/org/takes/facets/auth/social/PsGithub.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGithub.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -124,7 +126,7 @@ public final class PsGithub implements Pass {
         return PsGithub.parse(
             new JdkRequest(new Href(this.api).path("user").toString())
                 .header("accept", "application/json")
-                .header("Authorization", String.format("token %s", token))
+                .header("Authorization", PsGithub.authorization(token))
                 .fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .as(JsonResponse.class)
@@ -164,6 +166,17 @@ public final class PsGithub implements Pass {
     }
 
     /**
+     * Value of the {@code Authorization} header for the given token.
+     * @param token GitHub access token
+     * @return The header value
+     */
+    private static String authorization(final String token) {
+        return new UncheckedText(
+            new FormattedText("token %s", token)
+        ).asString();
+    }
+
+    /**
      * Make identity from JSON object.
      * @param json JSON received from Github
      * @return Identity found
@@ -173,7 +186,11 @@ public final class PsGithub implements Pass {
         props.put(PsGithub.LOGIN, json.getString(PsGithub.LOGIN, "unknown"));
         props.put("avatar", json.getString("avatar_url", "#"));
         return new Identity.Simple(
-            String.format("urn:github:%d", json.getInt("id")), props
+            new UncheckedText(
+                new FormattedText(
+                    "urn:github:%d", json.getInt("id")
+                )
+            ).asString(), props
         );
     }
 }

--- a/src/main/java/org/takes/facets/auth/social/PsGoogle.java
+++ b/src/main/java/org/takes/facets/auth/social/PsGoogle.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -158,10 +160,12 @@ public final class PsGoogle implements Pass {
         if (json.containsKey(PsGoogle.ERROR)) {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,
-                String.format(
-                    "could not retrieve id from Google, possible cause: %s.",
-                    json.getJsonObject(PsGoogle.ERROR).get("message")
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "could not retrieve id from Google, possible cause: %s.",
+                        json.getJsonObject(PsGoogle.ERROR).get("message")
+                    )
+                ).asString()
             );
         }
         return PsGoogle.parse(json);
@@ -212,7 +216,11 @@ public final class PsGoogle implements Pass {
             PsGoogle.NAME, json.getString(PsGoogle.DISPLAY_NAME, "unknown")
         );
         return new Identity.Simple(
-            String.format("urn:google:%s", json.getString("id")), props
+            new UncheckedText(
+                new FormattedText(
+                    "urn:google:%s", json.getString("id")
+                )
+            ).asString(), props
         );
     }
 }

--- a/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
+++ b/src/main/java/org/takes/facets/auth/social/PsLinkedin.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -166,7 +168,11 @@ public final class PsLinkedin implements Pass {
         props.put(fname, json.getString(fname, unknown));
         props.put(lname, json.getString(lname, unknown));
         return new Identity.Simple(
-            String.format("urn:linkedin:%s", json.getString("id")), props
+            new UncheckedText(
+                new FormattedText(
+                    "urn:linkedin:%s", json.getString("id")
+                )
+            ).asString(), props
         );
     }
 }

--- a/src/main/java/org/takes/facets/auth/social/PsTwitter.java
+++ b/src/main/java/org/takes/facets/auth/social/PsTwitter.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import lombok.EqualsAndHashCode;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.facets.auth.Identity;
@@ -144,7 +146,7 @@ public final class PsTwitter implements Pass {
         props.put(PsTwitter.NAME, json.getString(PsTwitter.NAME));
         props.put("picture", json.getString("profile_image_url"));
         return new Identity.Simple(
-            String.format("urn:twitter:%d", json.getInt("id")),
+            new UncheckedText(new FormattedText("urn:twitter:%d", json.getInt("id"))).asString(),
             props
         );
     }
@@ -160,15 +162,21 @@ public final class PsTwitter implements Pass {
             "application/x-www-form-urlencoded;charset=UTF-8"
         ).header(
             "Authorization",
-            String.format(
-                "Basic %s", DatatypeConverter.printBase64Binary(
-                    new UncheckedBytes(
-                        new BytesOf(
-                            String.format("%s:%s", this.app, this.key)
+            new UncheckedText(
+                new FormattedText(
+                    "Basic %s", DatatypeConverter.printBase64Binary(
+                        new UncheckedBytes(
+                            new BytesOf(
+                                new UncheckedText(
+                                    new FormattedText(
+                                        "%s:%s", this.app, this.key
+                                    )
+                                ).asString()
+                            )
+                        ).asBytes()
                         )
-                    ).asBytes()
-                    )
                 )
+            ).asString()
             )
             .fetch().as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)

--- a/src/main/java/org/takes/facets/cookies/RsWithCookie.java
+++ b/src/main/java/org/takes/facets/cookies/RsWithCookie.java
@@ -12,6 +12,8 @@ import lombok.ToString;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 import org.takes.rs.RsEmpty;
 import org.takes.rs.RsWithHeader;
@@ -101,7 +103,7 @@ public final class RsWithCookie extends RsWrap {
     private static String make(final CharSequence name,
         final CharSequence value, final CharSequence... attrs) {
         final StringBuilder text = new StringBuilder(
-            String.format("%s=%s;", name, value)
+            new UncheckedText(new FormattedText("%s=%s;", name, value)).asString()
         );
         for (final CharSequence attr : attrs) {
             text.append(attr).append(';');
@@ -117,10 +119,12 @@ public final class RsWithCookie extends RsWrap {
     private static CharSequence validValue(final CharSequence value) {
         if (!RsWithCookie.CVALUE_PTRN.matcher(value).matches()) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Cookie value \"%s\" contains invalid characters",
-                    value
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Cookie value \"%s\" contains invalid characters",
+                        value
+                    )
+                ).asString()
             );
         }
         return value;
@@ -134,10 +138,12 @@ public final class RsWithCookie extends RsWrap {
     private static CharSequence validName(final CharSequence name) {
         if (!RsWithCookie.CNAME_PTRN.matcher(name).matches()) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Cookie name \"%s\" contains invalid characters",
-                    name
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Cookie name \"%s\" contains invalid characters",
+                        name
+                    )
+                ).asString()
             );
         }
         return name;

--- a/src/main/java/org/takes/facets/fallback/FbStatus.java
+++ b/src/main/java/org/takes/facets/fallback/FbStatus.java
@@ -9,6 +9,8 @@ import lombok.EqualsAndHashCode;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 import org.takes.Take;
 import org.takes.misc.Opt;
@@ -53,12 +55,14 @@ public final class FbStatus extends FbWrap {
                 new RsWithType(
                     new RsWithBody(
                         res,
-                        String.format(
-                            "%s: %s", FbStatus.WHITESPACE.split(
-                                res.head().iterator().next(),
-                                2
-                            )[1], req.throwable().getLocalizedMessage()
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "%s: %s", FbStatus.WHITESPACE.split(
+                                    res.head().iterator().next(),
+                                    2
+                                )[1], req.throwable().getLocalizedMessage()
+                            )
+                        ).asString()
                     ), "text/plain"
                 )
             );

--- a/src/main/java/org/takes/facets/fallback/TkFallback.java
+++ b/src/main/java/org/takes/facets/fallback/TkFallback.java
@@ -10,6 +10,8 @@ import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -70,10 +72,12 @@ public final class TkFallback extends TkWrap {
             );
             if (!fbres.has()) {
                 throw new IOException(
-                    String.format(
-                        "There is no fallback available in %s",
-                        fbk.getClass().getCanonicalName()
-                    ),
+                    new UncheckedText(
+                        new FormattedText(
+                            "There is no fallback available in %s",
+                            fbk.getClass().getCanonicalName()
+                        )
+                    ).asString(),
                     TkFallback.error(ex, req, start)
                 );
             }
@@ -88,11 +92,13 @@ public final class TkFallback extends TkWrap {
             );
             if (!fbres.has()) {
                 throw new IOException(
-                    String.format(
-                        "There is no fallback available for %s in %s",
-                        ex.getClass().getCanonicalName(),
-                        fbk.getClass().getCanonicalName()
-                    ),
+                    new UncheckedText(
+                        new FormattedText(
+                            "There is no fallback available for %s in %s",
+                            ex.getClass().getCanonicalName(),
+                            fbk.getClass().getCanonicalName()
+                        )
+                    ).asString(),
                     TkFallback.error(ex, req, start)
                 );
             }
@@ -226,20 +232,24 @@ public final class TkFallback extends TkWrap {
         final String time;
         final long msec = System.currentTimeMillis() - start;
         if (msec < TimeUnit.SECONDS.toMillis(1L)) {
-            time = String.format("%dms", msec);
+            time = new UncheckedText(new FormattedText("%dms", msec)).asString();
         } else {
-            time = String.format(
-                "%ds",
-                msec / TimeUnit.SECONDS.toMillis(1L)
-            );
+            time = new UncheckedText(
+                new FormattedText(
+                    "%ds",
+                    msec / TimeUnit.SECONDS.toMillis(1L)
+                )
+            ).asString();
         }
         return new IllegalStateException(
-            String.format(
-                "[%s %s] failed in %s: %s",
-                new RqMethod.Base(req).method(),
-                new RqHref.Base(req).href(),
-                time, TkFallback.msg(exp)
-            ),
+            new UncheckedText(
+                new FormattedText(
+                    "[%s %s] failed in %s: %s",
+                    new RqMethod.Base(req).method(),
+                    new RqHref.Base(req).href(),
+                    time, TkFallback.msg(exp)
+                )
+            ).asString(),
             exp
         );
     }

--- a/src/main/java/org/takes/facets/flash/RsFlash.java
+++ b/src/main/java/org/takes/facets/flash/RsFlash.java
@@ -273,12 +273,14 @@ public final class RsFlash extends RsWrap {
 
     @Override
     public String toString() {
-        return String.format(
-            "%s(super=%s, text=%s)",
-            RsFlash.class.getSimpleName(),
-            super.toString(),
-            new UncheckedText(this.text).asString()
-        );
+        return new UncheckedText(
+            new FormattedText(
+                "%s(super=%s, text=%s)",
+                RsFlash.class.getSimpleName(),
+                super.toString(),
+                new UncheckedText(this.text).asString()
+            )
+        ).asString();
     }
 
     /**

--- a/src/main/java/org/takes/facets/fork/FkHitRefresh.java
+++ b/src/main/java/org/takes/facets/fork/FkHitRefresh.java
@@ -15,6 +15,8 @@ import lombok.EqualsAndHashCode;
 import org.cactoos.io.OutputTo;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.ScalarOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -62,7 +64,11 @@ public final class FkHitRefresh implements Fork {
                     new ProcessBuilder().command(cmd).start();
                 } catch (final IOException ex) {
                     throw new IllegalStateException(
-                        String.format("Failed to run command '%s'", cmd),
+                        new UncheckedText(
+                            new FormattedText(
+                                "Failed to run command '%s'", cmd
+                            )
+                        ).asString(),
                         ex
                     );
                 }

--- a/src/main/java/org/takes/facets/fork/RqRegex.java
+++ b/src/main/java/org/takes/facets/fork/RqRegex.java
@@ -7,6 +7,8 @@ package org.takes.facets.fork;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.regex.Matcher;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 
 /**
@@ -63,11 +65,13 @@ public interface RqRegex extends Request {
         public Matcher matcher() {
             if (!this.mtr.matches()) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "%s doesn't match %s",
-                        this.request,
-                        this.mtr.pattern()
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "%s doesn't match %s",
+                            this.request,
+                            this.mtr.pattern()
+                        )
+                    ).asString()
                 );
             }
             return this.mtr;

--- a/src/main/java/org/takes/facets/forward/RsForward.java
+++ b/src/main/java/org/takes/facets/forward/RsForward.java
@@ -10,6 +10,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.HttpURLConnection;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Response;
 import org.takes.rs.RsEmpty;
@@ -248,10 +250,12 @@ public class RsForward extends HttpException implements Response {
 
         @Override
         public String toString() {
-            return String.format(
-                "[%3d] %s %s",
-                this.code, this.loc, this.res
-            );
+            return new UncheckedText(
+                new FormattedText(
+                    "[%3d] %s %s",
+                    this.code, this.loc, this.res
+                )
+            ).asString();
         }
     }
 }

--- a/src/main/java/org/takes/facets/ret/RsReturn.java
+++ b/src/main/java/org/takes/facets/ret/RsReturn.java
@@ -14,6 +14,8 @@ import lombok.ToString;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 import org.takes.facets.cookies.RsWithCookie;
 import org.takes.misc.Expires;
@@ -72,10 +74,12 @@ public final class RsReturn extends RsWrap {
     private static String validLocation(final String loc) throws IOException {
         if (!RsReturn.LOC_PTRN.matcher(loc).matches()) {
             throw new IOException(
-                String.format(
-                    "Location \"%s\" should complain RFC 3987",
-                    loc
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Location \"%s\" should complain RFC 3987",
+                        loc
+                    )
+                ).asString()
             );
         }
         return loc;

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -13,6 +13,8 @@ import java.net.Socket;
 import lombok.EqualsAndHashCode;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputStreamOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -165,18 +167,30 @@ public final class BkBasic implements Back {
         final Socket socket) {
         return new RqWithHeaders(
             req,
-            String.format(
-                "%s: %s",
-                BkBasic.LOCALADDR,
-                socket.getLocalAddress().getHostAddress()
-            ),
-            String.format("%s: %d", BkBasic.LOCALPORT, socket.getLocalPort()),
-            String.format(
-                "%s: %s",
-                BkBasic.REMOTEADDR,
-                socket.getInetAddress().getHostAddress()
-            ),
-            String.format("%s: %d", BkBasic.REMOTEPORT, socket.getPort())
+            new UncheckedText(
+                new FormattedText(
+                    "%s: %s",
+                    BkBasic.LOCALADDR,
+                    socket.getLocalAddress().getHostAddress()
+                )
+            ).asString(),
+            new UncheckedText(
+                new FormattedText(
+                    "%s: %d", BkBasic.LOCALPORT, socket.getLocalPort()
+                )
+            ).asString(),
+            new UncheckedText(
+                new FormattedText(
+                    "%s: %s",
+                    BkBasic.REMOTEADDR,
+                    socket.getInetAddress().getHostAddress()
+                )
+            ).asString(),
+            new UncheckedText(
+                new FormattedText(
+                    "%s: %d", BkBasic.REMOTEPORT, socket.getPort()
+                )
+            ).asString()
         );
     }
 }

--- a/src/main/java/org/takes/http/BkParallel.java
+++ b/src/main/java/org/takes/http/BkParallel.java
@@ -12,6 +12,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Parallel back-end decorator.
@@ -110,11 +112,13 @@ public final class BkParallel extends BkWrap {
         public Thread newThread(final Runnable runnable) {
             final Thread thread = new Thread(runnable);
             thread.setName(
-                String.format(
-                    "%s-%d",
-                    BkParallel.class.getSimpleName(),
-                    this.total.getAndAdd(1)
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s-%d",
+                        BkParallel.class.getSimpleName(),
+                        this.total.getAndAdd(1)
+                    )
+                ).asString()
             );
             return thread;
         }

--- a/src/main/java/org/takes/http/FtRemote.java
+++ b/src/main/java/org/takes/http/FtRemote.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Take;
 
 /**
@@ -137,10 +139,12 @@ public final class FtRemote implements Front {
         }
         script.exec(
             URI.create(
-                String.format(
-                    "%s://localhost:%d",
-                    protocol, this.socket.getLocalPort()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s://localhost:%d",
+                        protocol, this.socket.getLocalPort()
+                    )
+                ).asString()
             )
         );
         exit.set(true);

--- a/src/main/java/org/takes/http/MainRemote.java
+++ b/src/main/java/org/takes/http/MainRemote.java
@@ -15,8 +15,10 @@ import lombok.EqualsAndHashCode;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.InputOf;
 import org.cactoos.number.NumberOf;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Trimmed;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Main method remote control.
@@ -72,14 +74,20 @@ public final class MainRemote {
         final File file = File.createTempFile("takes-", ".txt");
         if (!file.delete()) {
             throw new IOException(
-                String.format(
-                    "The temporary file '%s' could not be deleted before calling the exec method",
-                    file.getAbsolutePath()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "The temporary file '%s' could not be deleted before calling the exec method",
+                        file.getAbsolutePath()
+                    )
+                ).asString()
             );
         }
         final String[] passed = new String[1 + this.args.length];
-        passed[0] = String.format("--port=%s", file.getAbsoluteFile());
+        passed[0] = new UncheckedText(
+            new FormattedText(
+                "--port=%s", file.getAbsoluteFile()
+            )
+        ).asString();
         for (int idx = 0; idx < this.args.length; ++idx) {
             passed[idx + 1] = this.args[idx];
         }
@@ -93,20 +101,24 @@ public final class MainRemote {
         try {
             script.exec(
                 URI.create(
-                    String.format(
-                        "http://localhost:%d",
-                        MainRemote.port(file)
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "http://localhost:%d",
+                            MainRemote.port(file)
+                        )
+                    ).asString()
                 )
             );
         } catch (final IOException ex) {
             if (!file.delete()) {
                 ex.addSuppressed(
                     new IOException(
-                        String.format(
-                            "The temporary file '%s' could not be deleted while catching the error",
-                            file.getAbsolutePath()
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "The temporary file '%s' could not be deleted while catching the error",
+                                file.getAbsolutePath()
+                            )
+                        ).asString()
                     )
                 );
             }
@@ -116,10 +128,12 @@ public final class MainRemote {
         }
         if (!file.delete()) {
             throw new IOException(
-                String.format(
-                    "The temporary file '%s' could not be deleted after calling the exec method",
-                    file.getAbsolutePath()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "The temporary file '%s' could not be deleted after calling the exec method",
+                        file.getAbsolutePath()
+                    )
+                ).asString()
             );
         }
     }
@@ -197,17 +211,21 @@ public final class MainRemote {
                 this.method.invoke(null, (Object) this.passed);
             } catch (final InvocationTargetException ex) {
                 throw new IllegalStateException(
-                    String.format(
-                        "The %s method has been invoked at an illegal time.",
-                        this.method.getName()
-                    ), ex
+                    new UncheckedText(
+                        new FormattedText(
+                            "The %s method has been invoked at an illegal time.",
+                            this.method.getName()
+                        )
+                    ).asString(), ex
                 );
             } catch (final IllegalAccessException ex) {
                 throw new IllegalStateException(
-                    String.format(
-                        "The visibility of the %s method do not allow access.",
-                        this.method.getName()
-                    ), ex
+                    new UncheckedText(
+                        new FormattedText(
+                            "The visibility of the %s method do not allow access.",
+                            this.method.getName()
+                        )
+                    ).asString(), ex
                 );
             }
         }

--- a/src/main/java/org/takes/http/Options.java
+++ b/src/main/java/org/takes/http/Options.java
@@ -17,6 +17,8 @@ import lombok.EqualsAndHashCode;
 import org.cactoos.io.ReaderOf;
 import org.cactoos.io.WriterTo;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Command-line options.
@@ -156,7 +158,11 @@ final class Options {
             final Matcher matcher = ptn.matcher(arg);
             if (!matcher.matches()) {
                 throw new IllegalStateException(
-                    String.format("Can't parse this argument: '%s'", arg)
+                    new UncheckedText(
+                        new FormattedText(
+                            "Can't parse this argument: '%s'", arg
+                        )
+                    ).asString()
                 );
             }
             final String value = matcher.group(2);

--- a/src/main/java/org/takes/package-info.java
+++ b/src/main/java/org/takes/package-info.java
@@ -19,8 +19,5 @@
  * @see <a href="https://github.com/yegor256/takes">GitHub project</a>
  * @see <a href="http://www.yegor256.com/2015/03/22/takes-java-web-framework.html">Java Web App Architecture In Takes Framework</a>
  * @see <a href="https://en.wikipedia.org/wiki/Takes_(framework)">wikipedia about Takes framework</a>
- * @todo #998:30min Replace the usage of String#format
- *  in the project and leverage {@link org.cactoos.text.FormattedText} decorator
- *  as it is an elegant object-oriented way.
  */
 package org.takes;

--- a/src/main/java/org/takes/rq/ChunkedInputStream.java
+++ b/src/main/java/org/takes/rq/ChunkedInputStream.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import org.cactoos.scalar.Ternary;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.Sub;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Trimmed;
@@ -124,13 +125,15 @@ final class ChunkedInputStream extends InputStream {
         final int lfsymbol = this.origin.read();
         if (crsymbol != '\r' || lfsymbol != '\n') {
             throw new IOException(
-                String.format(
-                    "%s %d%s%d",
-                    "CRLF expected at end of chunk: ",
-                    crsymbol,
-                    "/",
-                    lfsymbol
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s %d%s%d",
+                        "CRLF expected at end of chunk: ",
+                        crsymbol,
+                        "/",
+                        lfsymbol
+                    )
+                ).asString()
             );
         }
     }
@@ -180,10 +183,12 @@ final class ChunkedInputStream extends InputStream {
             );
         } catch (final NumberFormatException ex) {
             throw new IOException(
-                String.format(
-                    "Bad chunk size: %s",
-                    baos.toString(Charset.defaultCharset())
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Bad chunk size: %s",
+                        baos.toString(Charset.defaultCharset())
+                    )
+                ).asString(),
                 ex
             );
         }
@@ -248,11 +253,13 @@ final class ChunkedInputStream extends InputStream {
         } else if (state == State.R) {
             if (next != '\n') {
                 throw new IOException(
-                    String.format(
-                        "%s%s",
-                        "Protocol violation: Unexpected",
-                        " single newline character in chunk size"
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "%s%s",
+                            "Protocol violation: Unexpected",
+                            " single newline character in chunk size"
+                        )
+                    ).asString()
                 );
             }
             result = State.END;

--- a/src/main/java/org/takes/rq/RqEmpty.java
+++ b/src/main/java/org/takes/rq/RqEmpty.java
@@ -6,6 +6,8 @@ package org.takes.rq;
 
 import lombok.EqualsAndHashCode;
 import org.cactoos.io.InputStreamOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Empty HTTP request implementation for testing purposes.
@@ -82,7 +84,11 @@ public final class RqEmpty extends RqWrap {
             if (index != 0) {
                 throw new IndexOutOfBoundsException(index);
             }
-            return String.format("%s %s", this.method, this.query);
+            return new UncheckedText(
+                new FormattedText(
+                    "%s %s", this.method, this.query
+                )
+            ).asString();
         }
 
         @Override

--- a/src/main/java/org/takes/rq/RqFake.java
+++ b/src/main/java/org/takes/rq/RqFake.java
@@ -11,6 +11,8 @@ import lombok.EqualsAndHashCode;
 import org.cactoos.Text;
 import org.cactoos.io.InputStreamOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Fake HTTP request implementation for testing purposes.
@@ -140,7 +142,11 @@ public final class RqFake extends RqWrap {
         public String get(final int index) {
             final String line;
             if (index == 0) {
-                line = String.format("%s %s", this.method, this.query);
+                line = new UncheckedText(
+                    new FormattedText(
+                        "%s %s", this.method, this.query
+                    )
+                ).asString();
             } else if (index == 1) {
                 line = "Host: www.example.com";
             } else {

--- a/src/main/java/org/takes/rq/RqHeaders.java
+++ b/src/main/java/org/takes/rq/RqHeaders.java
@@ -130,10 +130,12 @@ public interface RqHeaders extends Request {
                 if (parts.length < 2) {
                     throw new HttpException(
                         HttpURLConnection.HTTP_BAD_REQUEST,
-                        String.format(
-                            "Invalid HTTP header on line #%d: \"%s\"",
-                            pos, line
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "Invalid HTTP header on line #%d: \"%s\"",
+                                pos, line
+                            )
+                        ).asString()
                     );
                 }
                 final String key = new UncheckedText(
@@ -215,10 +217,12 @@ public interface RqHeaders extends Request {
             if (!params.hasNext()) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        "Header \"%s\" is mandatory, not found among %s",
-                        name, this.names()
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "Header \"%s\" is mandatory, not found among %s",
+                            name, this.names()
+                        )
+                    ).asString()
                 );
             }
             return params.next();

--- a/src/main/java/org/takes/rq/RqHref.java
+++ b/src/main/java/org/takes/rq/RqHref.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.util.Iterator;
 import lombok.EqualsAndHashCode;
 import org.cactoos.Text;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Trimmed;
 import org.cactoos.text.UncheckedText;
@@ -76,12 +77,14 @@ public interface RqHref extends Request {
                 proto = new TextOf("http");
             }
             return new Href(
-                String.format(
-                    "%s://%s%s",
-                    new UncheckedText(proto).asString(),
-                    new UncheckedText(host).asString(),
-                    new RqRequestLine.Base(this).uri()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s://%s%s",
+                        new UncheckedText(proto).asString(),
+                        new UncheckedText(host).asString(),
+                        new RqRequestLine.Base(this).uri()
+                    )
+                ).asString()
             );
         }
     }
@@ -142,11 +145,13 @@ public interface RqHref extends Request {
         public Href home() throws IOException {
             final URI full = URI.create(this.href().toString());
             return new Href(
-                String.format(
-                    "%s://%s/",
-                    full.getScheme(),
-                    full.getHost()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s://%s/",
+                        full.getScheme(),
+                        full.getHost()
+                    )
+                ).asString()
             );
         }
 
@@ -161,9 +166,11 @@ public interface RqHref extends Request {
             if (!params.hasNext()) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        "query param \"%s\" is mandatory", name
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "query param \"%s\" is mandatory", name
+                        )
+                    ).asString()
                 );
             }
             return params.next();

--- a/src/main/java/org/takes/rq/RqLengthAware.java
+++ b/src/main/java/org/takes/rq/RqLengthAware.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 
 /**
@@ -60,11 +62,13 @@ public final class RqLengthAware extends RqWrap {
                 result = new CapInputStream(req.body(), Long.parseLong(value));
             } catch (final NumberFormatException ex) {
                 throw new IOException(
-                    String.format(
-                        "Invalid %s header: %s",
-                        RqLengthAware.CONTENT_LENGTH,
-                        value
-                    ),
+                    new UncheckedText(
+                        new FormattedText(
+                            "Invalid %s header: %s",
+                            RqLengthAware.CONTENT_LENGTH,
+                            value
+                        )
+                    ).asString(),
                     ex
                 );
             }

--- a/src/main/java/org/takes/rq/RqLive.java
+++ b/src/main/java/org/takes/rq/RqLive.java
@@ -146,12 +146,14 @@ public final class RqLive extends RqWrap {
             && data.get() != '\t') {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,
-                String.format(
-                    "illegal character 0x%02X in HTTP header line #%d: \"%s\"",
-                    data.get(),
-                    position,
-                    new TextOf(baos.toByteArray())
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "illegal character 0x%02X in HTTP header line #%d: \"%s\"",
+                        data.get(),
+                        position,
+                        new TextOf(baos.toByteArray())
+                    )
+                ).asString()
             );
         }
         return data.get();

--- a/src/main/java/org/takes/rq/RqMethod.java
+++ b/src/main/java/org/takes/rq/RqMethod.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 
 /**
@@ -106,7 +108,11 @@ public interface RqMethod extends Request {
                 .method();
             if (Base.SEPARATORS.matcher(method).find()) {
                 throw new IOException(
-                    String.format("Invalid HTTP method: %s", method)
+                    new UncheckedText(
+                        new FormattedText(
+                            "Invalid HTTP method: %s", method
+                        )
+                    ).asString()
                 );
             }
             return method.toUpperCase(Locale.ENGLISH);

--- a/src/main/java/org/takes/rq/RqRequestLine.java
+++ b/src/main/java/org/takes/rq/RqRequestLine.java
@@ -12,9 +12,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.Trimmed;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 
@@ -205,10 +207,12 @@ public interface RqRequestLine extends Request {
             if (!valid) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        RqRequestLine.Base.BAD_REQUEST_MSG,
-                        line
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            RqRequestLine.Base.BAD_REQUEST_MSG,
+                            line
+                        )
+                    ).asString()
                 );
             }
             return matcher;
@@ -237,10 +241,12 @@ public interface RqRequestLine extends Request {
             final RqRequestLine.Base.Token token) throws IOException {
             if (value == null) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "There is no token %s in Request-Line header",
-                        token.toString()
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "There is no token %s in Request-Line header",
+                            token.toString()
+                        )
+                    ).asString()
                 );
             }
             return new IoCheckedText(
@@ -281,10 +287,12 @@ public interface RqRequestLine extends Request {
                         ) {
                             throw new HttpException(
                                 HttpURLConnection.HTTP_BAD_REQUEST,
-                                String.format(
-                                    RqRequestLine.Base.BAD_REQUEST_MSG,
-                                    value
-                                ),
+                                new UncheckedText(
+                                    new FormattedText(
+                                        RqRequestLine.Base.BAD_REQUEST_MSG,
+                                        value
+                                    )
+                                ).asString(),
                                 err
                             );
                         }
@@ -320,7 +328,7 @@ public interface RqRequestLine extends Request {
                     Character.toChars(point)
                 ).getBytes(StandardCharsets.UTF_8)) {
                     text.append('%').append(
-                        String.format("%02X", octet & 0xFF)
+                        new UncheckedText(new FormattedText("%02X", octet & 0xFF)).asString()
                     );
                 }
                 return text.toString();

--- a/src/main/java/org/takes/rq/RqWithHeader.java
+++ b/src/main/java/org/takes/rq/RqWithHeader.java
@@ -6,6 +6,8 @@ package org.takes.rq;
 
 import lombok.EqualsAndHashCode;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 
 /**
@@ -86,7 +88,7 @@ public final class RqWithHeader extends RqWrap {
 
         @Override
         public String toString() {
-            return String.format("%s: %s", this.name, this.value);
+            return new UncheckedText(new FormattedText("%s: %s", this.name, this.value)).asString();
         }
     }
 }

--- a/src/main/java/org/takes/rq/form/RqFormBase.java
+++ b/src/main/java/org/takes/rq/form/RqFormBase.java
@@ -131,9 +131,11 @@ public final class RqFormBase extends RqWrap implements RqForm {
             if (parts.length < 2) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        "invalid form body pair: %s", pair
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "invalid form body pair: %s", pair
+                        )
+                    ).asString()
                 );
             }
             final String key = RqFormBase.decode(new Lowered(parts[0]));

--- a/src/main/java/org/takes/rq/form/RqFormSmart.java
+++ b/src/main/java/org/takes/rq/form/RqFormSmart.java
@@ -9,6 +9,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.Iterator;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.rq.RqForm;
@@ -76,9 +78,11 @@ public final class RqFormSmart implements RqForm {
         if (!params.hasNext()) {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,
-                String.format(
-                    "form param \"%s\" is mandatory", name
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "form param \"%s\" is mandatory", name
+                    )
+                ).asString()
             );
         }
         return params.next();

--- a/src/main/java/org/takes/rq/multipart/RqMtBase.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtBase.java
@@ -183,20 +183,24 @@ public final class RqMtBase implements RqMultipart {
         if (!multipart.value()) {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,
-                String.format(
-                    "RqMtBase can only parse multipart/form-data, while Content-Type specifies a different type: \"%s\"",
-                    header
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "RqMtBase can only parse multipart/form-data, while Content-Type specifies a different type: \"%s\"",
+                        header
+                    )
+                ).asString()
             );
         }
         final Matcher matcher = RqMtBase.BOUNDARY.matcher(header);
         if (!matcher.matches()) {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,
-                String.format(
-                    "boundary is not specified in Content-Type header: \"%s\"",
-                    header
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "boundary is not specified in Content-Type header: \"%s\"",
+                        header
+                    )
+                ).asString()
             );
         }
         final ReadableByteChannel body = Channels.newChannel(
@@ -209,9 +213,11 @@ public final class RqMtBase implements RqMultipart {
                 "failed to read the request body"
             );
         }
-        final byte[] boundary = String.format(
-            "%s--%s", RqMtBase.CRLF, matcher.group(1)
-        ).getBytes(RqMtBase.ENCODING);
+        final byte[] boundary = new UncheckedText(
+            new FormattedText(
+                "%s--%s", RqMtBase.CRLF, matcher.group(1)
+            )
+        ).asString().getBytes(RqMtBase.ENCODING);
         buf.flip();
         buf.position(boundary.length - 2);
         final Collection<Request> requests = new ArrayList<>(0);
@@ -279,10 +285,12 @@ public final class RqMtBase implements RqMultipart {
             if (!matcher.matches()) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        "\"name\" not found in Content-Disposition header: %s",
-                        header
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "\"name\" not found in Content-Disposition header: %s",
+                            header
+                        )
+                    ).asString()
                 );
             }
             final String name = matcher.group(1);

--- a/src/main/java/org/takes/rq/multipart/RqMtFake.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtFake.java
@@ -13,6 +13,8 @@ import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Body;
 import org.takes.Request;
 import org.takes.rq.RequestOf;
@@ -106,16 +108,20 @@ public final class RqMtFake implements RqMultipart {
                 new RequestOf(
                     () -> new RqWithHeaders(
                         rqst,
-                        String.format(
-                            "Content-Type: multipart/form-data; boundary=%s",
-                            RqMtFake.BOUNDARY
-                        ),
-                        String.format(
-                            "Content-Length: %s",
-                            new Unchecked<>(
-                                new LengthOf(new InputOf(body.body()))
-                            ).value()
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "Content-Type: multipart/form-data; boundary=%s",
+                                RqMtFake.BOUNDARY
+                            )
+                        ).asString(),
+                        new UncheckedText(
+                            new FormattedText(
+                                "Content-Length: %s",
+                                new Unchecked<>(
+                                    new LengthOf(new InputOf(body.body()))
+                                ).value()
+                            )
+                        ).asString()
                     ).head(),
                     body
                 )
@@ -157,11 +163,17 @@ public final class RqMtFake implements RqMultipart {
          */
         private static String assemble(final Request... parts)
             throws IOException {
+            final String opening = new UncheckedText(
+                new FormattedText("--%s", RqMtFake.BOUNDARY)
+            ).asString();
+            final String closing = new UncheckedText(
+                new FormattedText("--%s--", RqMtFake.BOUNDARY)
+            ).asString();
             final StringBuilder builder = new StringBuilder(128);
             for (final Request part : parts) {
                 final String disposition = new RqHeaders.Smart(part)
                     .single("Content-Disposition");
-                builder.append(String.format("--%s", RqMtFake.BOUNDARY))
+                builder.append(opening)
                     .append(RqMtFake.CRLF)
                     .append("Content-Disposition: ")
                     .append(disposition)
@@ -175,7 +187,7 @@ public final class RqMtFake implements RqMultipart {
             }
             builder.append("Content-Transfer-Encoding: utf-8")
                 .append(RqMtFake.CRLF)
-                .append(String.format("--%s--", RqMtFake.BOUNDARY));
+                .append(closing);
             return builder.toString();
         }
     }

--- a/src/main/java/org/takes/rq/multipart/RqMtSmart.java
+++ b/src/main/java/org/takes/rq/multipart/RqMtSmart.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.Iterator;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.rq.RqMultipart;
@@ -51,9 +53,11 @@ public final class RqMtSmart implements RqMultipart {
         if (!parts.hasNext()) {
             throw new HttpException(
                 HttpURLConnection.HTTP_BAD_REQUEST,
-                String.format(
-                    "form param \"%s\" is mandatory", name
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "form param \"%s\" is mandatory", name
+                    )
+                ).asString()
             );
         }
         return parts.next();

--- a/src/main/java/org/takes/rs/RsBody.java
+++ b/src/main/java/org/takes/rs/RsBody.java
@@ -19,6 +19,8 @@ import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Interface for response body content used by {@link RsWithBody}.
@@ -253,11 +255,13 @@ interface RsBody extends Input {
                     () -> {
                         final File file = new File(
                             System.getProperty("java.io.tmpdir"),
-                            String.format(
-                                "%s-%s.tmp",
-                                RsBody.TempFile.class.getName(),
-                                UUID.randomUUID().toString()
-                            )
+                            new UncheckedText(
+                                new FormattedText(
+                                    "%s-%s.tmp",
+                                    RsBody.TempFile.class.getName(),
+                                    UUID.randomUUID().toString()
+                                )
+                            ).asString()
                         );
                         file.deleteOnExit();
                         return file;

--- a/src/main/java/org/takes/rs/RsHeaders.java
+++ b/src/main/java/org/takes/rs/RsHeaders.java
@@ -136,10 +136,12 @@ public interface RsHeaders extends Response {
                 if (parts.length < 2) {
                     throw new HttpException(
                         HttpURLConnection.HTTP_BAD_REQUEST,
-                        String.format(
-                            "Invalid HTTP header on line #%d: \"%s\"",
-                            pos, line
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "Invalid HTTP header on line #%d: \"%s\"",
+                                pos, line
+                            )
+                        ).asString()
                     );
                 }
                 final String key = new UncheckedText(
@@ -221,10 +223,12 @@ public interface RsHeaders extends Response {
             if (!params.hasNext()) {
                 throw new HttpException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    String.format(
-                        "Header \"%s\" is mandatory, not found among %s",
-                        name, this.names()
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "Header \"%s\" is mandatory, not found among %s",
+                            name, this.names()
+                        )
+                    ).asString()
                 );
             }
             return params.next();

--- a/src/main/java/org/takes/rs/RsPrint.java
+++ b/src/main/java/org/takes/rs/RsPrint.java
@@ -15,6 +15,8 @@ import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.cactoos.Text;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 
 /**
@@ -121,18 +123,22 @@ public final class RsPrint extends RsWrap implements Text {
         for (final String line : this.head()) {
             if (pos == 0 && !RsPrint.FIRST.matcher(line).matches()) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "First line of HTTP response \"%s\" doesn't match \"%s\" regular expression, but it should, according to RFC 7230",
-                        line, RsPrint.FIRST
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "First line of HTTP response \"%s\" doesn't match \"%s\" regular expression, but it should, according to RFC 7230",
+                            line, RsPrint.FIRST
+                        )
+                    ).asString()
                 );
             }
             if (pos > 0 && !RsPrint.OTHERS.matcher(line).matches()) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "Header line #%d of HTTP response \"%s\" doesn't match \"%s\" regular expression, but it should, according to RFC 7230",
-                        pos + 1, line, RsPrint.OTHERS
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "Header line #%d of HTTP response \"%s\" doesn't match \"%s\" regular expression, but it should, according to RFC 7230",
+                            pos + 1, line, RsPrint.OTHERS
+                        )
+                    ).asString()
                 );
             }
             writer.append(line);

--- a/src/main/java/org/takes/rs/RsStatus.java
+++ b/src/main/java/org/takes/rs/RsStatus.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 
 /**
@@ -67,9 +69,11 @@ public interface RsStatus extends Response {
             final Matcher matcher = RsStatus.Base.LINE.matcher(line);
             if (!matcher.matches()) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "Invalid status line: '%s'", line
-                    )
+                    new UncheckedText(
+                        new FormattedText(
+                            "Invalid status line: '%s'", line
+                        )
+                    ).asString()
                 );
             }
             return Integer.parseInt(matcher.group(1));

--- a/src/main/java/org/takes/rs/RsWithHeader.java
+++ b/src/main/java/org/takes/rs/RsWithHeader.java
@@ -10,6 +10,8 @@ import lombok.ToString;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.iterable.Joined;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 
 /**
@@ -107,10 +109,12 @@ public final class RsWithHeader extends RsWrap {
         final String header) {
         if (!RsWithHeader.HEADER.matcher(header).matches()) {
             throw new IllegalArgumentException(
-                String.format(
-                    "header line of HTTP response \"%s\" doesn't match \"%s\" regular expression, but it should, according to RFC 7230",
-                    header, RsWithHeader.HEADER
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "header line of HTTP response \"%s\" doesn't match \"%s\" regular expression, but it should, according to RFC 7230",
+                        header, RsWithHeader.HEADER
+                    )
+                ).asString()
             );
         }
         return new Joined<String>(head, new IterableOf<>(header));
@@ -159,7 +163,7 @@ public final class RsWithHeader extends RsWrap {
 
         @Override
         public String toString() {
-            return String.format("%s: %s", this.name, this.value);
+            return new UncheckedText(new FormattedText("%s: %s", this.name, this.value)).asString();
         }
     }
 }

--- a/src/main/java/org/takes/rs/RsWithStatus.java
+++ b/src/main/java/org/takes/rs/RsWithStatus.java
@@ -19,6 +19,7 @@ import org.cactoos.scalar.Not;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.StartsWith;
 import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 
 /**
@@ -89,10 +90,12 @@ public final class RsWithStatus extends RsWrap {
         final int status, final CharSequence reason) throws IOException {
         if (status < 100 || status > 999) {
             throw new IllegalArgumentException(
-                String.format(
-                    "According to RFC 7230 HTTP status code must have three digits: %d",
-                    status
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "According to RFC 7230 HTTP status code must have three digits: %d",
+                        status
+                    )
+                ).asString()
             );
         }
         return new Mapped<>(

--- a/src/main/java/org/takes/rs/RsWithType.java
+++ b/src/main/java/org/takes/rs/RsWithType.java
@@ -9,6 +9,8 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 import org.takes.misc.Opt;
 
@@ -99,12 +101,14 @@ public final class RsWithType extends RsWrap {
             response = new RsWithHeader(
                 new RsWithoutHeader(res, RsWithType.HEADER),
                 RsWithType.HEADER,
-                String.format(
-                    "%s; %s=%s",
-                    type,
-                    RsWithType.CHARSET,
-                    charset.get().name()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s; %s=%s",
+                        type,
+                        RsWithType.CHARSET,
+                        charset.get().name()
+                    )
+                ).asString()
             );
         } else {
             response = new RsWithHeader(

--- a/src/main/java/org/takes/rs/RsXslt.java
+++ b/src/main/java/org/takes/rs/RsXslt.java
@@ -25,6 +25,8 @@ import org.cactoos.io.InputStreamOf;
 import org.cactoos.io.ReaderOf;
 import org.cactoos.io.WriterTo;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Response;
 
 /**
@@ -96,10 +98,12 @@ public final class RsXslt extends RsWrap {
                     rsp::head,
                     () -> RsXslt.transform(rsp.body(), resolver)
                 ),
-                () -> String.format(
-                    "X-Takes-RsXslt-TransformerFactory: %s",
-                    RsXslt.factory(resolver).getClass().getCanonicalName()
-                )
+                () -> new UncheckedText(
+                    new FormattedText(
+                        "X-Takes-RsXslt-TransformerFactory: %s",
+                        RsXslt.factory(resolver).getClass().getCanonicalName()
+                    )
+                ).asString()
             )
         );
     }
@@ -143,10 +147,12 @@ public final class RsXslt extends RsWrap {
             return RsXslt.transform(fct, origin);
         } catch (final TransformerException ex) {
             throw new IOException(
-                String.format(
-                    "Can't transform via %s",
-                    fct.getClass().getName()
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Can't transform via %s",
+                        fct.getClass().getName()
+                    )
+                ).asString(),
                 ex
             );
         }
@@ -239,11 +245,13 @@ public final class RsXslt extends RsWrap {
         final Transformer tnfr = factory.newTransformer(stylesheet);
         if (tnfr == null) {
             throw new TransformerConfigurationException(
-                String.format(
-                    "%s failed to create new XSL transformer for '%s'",
-                    factory.getClass(),
-                    stylesheet.getSystemId()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%s failed to create new XSL transformer for '%s'",
+                        factory.getClass(),
+                        stylesheet.getSystemId()
+                    )
+                ).asString()
             );
         }
         return tnfr;
@@ -270,7 +278,11 @@ public final class RsXslt extends RsWrap {
                     input = uri.toURL().openStream();
                 } catch (final IOException ex) {
                     throw new IllegalStateException(
-                        String.format("Failed to open URL '%s'", uri),
+                        new UncheckedText(
+                            new FormattedText(
+                                "Failed to open URL '%s'", uri
+                            )
+                        ).asString(),
                         ex
                     );
                 }
@@ -278,10 +290,12 @@ public final class RsXslt extends RsWrap {
                 input = this.getClass().getResourceAsStream(uri.getPath());
                 if (input == null) {
                     throw new TransformerException(
-                        String.format(
-                            "\"%s\" not found in classpath, base=\"%s\"",
-                            href, base
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "\"%s\" not found in classpath, base=\"%s\"",
+                                href, base
+                            )
+                        ).asString()
                     );
                 }
             }

--- a/src/main/java/org/takes/rs/xe/RsXembly.java
+++ b/src/main/java/org/takes/rs/xe/RsXembly.java
@@ -22,6 +22,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.cactoos.io.WriterTo;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.rs.ResponseOf;
 import org.takes.rs.RsEmpty;
 import org.takes.rs.RsWithStatus;
@@ -175,11 +177,13 @@ public final class RsXembly extends RsWrap {
             return result.getNode();
         } catch (final TransformerException ex) {
             throw new IllegalArgumentException(
-                String.format(
-                    "Could not clone Node %s with Transformer %s",
-                    source,
-                    transformer
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Could not clone Node %s with Transformer %s",
+                        source,
+                        transformer
+                    )
+                ).asString(),
                 ex
             );
         }

--- a/src/main/java/org/takes/rs/xe/XeMillis.java
+++ b/src/main/java/org/takes/rs/xe/XeMillis.java
@@ -5,6 +5,8 @@
 package org.takes.rs.xe;
 
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -80,10 +82,12 @@ public final class XeMillis implements XeSource {
         final Directives dirs = new Directives();
         if (this.finish) {
             dirs.xpath(this.name.toString()).strict(1).xset(
-                String.format(
-                    "%d - number(text())",
-                    System.currentTimeMillis()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%d - number(text())",
+                        System.currentTimeMillis()
+                    )
+                ).asString()
             );
         } else {
             dirs.add(this.name.toString())

--- a/src/main/java/org/takes/rs/xe/XeSla.java
+++ b/src/main/java/org/takes/rs/xe/XeSla.java
@@ -7,6 +7,8 @@ package org.takes.rs.xe;
 import java.lang.management.ManagementFactory;
 import java.util.Locale;
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.xembly.Directives;
 
 /**
@@ -51,12 +53,14 @@ public final class XeSla extends XeWrap {
         super(
             () -> new Directives().attr(
                 attr.toString(),
-                String.format(
-                    Locale.US,
-                    "%.3f",
-                    ManagementFactory.getOperatingSystemMXBean()
-                        .getSystemLoadAverage()
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "%.3f",
+                        Locale.US,
+                        ManagementFactory.getOperatingSystemMXBean()
+                            .getSystemLoadAverage()
+                    )
+                ).asString()
             )
         );
     }

--- a/src/main/java/org/takes/rs/xe/XeStylesheet.java
+++ b/src/main/java/org/takes/rs/xe/XeStylesheet.java
@@ -5,6 +5,8 @@
 package org.takes.rs.xe;
 
 import lombok.EqualsAndHashCode;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.xembly.Directives;
 
 /**
@@ -38,7 +40,7 @@ public final class XeStylesheet extends XeWrap {
         super(
             () -> new Directives().pi(
                 "xml-stylesheet",
-                String.format("href='%s' type='text/xsl'", xsl)
+                new UncheckedText(new FormattedText("href='%s' type='text/xsl'", xsl)).asString()
             )
         );
     }

--- a/src/main/java/org/takes/servlet/HttpServletRequestFake.java
+++ b/src/main/java/org/takes/servlet/HttpServletRequestFake.java
@@ -31,6 +31,8 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.rq.RqHeaders;
 import org.takes.rq.RqHref;
@@ -84,30 +86,12 @@ public final class HttpServletRequestFake implements HttpServletRequest {
 
     @Override
     public String getHeader(final String key) {
-        final Enumeration<String> headers = this.getHeaders(key);
-        if (!headers.hasMoreElements()) {
-            throw new NoSuchElementException(
-                String.format(
-                    "Value of header %s not found",
-                    key
-                )
-            );
-        }
-        return headers.nextElement();
+        return new HttpServletRequestFake.Header(this.request, key).first();
     }
 
     @Override
     public Enumeration<String> getHeaders(final String key) {
-        try {
-            return Collections.enumeration(
-                new RqHeaders.Base(this.request).header(key)
-            );
-        } catch (final IOException ex) {
-            throw new IllegalArgumentException(
-                String.format("Failed to read header '%s'", key),
-                ex
-            );
-        }
+        return new HttpServletRequestFake.Header(this.request, key).all();
     }
 
     @Override
@@ -192,17 +176,9 @@ public final class HttpServletRequestFake implements HttpServletRequest {
 
     @Override
     public String getQueryString() {
-        final String raw = this.getRequestURI();
-        final URI uri;
-        try {
-            uri = new URI(raw);
-        } catch (final URISyntaxException ex) {
-            throw new IllegalStateException(
-                String.format("Failed to parse URI '%s'", raw),
-                ex
-            );
-        }
-        return uri.getQuery();
+        return new HttpServletRequestFake.Address(
+            this.getRequestURI()
+        ).query();
     }
 
     @Override
@@ -212,40 +188,16 @@ public final class HttpServletRequestFake implements HttpServletRequest {
 
     @Override
     public String getServerName() {
-        final String raw = this.getRequestURI();
-        final URI uri;
-        try {
-            uri = new URI(raw);
-        } catch (final URISyntaxException ex) {
-            throw new IllegalStateException(
-                String.format("Failed to parse URI '%s'", raw),
-                ex
-            );
-        }
-        String host = uri.getHost();
-        if (host == null || host.isEmpty()) {
-            host = "localhost";
-        }
-        return host;
+        return new HttpServletRequestFake.Address(
+            this.getRequestURI()
+        ).host();
     }
 
     @Override
     public int getServerPort() {
-        final String raw = this.getRequestURI();
-        final URI uri;
-        try {
-            uri = new URI(raw);
-        } catch (final URISyntaxException ex) {
-            throw new IllegalStateException(
-                String.format("Failed to parse URI '%s'", raw),
-                ex
-            );
-        }
-        int port = uri.getPort();
-        if (port == -1) {
-            port = 80;
-        }
-        return port;
+        return new HttpServletRequestFake.Address(
+            this.getRequestURI()
+        ).port();
     }
 
     @Override
@@ -545,5 +497,142 @@ public final class HttpServletRequestFake implements HttpServletRequest {
     @Override
     public DispatcherType getDispatcherType() {
         throw new UnsupportedOperationException("#getDispatcherType()");
+    }
+
+    /**
+     * A single header of the request, by its name.
+     * @since 2.0
+     */
+    private static final class Header {
+
+        /**
+         * The request to read from.
+         */
+        private final Request request;
+
+        /**
+         * Name of the header.
+         */
+        private final String key;
+
+        /**
+         * Ctor.
+         * @param req The request
+         * @param name Name of the header
+         */
+        Header(final Request req, final String name) {
+            this.request = req;
+            this.key = name;
+        }
+
+        /**
+         * All values of it.
+         * @return The values
+         */
+        Enumeration<String> all() {
+            try {
+                return Collections.enumeration(
+                    new RqHeaders.Base(this.request).header(this.key)
+                );
+            } catch (final IOException ex) {
+                throw new IllegalArgumentException(
+                    new UncheckedText(
+                        new FormattedText(
+                            "Failed to read header '%s'", this.key
+                        )
+                    ).asString(),
+                    ex
+                );
+            }
+        }
+
+        /**
+         * The first value of it.
+         * @return The value
+         */
+        String first() {
+            final Enumeration<String> values = this.all();
+            if (!values.hasMoreElements()) {
+                throw new NoSuchElementException(
+                    new UncheckedText(
+                        new FormattedText(
+                            "Value of header %s not found", this.key
+                        )
+                    ).asString()
+                );
+            }
+            return values.nextElement();
+        }
+    }
+
+    /**
+     * The URI of the request, parsed from its raw form.
+     * @since 2.0
+     */
+    private static final class Address {
+
+        /**
+         * Raw URI, as it arrived in the request line.
+         */
+        private final String raw;
+
+        /**
+         * Ctor.
+         * @param uri Raw URI
+         */
+        Address(final String uri) {
+            this.raw = uri;
+        }
+
+        /**
+         * Query string of it.
+         * @return The query, may be NULL
+         */
+        String query() {
+            return this.value().getQuery();
+        }
+
+        /**
+         * Host of it.
+         * @return The host, {@code localhost} if absent
+         */
+        String host() {
+            String host = this.value().getHost();
+            if (host == null || host.isEmpty()) {
+                host = "localhost";
+            }
+            return host;
+        }
+
+        /**
+         * Port of it.
+         * @return The port, {@code 80} if absent
+         */
+        int port() {
+            int port = this.value().getPort();
+            if (port == -1) {
+                port = 80;
+            }
+            return port;
+        }
+
+        /**
+         * Parse it.
+         * @return The URI
+         */
+        private URI value() {
+            try {
+                return new URI(this.raw);
+            } catch (final URISyntaxException ex) {
+                throw new IllegalStateException(
+                    new UncheckedText(
+                        new FormattedText(
+                            "Failed to parse URI '%s'", this.raw
+                        )
+                    ).asString(),
+                    ex
+                );
+            }
+        }
     }
 }

--- a/src/main/java/org/takes/servlet/HttpServletResponseFake.java
+++ b/src/main/java/org/takes/servlet/HttpServletResponseFake.java
@@ -21,9 +21,9 @@ import org.cactoos.iterable.Filtered;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.Lowered;
 import org.cactoos.text.StartsWith;
-import org.cactoos.text.TextOf;
 import org.takes.Response;
 import org.takes.facets.cookies.RsWithCookie;
 import org.takes.rs.RsWithHeader;
@@ -135,7 +135,7 @@ public final class HttpServletResponseFake implements HttpServletResponse {
             new Filtered<>(
                 hdr -> new StartsWith(
                     new Lowered(hdr),
-                    new TextOf(String.format("%s", new Lowered(header)))
+                    new FormattedText("%s", new Lowered(header))
                 ).value(),
                 head
             )

--- a/src/main/java/org/takes/servlet/RqFrom.java
+++ b/src/main/java/org/takes/servlet/RqFrom.java
@@ -10,6 +10,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 
 /**
@@ -63,24 +65,30 @@ final class RqFrom implements Request {
         }
         names.forEach(
             header -> head.add(
-                String.format(
-                    "%s: %s",
-                    header,
-                    this.sreq.getHeader(header)
+                new UncheckedText(
+                    new FormattedText(
+                        "%s: %s",
+                        header,
+                        this.sreq.getHeader(header)
+                    )
+                ).asString()
+            )
+        );
+        head.add(
+            new UncheckedText(
+                new FormattedText(
+                    "X-Takes-LocalAddress: %s",
+                    this.sreq.getLocalAddr()
                 )
-            )
+            ).asString()
         );
         head.add(
-            String.format(
-                "X-Takes-LocalAddress: %s",
-                this.sreq.getLocalAddr()
-            )
-        );
-        head.add(
-            String.format(
-                "X-Takes-RemoteAddress: %s",
-                this.sreq.getRemoteAddr()
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "X-Takes-RemoteAddress: %s",
+                    this.sreq.getRemoteAddr()
+                )
+            ).asString()
         );
         return head;
     }

--- a/src/main/java/org/takes/servlet/SrvTake.java
+++ b/src/main/java/org/takes/servlet/SrvTake.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicReference;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Take;
 
@@ -87,10 +89,12 @@ public final class SrvTake extends HttpServlet {
             cls = Class.forName(cname);
         } catch (final ClassNotFoundException err) {
             throw new ServletException(
-                String.format(
-                    "Class %s was not found",
-                    cname
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Class %s was not found",
+                        cname
+                    )
+                ).asString(),
                 err
             );
         }
@@ -100,34 +104,42 @@ public final class SrvTake extends HttpServlet {
                 .newInstance(this.getServletContext());
         } catch (final InstantiationException err) {
             throw new ServletException(
-                String.format(
-                    "Can't construct %s class",
-                    cls.getCanonicalName()
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Can't construct %s class",
+                        cls.getCanonicalName()
+                    )
+                ).asString(),
                 err
             );
         } catch (final IllegalAccessException err) {
             throw new ServletException(
-                String.format(
-                    "Constructor %s(ServletContext) is private",
-                    cls.getCanonicalName()
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Constructor %s(ServletContext) is private",
+                        cls.getCanonicalName()
+                    )
+                ).asString(),
                 err
             );
         } catch (final InvocationTargetException err) {
             throw new ServletException(
-                String.format(
-                    "Error during instantiating %s",
-                    cls.getCanonicalName()
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Error during instantiating %s",
+                        cls.getCanonicalName()
+                    )
+                ).asString(),
                 err
             );
         } catch (final NoSuchMethodException err) {
             throw new ServletException(
-                String.format(
-                    "Constructor %s(ServletContext) was not found",
-                    cls.getCanonicalName()
-                ),
+                new UncheckedText(
+                    new FormattedText(
+                        "Constructor %s(ServletContext) was not found",
+                        cls.getCanonicalName()
+                    )
+                ).asString(),
                 err
             );
         }

--- a/src/main/java/org/takes/tk/TkClasspath.java
+++ b/src/main/java/org/takes/tk/TkClasspath.java
@@ -9,6 +9,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Request;
 import org.takes.Response;
@@ -95,20 +97,45 @@ public final class TkClasspath extends TkWrap {
             new Take() {
                 @Override
                 public Response act(final Request request) throws IOException {
-                    final String name = String.format(
-                        "%s%s", prefix, new RqHref.Base(request).href().path()
-                    );
+                    final String name = TkClasspath.resource(prefix, request);
                     final InputStream input = this.getClass()
                         .getResourceAsStream(name);
                     if (input == null) {
                         throw new HttpException(
                             HttpURLConnection.HTTP_NOT_FOUND,
-                            String.format("%s not found in classpath", name)
+                            TkClasspath.missing(name)
                         );
                     }
                     return new RsWithBody(input);
                 }
             }
         );
+    }
+
+    /**
+     * Name of the classpath resource the request asks for.
+     * @param prefix Classpath prefix
+     * @param request The request
+     * @return The name
+     * @throws IOException If fails
+     */
+    private static String resource(final String prefix, final Request request)
+        throws IOException {
+        return new UncheckedText(
+            new FormattedText(
+                "%s%s", prefix, new RqHref.Base(request).href().path()
+            )
+        ).asString();
+    }
+
+    /**
+     * Message about a resource that is absent in the classpath.
+     * @param name Name of the resource
+     * @return The message
+     */
+    private static String missing(final String name) {
+        return new UncheckedText(
+            new FormattedText("%s not found in classpath", name)
+        ).asString();
     }
 }

--- a/src/main/java/org/takes/tk/TkCors.java
+++ b/src/main/java/org/takes/tk/TkCors.java
@@ -10,6 +10,8 @@ import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -113,10 +115,12 @@ public final class TkCors implements Take {
                 this.origin.act(req),
                 "Access-Control-Allow-Credentials: true",
                 "Access-Control-Allow-Methods: OPTIONS, GET, PUT, POST, DELETE, HEAD",
-                String.format(
-                    "Access-Control-Allow-Origin: %s",
-                    domain
-                )
+                new UncheckedText(
+                    new FormattedText(
+                        "Access-Control-Allow-Origin: %s",
+                        domain
+                    )
+                ).asString()
             );
         } else {
             response = new RsWithHeaders(

--- a/src/main/java/org/takes/tk/TkFiles.java
+++ b/src/main/java/org/takes/tk/TkFiles.java
@@ -9,6 +9,8 @@ import java.net.HttpURLConnection;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.cactoos.io.InputOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.rq.RqHref;
 import org.takes.rs.RsWithBody;
@@ -92,9 +94,11 @@ public final class TkFiles extends TkWrap {
                 if (!file.exists()) {
                     throw new HttpException(
                         HttpURLConnection.HTTP_NOT_FOUND,
-                        String.format(
-                            "%s not found", file.getAbsolutePath()
-                        )
+                        new UncheckedText(
+                            new FormattedText(
+                                "%s not found", file.getAbsolutePath()
+                            )
+                        ).asString()
                     );
                 }
                 return new RsWithBody(new InputOf(file).stream());

--- a/src/main/java/org/takes/tk/TkProxy.java
+++ b/src/main/java/org/takes/tk/TkProxy.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.Lowered;
 import org.cactoos.text.UncheckedText;
 import org.takes.Request;
@@ -132,10 +133,12 @@ public final class TkProxy implements Take {
         final com.jcabi.http.Response rsp) {
         final Collection<String> hdrs = new ArrayList<>(0);
         hdrs.add(
-            String.format(
-                "X-Takes-TkProxy: from %s to %s by %s",
-                home, dest, this.label
-            )
+            new UncheckedText(
+                new FormattedText(
+                    "X-Takes-TkProxy: from %s to %s by %s",
+                    home, dest, this.label
+                )
+            ).asString()
         );
         for (final Map.Entry<String, List<String>> entry
             : rsp.headers().entrySet()) {
@@ -146,7 +149,11 @@ public final class TkProxy implements Take {
                 } else {
                     val = value;
                 }
-                hdrs.add(String.format("%s: %s", entry.getKey(), val));
+                hdrs.add(
+                    new UncheckedText(
+                        new FormattedText("%s: %s", entry.getKey(), val)
+                    ).asString()
+                );
             }
         }
         return new RsWithStatus(

--- a/src/main/java/org/takes/tk/TkRetry.java
+++ b/src/main/java/org/takes/tk/TkRetry.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -69,16 +71,18 @@ public final class TkRetry implements Take {
             }
         }
         throw new IOException(
-            String.format(
-                "failed after %d attempts: %s",
-                failures.size(),
-                new ListOf<>(
-                    new Mapped<>(
-                        Exception::getMessage,
-                        failures
+            new UncheckedText(
+                new FormattedText(
+                    "failed after %d attempts: %s",
+                    failures.size(),
+                    new ListOf<>(
+                        new Mapped<>(
+                            Exception::getMessage,
+                            failures
+                        )
                     )
                 )
-            ),
+            ).asString(),
             failures.get(failures.size() - 1)
         );
     }

--- a/src/main/java/org/takes/tk/TkVerbose.java
+++ b/src/main/java/org/takes/tk/TkVerbose.java
@@ -6,6 +6,8 @@ package org.takes.tk;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.HttpException;
 import org.takes.Take;
 import org.takes.rq.RqHref;
@@ -34,11 +36,13 @@ public final class TkVerbose extends TkWrap {
                 } catch (final HttpException ex) {
                     throw new HttpException(
                         ex.code(),
-                        String.format(
-                            "%s %s",
-                            new RqMethod.Base(request).method(),
-                            new RqHref.Base(request).href()
-                        ),
+                        new UncheckedText(
+                            new FormattedText(
+                                "%s %s",
+                                new RqMethod.Base(request).method(),
+                                new RqHref.Base(request).href()
+                            )
+                        ).asString(),
                         ex
                     );
                 }

--- a/src/main/java/org/takes/tk/TkVersioned.java
+++ b/src/main/java/org/takes/tk/TkVersioned.java
@@ -7,6 +7,8 @@ package org.takes.tk;
 import java.util.ResourceBundle;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Take;
 import org.takes.rs.RsWithHeader;
 
@@ -100,11 +102,13 @@ public final class TkVersioned extends TkWrap {
     private static String make() {
         final ResourceBundle res =
             ResourceBundle.getBundle("org.takes.version");
-        return String.format(
-            "%s %s %s",
-            res.getString("version"),
-            res.getString("revision"),
-            res.getString("date")
-        );
+        return new UncheckedText(
+            new FormattedText(
+                "%s %s %s",
+                res.getString("version"),
+                res.getString("revision"),
+                res.getString("date")
+            )
+        ).asString();
     }
 }

--- a/src/main/java/org/takes/tk/TkWithHeader.java
+++ b/src/main/java/org/takes/tk/TkWithHeader.java
@@ -6,6 +6,8 @@ package org.takes.tk;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
 import org.takes.Take;
 import org.takes.rs.RsWithHeader;
 
@@ -127,7 +129,7 @@ public final class TkWithHeader extends TkWrap {
 
         @Override
         public String toString() {
-            return String.format("%s: %s", this.name, this.value);
+            return new UncheckedText(new FormattedText("%s: %s", this.name, this.value)).asString();
         }
     }
 }


### PR DESCRIPTION
Closes #1603.

Resolves the `998-f7f5cb52` puzzle from #998: the `@todo` in `org/takes/package-info.java` asked to replace `String#format` with the `org.cactoos.text.FormattedText` decorator.

All 131 uses of `String.format` in `src/main/java` are gone, across 69 files. Where the surrounding code needs a `String` back — exception messages, `toString()`, header values — the result is wrapped in `UncheckedText`, the idiom already used in `Href`:

```java
new UncheckedText(
    new FormattedText("%s not found in classpath", name)
).asString()
```

### Scope

`src/test/java` still uses `String.format` in 125 places. This PR deliberately covers the main sources only; say the word and I will do the tests as a follow-up. The one remaining hit in `src/main` is a code sample inside the Javadoc of `org/takes/rq/form/package-info.java`, which is illustrative text rather than project code.

### Places that needed more than a swap

The replacement expression is longer than what it replaces, which pushed five files past a qulice limit:

* `TkClasspath` — the anonymous `Take` went over the 20-line cap, so the resource name and the "not found" message move into private static methods.
* `PsGithub`, `Token.Jose` — a fluent call may not open a multi-line block, so the `Authorization` header value and the `HS%s` algorithm name are built in private static methods.
* `RqMtFake` — the two boundary markers are now built once, before the loop, instead of inside the `append` chain.
* `HttpServletRequestFake` — this class was already sitting exactly on the 30-dependency fan-out limit, so any new type broke it. Its URI parsing and header lookup move into two nested classes, `Address` and `Header`, which also collapses the three identical copies of the URI-parsing block.

### Behaviour

Unchanged. `FormattedText` formats with the default locale, exactly as `String.format` does — I checked this against cactoos 0.61.1 under a non-English default locale, since a silent locale switch would have been an easy way to break number formatting. The one real difference is argument order: `XeSla` passed `Locale.US` before the pattern, while `FormattedText` takes the locale after it.

### Verification

`mvn test -DexcludedGroups=` — 665 tests, 0 failures, 5 skipped (the full suite, including the `deep`-tagged tests). `mvn -Pqulice -DskipTests verify` is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE354TBjzXiizqyZi21hTM)_