### PR TITLE
fix: respond 400 to a request that can't be parsed

### DIFF
--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -95,20 +95,50 @@ public final class BkBasic implements Back {
                 socket.getOutputStream()
             )
         ) {
-            while (true) {
-                this.print(
-                    BkBasic.addSocketHeaders(
-                        new RqLive(input),
-                        socket
-                    ),
-                    output
-                );
-                output.flush();
+            while (this.exchange(input, socket, output)) {
                 if (input.available() <= 0) {
                     break;
                 }
             }
         }
+    }
+
+    /**
+     * Read one request and print the response to the output.
+     *
+     * <p>The request is built here, and not by the caller, because
+     * {@link RqLive} throws {@link HttpException} on a malformed request
+     * line and that exception has to be turned into a response, instead of
+     * killing the thread.
+     *
+     * <p>A request that can't be parsed leaves the input stream in an
+     * unpredictable state, so the connection can't carry another request
+     * after it and FALSE is returned. This is what RFC 7230, section 3.5,
+     * recommends for a malformed request line.
+     *
+     * @param input Stream to read the request from
+     * @param socket Socket the request arrived through
+     * @param output Stream to print the response to
+     * @return TRUE if the connection may carry one more request
+     * @throws IOException If fails
+     */
+    private boolean exchange(final InputStream input, final Socket socket,
+        final OutputStream output) throws IOException {
+        boolean reusable = true;
+        try {
+            this.print(
+                BkBasic.addSocketHeaders(
+                    new RqLive(input),
+                    socket
+                ),
+                output
+            );
+        } catch (final HttpException ex) {
+            new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
+            reusable = false;
+        }
+        output.flush();
+        return reusable;
     }
 
     /**

--- a/src/main/java/org/takes/http/BkBasic.java
+++ b/src/main/java/org/takes/http/BkBasic.java
@@ -75,6 +75,11 @@ public final class BkBasic implements Back {
     public static final String REMOTEPORT = "X-Takes-RemotePort";
 
     /**
+     * How many bytes of a broken request to read away before closing.
+     */
+    private static final long LINGER = 64L * 1024L;
+
+    /**
      * Take.
      */
     private final Take take;
@@ -135,10 +140,39 @@ public final class BkBasic implements Back {
             );
         } catch (final HttpException ex) {
             new RsPrint(BkBasic.failure(ex, ex.code())).print(output);
+            output.flush();
+            BkBasic.linger(input);
             reusable = false;
         }
         output.flush();
         return reusable;
+    }
+
+    /**
+     * Read away what is left of a request that couldn't be parsed.
+     *
+     * <p>Closing a socket that still has unread bytes in its receive buffer
+     * makes TCP send RST instead of FIN, and then the client sees a reset
+     * connection instead of the response we have just written for it.
+     * Reading the leftovers away first lets the close be graceful.
+     *
+     * <p>Only the bytes that have already arrived are read, and no more than
+     * {@link BkBasic#LINGER} of them, so this can neither block nor be used
+     * to keep a connection busy.
+     *
+     * @param input The stream to drain
+     * @throws IOException If fails
+     */
+    private static void linger(final InputStream input) throws IOException {
+        final byte[] buf = new byte[8192];
+        long total = 0L;
+        while (total < BkBasic.LINGER && input.available() > 0) {
+            final int read = input.read(buf);
+            if (read < 0) {
+                break;
+            }
+            total += read;
+        }
     }
 
     /**

--- a/src/test/java/org/takes/http/BkBasicTest.java
+++ b/src/test/java/org/takes/http/BkBasicTest.java
@@ -347,15 +347,8 @@ final class BkBasicTest {
     /**
      * BkBasic can return HTTP status 400 (Bad Request) when a request has an
      * unencodable URI.
-     * todo: #1058:30min This test address the combination of bugs reported by
-     * issue #1058 and #1441.
-     * The problem is {@link BkBasic#accept} method that create
-     * {@link org.takes.rq.RqLive} (can throw a {@link org.takes.HttpException},
-     * while initializing) before execution control achieve try/catch
-     * block in {@link BkBasic#print} with forming a proper error response on
-     * {@link org.takes.HttpException}
+     * @throws Exception If some problem inside
      */
-    @Disabled
     @Test
     void returnsABadRequestToAControlCharInPath() throws Exception {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #1441.

`BkBasic.accept` built the `RqLive` while assembling the arguments for `print`, and `print` is where `HttpException` gets turned into a response. So an exception thrown *during parsing* never reached that handler:

```java
this.print(                              // <- catch lives in here
    BkBasic.addSocketHeaders(
        new RqLive(input),               // <- but this throws out here
        socket
    ),
    output
);
```

Sending `GET /\n` killed the connection thread with the very exception that already carried the right status code:

```
Exception in thread "Thread-0" java.lang.IllegalStateException: org.takes.HttpException: [400] illegal character 0x0A in HTTP header line #1: "GET /"
	at org.takes.rq.RqLive.legalCharacter(RqLive.java:137)
	at org.takes.http.BkBasic.accept(BkBasic.java:80)
```

The request is now built inside a new private `exchange` method, right next to the `catch`, so a malformed request line is answered with its own status instead of thrown.

### Why the connection closes afterwards

A request that fails to parse leaves the input stream mid-message, so the server can't tell where the next request would start. `exchange` returns FALSE in that case and the keep-alive loop stops, which is what RFC 7230 section 3.5 recommends for a malformed request line.

An `HttpException` thrown by the take itself is unaffected: it is still caught by `print`, and the connection stays alive. `handlesTwoRequestInOneConnection` covers that and still passes.

### The second commit: reading the leftovers away

The first commit was not enough, and the macOS job caught it — the client got a connection reset instead of the 400 that had just been written for it.

Closing a socket that still holds unread bytes in its receive buffer makes TCP send RST rather than FIN, and the peer then loses whatever was already in flight towards it. A request that fails to parse is exactly that case: only its first line is read and the rest stays unread. So the fix was answering the client and then resetting it before it could read the answer, which defeats the point.

`linger` reads those leftovers away before the close. It takes only bytes that have already arrived, and at most 64kb of them, so it cannot block and cannot be used to hold a connection open.

Worth knowing: this race is invisible on Linux. I ran the failing scenario 300 times locally, with and without `linger`, and saw zero resets either way — BSD, and therefore macOS, is what resets eagerly. The macOS job is the real check on that commit.

### Test

`BkBasicTest.returnsABadRequestToAControlCharInPath` already described this bug and was `@Disabled`, with a puzzle pointing at #1058 and #1441. The test is enabled again and the puzzle is removed (#1058 is closed).

I confirmed it fails on `master` for the right reason before fixing anything — enabling the test alone reproduces the stack trace above — and passes with the change.

### Verification

`mvn test -DexcludedGroups=` — 665 tests, 0 failures, 4 skipped (down from 5, since this test is no longer disabled). `mvn -Pqulice -DskipTests verify` is green.