### PR TITLE
fix: pretty-print any JSON value, not only objects

### DIFF
--- a/src/main/java/org/takes/rs/RsPrettyJson.java
+++ b/src/main/java/org/takes/rs/RsPrettyJson.java
@@ -83,7 +83,7 @@ public final class RsPrettyJson implements Response {
                 Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true)
             ).createWriter(res)
         ) {
-            wrt.writeObject(Json.createReader(body).readObject());
+            wrt.write(Json.createReader(body).readValue());
         } catch (final JsonException ex) {
             throw new IOException(ex);
         }

--- a/src/test/java/org/takes/rs/RsPrettyJsonTest.java
+++ b/src/test/java/org/takes/rs/RsPrettyJsonTest.java
@@ -46,6 +46,37 @@ final class RsPrettyJsonTest {
     }
 
     @Test
+    void formatsJsonArrayBody() throws Exception {
+        MatcherAssert.assertThat(
+            "Pretty JSON formatter must format a JSON array too",
+            new RsBodyPrint(
+                new RsPrettyJson(
+                    new RsWithBody("[{\"a\": 1 },2]")
+                )
+            ).asString(),
+            Matchers.is(
+                String.format(
+                    "[%1$s    {%1$s        \"a\": 1%1$s    },%1$s    2%1$s]",
+                    RsPrettyJsonTest.LF
+                )
+            )
+        );
+    }
+
+    @Test
+    void formatsJsonScalarBody() throws Exception {
+        MatcherAssert.assertThat(
+            "Pretty JSON formatter must format a bare JSON value too",
+            new RsBodyPrint(
+                new RsPrettyJson(
+                    new RsWithBody("42")
+                )
+            ).asString(),
+            Matchers.is("42")
+        );
+    }
+
+    @Test
     void rejectsNonJsonBody() {
         Assertions.assertThrows(
             IOException.class,


### PR DESCRIPTION
Closes #1299.

`RsPrettyJson.transform` read the body with `readObject` and wrote it with `writeObject`, both of which insist on a JSON object:

```java
wrt.writeObject(Json.createReader(body).readObject());
```

So a response carrying a JSON array died exactly as reported in the issue:

```
java.io.IOException: jakarta.json.stream.JsonParsingException: JsonParser#getObject() ...
  is valid only for START_OBJECT parser state. But current parser state is START_ARRAY
```

`readValue` / `write` accept any JSON document — object, array, or bare value — so the line becomes:

```java
wrt.write(Json.createReader(body).readValue());
```

I reproduced the failure first: `formatsJsonArrayBody` fails without the change, with the stack trace above, and passes with it.

### Invalid input still fails

Worth checking, since `readValue` is more permissive than `readObject`: it is more permissive only about *what kinds of JSON* it accepts, not about malformed input. `foo` is still rejected, and the existing `rejectsNonJsonBody` still passes unchanged.

### New tests

* `formatsJsonArrayBody` — the reported case, an array containing an object and a number.
* `formatsJsonScalarBody` — a bare `42`, which `readValue` now admits. Added to pin the behaviour down rather than leave it as an accident of the fix.

### Rebased onto c285c6a, and the extra commit is gone

This branch previously carried a second commit that commented the nine empty constructors PMD was flagging, because `master` was red at the time and the merge build inherited it. `master` has since fixed those itself, in c285c6a, with `// nothing to initialize`. As promised in that commit, it is dropped — the branch is now a single commit again, rebased onto `c285c6a`.

That rebase also picks up the qulice 0.35.2 upgrade, so the change has been re-verified against the new static analysis rather than the version from three weeks ago.

### Not included: passing a `JsonStructure` directly

The issue also asks for a way to hand `RsPrettyJson` an already-parsed `JsonStructure`, to skip serialising and re-parsing the body. I have deliberately left that out, because it is an API design decision rather than a bug fix, and it does not fit the class as it stands: `RsPrettyJson` keeps a `Response` to decorate and transforms it lazily, and a parse-free path needs either a second source of truth for the body or a restructuring of that lazy field. Doing it inside the constructor also runs into qulice's `ConstructorsCodeFreeCheck`.

Today `new RsPrettyJson(new RsJson(structure))` works, at the cost of the round trip the reporter wanted to avoid. If you want the parse-free variant, tell me which shape you prefer — a `RsPrettyJson(JsonStructure)` mirroring `RsJson(JsonStructure)`, or a `RsPrettyJson(Response, JsonStructure)` that keeps the decorator semantics — and I will do it as a follow-up. I did not want to invent public API for your framework unasked.

### Verification

On `efe3ce9`, rebased onto `c285c6a`: `mvn test -DexcludedGroups=` — 667 tests, 0 failures, 4 skipped. `mvn -Pqulice -DskipTests verify` is green under qulice 0.35.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RE354TBjzXiizqyZi21hTM